### PR TITLE
[ADVISOR-2585] Delete executed task

### DIFF
--- a/api.js
+++ b/api.js
@@ -6,39 +6,42 @@ import {
   SYSTEMS_ROOT,
 } from './src/constants';
 
+const returnErrOrData = (response) => {
+  if (response.status === 200) {
+    return response.data;
+  } else {
+    return response;
+  }
+};
+
 const getTasks = async (path) => {
-  let response;
-  const request = await axios
+  const response = await axios
     .get(TASKS_API_ROOT.concat(path))
     .catch(function (error) {
       return error;
     });
 
-  if (request.status === 200) {
-    response = request.data;
-  } else {
-    response = request;
-  }
-
-  return response;
+  return returnErrOrData(response);
 };
 
 const postTask = async (path, data) => {
-  let response;
-
-  const request = await axios
+  const response = await axios
     .post(TASKS_API_ROOT.concat(path), data)
     .catch(function (error) {
       return error;
     });
 
-  if (request.status === 200) {
-    response = request.data;
-  } else {
-    response = request;
-  }
+  return returnErrOrData(response);
+};
 
-  return response;
+const deleteTask = async (path) => {
+  const response = await axios
+    .delete(TASKS_API_ROOT.concat(path))
+    .catch(function (error) {
+      return error;
+    });
+
+  return returnErrOrData(response);
 };
 
 export const fetchAvailableTasks = () => {
@@ -68,4 +71,12 @@ export const fetchSystems = (path) => {
 
 export const executeTask = (body) => {
   return postTask(EXECUTED_TASK_ROOT, body);
+};
+
+export const deleteExecutedTask = (id) => {
+  return deleteTask(EXECUTED_TASK_ROOT.concat(`/${id}`));
+};
+
+export const cancelExecutedTask = (id) => {
+  return postTask(EXECUTED_TASK_ROOT.concat(`/${id}/cancel`));
 };

--- a/src/PresentationalComponents/DeleteCancelTaskModal/DeleteCancelTaskModal.js
+++ b/src/PresentationalComponents/DeleteCancelTaskModal/DeleteCancelTaskModal.js
@@ -1,0 +1,153 @@
+import React from 'react';
+import { Button, Modal } from '@patternfly/react-core';
+import propTypes from 'prop-types';
+import {
+  //CANCEL_TASK_BODY,
+  //CANCEL_TASK_ERROR,
+  DELETE_TASK_BODY,
+  DELETE_TASK_ERROR,
+} from '../../constants';
+import { /*cancelExecutedTask,*/ deleteExecutedTask } from '../../../api';
+import { dispatchNotification } from '../../Utilities/Dispatcher';
+
+const DeleteCancelTaskModal = ({
+  id,
+  isOpen,
+  //setIsCancel,
+  setIsDelete,
+  setModalOpened,
+  startTime,
+  //status,
+  title,
+}) => {
+  const createNotification = (message) => {
+    dispatchNotification({
+      variant: 'danger',
+      title: message(title),
+      description: 'Please try again',
+      dismissable: true,
+      autoDismiss: false,
+    });
+  };
+
+  const handleTask = async (apiCall, ERROR, setType) => {
+    const result = await apiCall(id);
+    setModalOpened(false);
+    if (result?.response?.status && result?.response?.status !== 200) {
+      createNotification(ERROR);
+    } else {
+      setType(true);
+    }
+  };
+
+  const renderButtons = () => {
+    return [
+      <Button
+        key="delete-task-button"
+        ouiaId="delete-task-modal-button"
+        variant="danger"
+        onClick={() =>
+          handleTask(deleteExecutedTask, DELETE_TASK_ERROR, setIsDelete)
+        }
+      >
+        Delete task
+      </Button>,
+      <Button
+        key="cancel"
+        ouiaId="cancel-delete-modal-button"
+        variant="link"
+        onClick={() => setModalOpened(false)}
+      >
+        Cancel
+      </Button>,
+    ];
+    /*let actions;
+
+    if (status === 'Completed') {
+      actions = [
+        <Button
+          key="delete-task-button"
+          ouiaId="delete-task-modal-button"
+          variant="danger"
+          onClick={() =>
+            handleTask(deleteExecutedTask, DELETE_TASK_ERROR, setIsDelete)
+          }
+        >
+          Delete task
+        </Button>,
+        <Button
+          key="cancel"
+          ouiaId="cancel-delete-modal-button"
+          variant="link"
+          onClick={() => setModalOpened(false)}
+        >
+          Cancel
+        </Button>,
+      ];
+    } else if (status === 'Running') {
+      actions = [
+        <Button
+          key="cancel-task-button"
+          ouiaId="cancel-task-modal-button"
+          variant="danger"
+          onClick={() =>
+            handleTask(cancelExecutedTask, CANCEL_TASK_ERROR, setIsCancel)
+          }
+        >
+          Cancel task
+        </Button>,
+        <Button
+          key="cancel-delete-task-button"
+          ouiaId="cancel-delete-task-modal-button"
+          variant="danger"
+          onClick={() =>
+            handleTask(deleteExecutedTask, DELETE_TASK_ERROR, setIsDelete)
+          }
+        >
+          Cancel task and delete result
+        </Button>,
+        <Button
+          key="cancel"
+          ouiaId="cancel-delete-modal-button"
+          variant="link"
+          onClick={() => setModalOpened(false)}
+        >
+          Cancel
+        </Button>,
+      ];
+    }
+
+    return actions;*/
+  };
+
+  return (
+    <Modal
+      aria-label="cancel-delete-task-modal"
+      //title={`${status === 'Completed' ? 'Delete' : 'Cancel'} this task?`}
+      title="Delete this task?"
+      titleIconVariant="warning"
+      isOpen={isOpen}
+      onClose={() => setModalOpened(false)}
+      width={'50%'}
+      actions={renderButtons()}
+    >
+      {/*status === 'Completed'
+        ? DELETE_TASK_BODY(startTime, title)
+        : CANCEL_TASK_BODY(startTime, title)*/}
+      {DELETE_TASK_BODY(startTime, title)}
+    </Modal>
+  );
+};
+
+DeleteCancelTaskModal.propTypes = {
+  id: propTypes.number,
+  isOpen: propTypes.bool,
+  setIsCancel: propTypes.func,
+  setIsDelete: propTypes.func,
+  setModalOpened: propTypes.func,
+  startTime: propTypes.string,
+  status: propTypes.string,
+  title: propTypes.string,
+};
+
+export default DeleteCancelTaskModal;

--- a/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
+++ b/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
@@ -30,6 +30,7 @@ const ExecuteTaskButton = ({
         title: 'Error',
         description: result.message,
         dismissable: true,
+        autoDismiss: false,
       });
     } else {
       EXECUTE_TASK_NOTIFICATION(title, ids, result.data.id);

--- a/src/PresentationalComponents/FlexibleFlex/FlexibleFlex.js
+++ b/src/PresentationalComponents/FlexibleFlex/FlexibleFlex.js
@@ -2,27 +2,28 @@ import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 
-const renderFlexItem = (content) => {
+const renderFlexItem = (content, key, idx) => {
+  let keyString = idx !== undefined ? `${key}-${idx}` : `${key}`;
   return (
-    <FlexItem className={content.classname}>
+    <FlexItem key={content.key || `${keyString}`} className={content.classname}>
       {content.children || content}
     </FlexItem>
   );
 };
 
 const FlexibleFlex = ({ data, flexContents, flexProps }) => {
-  return flexContents.map((item) => {
+  return flexContents.map((item, idx) => {
     return (
-      <Flex key={item.match} {...flexProps}>
+      <Flex key={item.key} {...flexProps}>
         {Array.isArray(item.children)
           ? item.children.map((content) => renderFlexItem(content))
-          : renderFlexItem(item.children)}
+          : renderFlexItem(item.children, item.key)}
         {item.match
           ? item.renderFunc
             ? renderFlexItem(
                 item.renderFunc(item.match.map((prop) => data[prop]))
               )
-            : renderFlexItem(data[item.match])
+            : renderFlexItem(data[item.match], item.key, idx)
           : null}
       </Flex>
     );

--- a/src/SmartComponents/AvailableTasks/AvailableTasks.js
+++ b/src/SmartComponents/AvailableTasks/AvailableTasks.js
@@ -50,6 +50,7 @@ const AvailableTasks = ({ openTaskModal }) => {
         title: 'Error',
         description: result.message,
         dismissable: true,
+        autoDismiss: false,
       });
     } else {
       setAvailableTasks(result.data);

--- a/src/SmartComponents/CompletedTaskDetails/Columns.js
+++ b/src/SmartComponents/CompletedTaskDetails/Columns.js
@@ -15,7 +15,7 @@ const SystemNameCell = ({ /*id,*/ display_name }, index) => (
 
 SystemNameCell.propTypes = {
   id: propTypes.string,
-  display_name: propTypes.string,
+  display_name: propTypes.node,
 };
 
 export const SystemColumn = {

--- a/src/SmartComponents/CompletedTaskDetailsKebab/CompletedTaskDetailsKebab.js
+++ b/src/SmartComponents/CompletedTaskDetailsKebab/CompletedTaskDetailsKebab.js
@@ -1,0 +1,55 @@
+import React, { useState, useEffect } from 'react';
+import propTypes from 'prop-types';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  KebabToggle,
+} from '@patternfly/react-core';
+
+const CompletedTaskDetailsKebab = ({ /*status,*/ setModalOpened }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const createDropdownItems = () => {
+    //let type = status === 'Running' ? 'cancel' : 'delete';
+    let type = 'delete';
+    return [
+      <DropdownItem
+        key={`${type}-task`}
+        component="button"
+        data-ouia-component-id={`${type}-task-dropdown-item`}
+        onClick={() => setModalOpened(true)}
+      >
+        {type[0].toUpperCase() + type.slice(1)}
+      </DropdownItem>,
+    ];
+  };
+
+  const [dropdownItems, setDropdownItems] = useState(createDropdownItems());
+
+  useEffect(() => {
+    setDropdownItems(createDropdownItems());
+  }, []);
+
+  return (
+    <Dropdown
+      onSelect={() => setIsOpen(false)}
+      position={DropdownPosition.right}
+      toggle={
+        <KebabToggle
+          onToggle={() => setIsOpen(!isOpen)}
+          id="executed-task-kebab"
+        />
+      }
+      isOpen={isOpen}
+      isPlain
+      dropdownItems={dropdownItems}
+    />
+  );
+};
+
+CompletedTaskDetailsKebab.propTypes = {
+  setModalOpened: propTypes.func,
+  status: propTypes.string,
+};
+
+export default CompletedTaskDetailsKebab;

--- a/src/SmartComponents/CompletedTasksTable/Columns.js
+++ b/src/SmartComponents/CompletedTasksTable/Columns.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import {
-  renderColumnComponent,
-  renderRunDateTime,
-} from '../../Utilities/helpers';
+import { renderColumnComponent } from '../../Utilities/helpers';
 
 const TaskNameCell = ({ id, task_title }, index) => (
   <Link key={`task-title-${index}`} to={`/executed/${id}`}>
@@ -14,7 +11,7 @@ const TaskNameCell = ({ id, task_title }, index) => (
 
 TaskNameCell.propTypes = {
   id: propTypes.number,
-  task_title: propTypes.string,
+  task_title: propTypes.any,
   index: propTypes.number,
 };
 
@@ -43,7 +40,7 @@ export const RunDateTimeColumn = {
     width: 20,
   },
   sortByProp: 'run_date_time',
-  renderExport: (task) => renderRunDateTime(task.run_date_time),
+  renderExport: (task) => task.run_date_time,
 };
 
 export const exportableColumns = [

--- a/src/SmartComponents/CompletedTasksTable/__tests__/__snapshots__/CompletedTasksTable.tests.js.snap
+++ b/src/SmartComponents/CompletedTasksTable/__tests__/__snapshots__/CompletedTasksTable.tests.js.snap
@@ -782,7 +782,7 @@ exports[`CompletedTasksTable should render correctly 1`] = `
                 data-ouia-component-id="Export"
                 data-ouia-component-type="PF4/DropdownToggle"
                 data-ouia-safe="true"
-                id="pf-dropdown-toggle-id-3"
+                id="pf-dropdown-toggle-id-8"
                 type="button"
               >
                 <span>
@@ -1094,6 +1094,11 @@ exports[`CompletedTasksTable should render correctly 1`] = `
               </div>
             </button>
           </th>
+          <td
+            class=""
+            data-key="3"
+            data-label=""
+          />
         </tr>
       </thead>
       <tbody
@@ -1149,6 +1154,41 @@ exports[`CompletedTasksTable should render correctly 1`] = `
               />
             </div>
           </td>
+          <td
+            class="pf-c-table__action"
+            data-key="3"
+            style="padding-right: 0px;"
+          >
+            <div
+              class="pf-c-dropdown pf-m-align-right"
+              data-ouia-component-id="OUIA-Generated-Dropdown-1"
+              data-ouia-component-type="PF4/Dropdown"
+              data-ouia-safe="true"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Actions"
+                class="pf-c-dropdown__toggle pf-m-plain"
+                id="pf-dropdown-toggle-id-10"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </td>
         </tr>
         <tr
           class=""
@@ -1197,6 +1237,41 @@ exports[`CompletedTasksTable should render correctly 1`] = `
               <span
                 class="pf-u-screen-reader"
               />
+            </div>
+          </td>
+          <td
+            class="pf-c-table__action"
+            data-key="3"
+            style="padding-right: 0px;"
+          >
+            <div
+              class="pf-c-dropdown pf-m-align-right"
+              data-ouia-component-id="OUIA-Generated-Dropdown-2"
+              data-ouia-component-type="PF4/Dropdown"
+              data-ouia-safe="true"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Actions"
+                class="pf-c-dropdown__toggle pf-m-plain"
+                id="pf-dropdown-toggle-id-11"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
             </div>
           </td>
         </tr>
@@ -1249,6 +1324,41 @@ exports[`CompletedTasksTable should render correctly 1`] = `
               />
             </div>
           </td>
+          <td
+            class="pf-c-table__action"
+            data-key="3"
+            style="padding-right: 0px;"
+          >
+            <div
+              class="pf-c-dropdown pf-m-align-right"
+              data-ouia-component-id="OUIA-Generated-Dropdown-3"
+              data-ouia-component-type="PF4/Dropdown"
+              data-ouia-safe="true"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Actions"
+                class="pf-c-dropdown__toggle pf-m-plain"
+                id="pf-dropdown-toggle-id-12"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </td>
         </tr>
         <tr
           class=""
@@ -1299,6 +1409,41 @@ exports[`CompletedTasksTable should render correctly 1`] = `
               />
             </div>
           </td>
+          <td
+            class="pf-c-table__action"
+            data-key="3"
+            style="padding-right: 0px;"
+          >
+            <div
+              class="pf-c-dropdown pf-m-align-right"
+              data-ouia-component-id="OUIA-Generated-Dropdown-4"
+              data-ouia-component-type="PF4/Dropdown"
+              data-ouia-safe="true"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Actions"
+                class="pf-c-dropdown__toggle pf-m-plain"
+                id="pf-dropdown-toggle-id-13"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </td>
         </tr>
         <tr
           class=""
@@ -1347,6 +1492,41 @@ exports[`CompletedTasksTable should render correctly 1`] = `
               <span
                 class="pf-u-screen-reader"
               />
+            </div>
+          </td>
+          <td
+            class="pf-c-table__action"
+            data-key="3"
+            style="padding-right: 0px;"
+          >
+            <div
+              class="pf-c-dropdown pf-m-align-right"
+              data-ouia-component-id="OUIA-Generated-Dropdown-5"
+              data-ouia-component-type="PF4/Dropdown"
+              data-ouia-safe="true"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="Actions"
+                class="pf-c-dropdown__toggle pf-m-plain"
+                id="pf-dropdown-toggle-id-14"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
             </div>
           </td>
         </tr>

--- a/src/SmartComponents/CompletedTasksTable/hooks/useActionResolvers.js
+++ b/src/SmartComponents/CompletedTasksTable/hooks/useActionResolvers.js
@@ -1,0 +1,30 @@
+const useActionResolver = (handleTask) => {
+  const onClick = (apiCall, task) => {
+    apiCall(task);
+  };
+
+  return (/*row*/) => [
+    /*{
+      title: 'Download report',
+      onClick: (_event, _index, task) =>
+        onClick(`/executed_task/${task.id}/delete`, task),
+    },
+    {
+      title: 'Run this task again',
+      onClick: (_event, _index, task) =>
+        onClick(`/executed_task/${task.id}/delete`, task),
+    },*/
+    {
+      title: 'Delete',
+      /*row.task.title.props.status === 'Completed' ||
+        row.task.title.props.status === 'Cancelled'
+          ? 'Delete'
+          : 'Cancel',*/
+      onClick: (_event, _index, task) => {
+        onClick(handleTask, task.task.title.props);
+      },
+    },
+  ];
+};
+
+export default useActionResolver;

--- a/src/SmartComponents/TasksPage/TasksPage.js
+++ b/src/SmartComponents/TasksPage/TasksPage.js
@@ -46,6 +46,7 @@ const TasksPage = ({ tab }) => {
         title: 'Error',
         description: task.message,
         dismissable: true,
+        autoDismiss: false,
       });
     } else {
       setActiveTask(task);

--- a/src/Utilities/helpers.js
+++ b/src/Utilities/helpers.js
@@ -5,26 +5,24 @@ import {
   SkeletonSize,
 } from '@redhat-cloud-services/frontend-components/Skeleton';
 
-const renderRunning = (time) => {
-  return time === 'null' || !time ? 'Running' : false;
+const renderRunning = (status) => {
+  return status === 'Completed' ? false : status;
 };
 
 export const renderRunDateTime = (time) => {
   if (time === 'loading') {
     return <Skeleton size={SkeletonSize.md} />;
   } else {
-    return (
-      renderRunning(time) || moment.utc(time).format('DD MMM YYYY, HH:mm UTC')
-    );
+    return moment.utc(time).format('DD MMM YYYY, HH:mm UTC');
   }
 };
 
-export const getTimeDiff = ([start, end]) => {
+export const getTimeDiff = ([start, end, status]) => {
   if (start === 'loading') {
     return <Skeleton size={SkeletonSize.md} />;
   } else {
     return (
-      renderRunning(end) ||
+      renderRunning(status) ||
       `${renderRunDateTime(end)} (${moment
         .duration(
           moment(renderRunDateTime(end), 'DD MMM YYYY, HH:mm').diff(

--- a/src/Utilities/hooks/useTableTools/useActionResolver.js
+++ b/src/Utilities/hooks/useTableTools/useActionResolver.js
@@ -1,0 +1,21 @@
+const useActionResolver = ({ actionResolver }) => {
+  const isActionResolverEnabled = !!actionResolver;
+  return isActionResolverEnabled
+    ? {
+        tableProps: {
+          actionResolver,
+        },
+      }
+    : {};
+};
+
+export const useActionResolverWithItems = ({ items, ...optionsAndProps }) => {
+  const actionResolver =
+    items.length > 0
+      ? useActionResolver({
+          items,
+          ...optionsAndProps,
+        })
+      : {};
+  return actionResolver;
+};

--- a/src/Utilities/hooks/useTableTools/useTableTools.js
+++ b/src/Utilities/hooks/useTableTools/useTableTools.js
@@ -3,6 +3,7 @@ import useFilterConfig from './useFilterConfig';
 import usePaginate from './usePaginate';
 import { useExportWithItems } from './useExport';
 import { useTableSortWithItems } from './useTableSort';
+import { useActionResolverWithItems } from './useActionResolver';
 
 const filteredAndSortedItems = (items, filter, sorter) => {
   const filtered = filter ? filter(items) : items;
@@ -30,6 +31,14 @@ const useTableTools = (items = [], columns = [], options = {}) => {
     columns,
     options
   );
+
+  const { tableProps: actionResolverTableProps } = useActionResolverWithItems({
+    //items: filteredAndSortedItems(identifiedItems, filter, sorter),
+    items: filteredAndSortedItems(items, filter, sorter),
+    ...options,
+    //...tablePropsOption,
+    ...tableProps,
+  });
 
   const { toolbarProps: exportToolbarProps } = useExportWithItems(
     filteredAndSortedItems(items, filter, sorter),
@@ -60,6 +69,7 @@ const useTableTools = (items = [], columns = [], options = {}) => {
     cells: columns,
     ...rowBuilderTableProps,
     ...sortableTableProps,
+    ...actionResolverTableProps,
   };
 
   return {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import moment from 'moment';
 import { Button } from '@patternfly/react-core';
 import { PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { dispatchNotification } from './Utilities/Dispatcher';
 import { getTimeDiff, renderRunDateTime } from './Utilities/helpers';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import TasksPopover from './PresentationalComponents/TasksPopover/TasksPopover';
+import CompletedTaskDetailsKebab from './SmartComponents/CompletedTaskDetailsKebab/CompletedTaskDetailsKebab';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import {
   Skeleton,
@@ -66,22 +68,37 @@ export const COMPLETED_INFO_BUTTONS_FLEX_PROPS = {
 };
 
 export const COMPLETED_INFO_PANEL = [
-  { children: <b>Systems</b>, match: ['system_count'] },
+  { children: <b>Systems</b>, match: ['system_count'], key: 'systems' },
   {
     children: <b>Run start</b>,
     match: ['start_time'],
+    key: 'run-start',
     renderFunc: (start) => renderRunDateTime(...start),
   },
   {
     children: <b>Run end</b>,
-    match: ['start_time', 'end_time'],
-    renderFunc: (start, end) => getTimeDiff(start, end),
+    match: ['start_time', 'end_time', 'status'],
+    key: 'run-end',
+    renderFunc: (start, end, status) => getTimeDiff(start, end, status),
   },
-  { children: <b>Initiated by</b>, match: ['initiated_by'] },
-  { children: <b>Systems with messages</b>, match: ['messages_count'] },
+  {
+    children: <b>Initiated by</b>,
+    match: ['initiated_by'],
+    key: 'initiated-by',
+  },
+  {
+    children: <b>Systems with messages</b>,
+    match: ['messages_count'],
+    key: 'systems-with-messages',
+  },
 ];
 
-export const COMPLETED_INFO_BUTTONS = (slug, openTaskModal) => {
+export const COMPLETED_INFO_BUTTONS = (
+  slug,
+  openTaskModal,
+  //status,
+  setModalOpened
+) => {
   return [
     {
       children: (
@@ -98,6 +115,16 @@ export const COMPLETED_INFO_BUTTONS = (slug, openTaskModal) => {
           variant="secondary"
         />
       ),
+      key: 'run-task-again-details-button',
+    },
+    {
+      children: (
+        <CompletedTaskDetailsKebab
+          //status={status}
+          setModalOpened={setModalOpened}
+        />
+      ),
+      key: 'completed-task-details-kebab',
     },
   ];
 };
@@ -138,6 +165,7 @@ const TASKS_PAGE_POPOVER_FOOTER = (
 const TASKS_PAGE_HEADER_TITLE = {
   children: <PageHeaderTitle title="Tasks" />,
   classname: 'page-header-title',
+  key: 'tasks-page-header-title',
 };
 
 const TASKS_PAGE_HEADER_POPOVER = {
@@ -150,11 +178,13 @@ const TASKS_PAGE_HEADER_POPOVER = {
       content={<OutlinedQuestionCircleIcon />}
     />
   ),
+  key: 'tasks-page-header-popover',
 };
 
 export const TASKS_PAGE_HEADER = [
   {
     children: [TASKS_PAGE_HEADER_TITLE, TASKS_PAGE_HEADER_POPOVER],
+    key: 'tasks-page-header',
   },
 ];
 
@@ -270,3 +300,23 @@ export const EXECUTE_TASK_NOTIFICATION = (title, ids, task_id) => {
   });
 };
 /*eslint-enable react/no-unescaped-entities*/
+
+export const DELETE_TASK_BODY = (startTime, title) => {
+  return `Deleting the ${moment
+    .utc(startTime)
+    .format(
+      'MMM DD YYYY'
+    )} run of "${title}" will remove all data about this task. The report will no longer be accessible.`;
+};
+
+export const DELETE_TASK_ERROR = (title) => {
+  return `Error: Task "${title}" could not be deleted`;
+};
+
+export const CANCEL_TASK_BODY = (startTime, title) => {
+  return `Cancelling the ${startTime} run of "${title}" will stop any analysis in progress. Any existing results will be available.`;
+};
+
+export const CANCEL_TASK_ERROR = (title) => {
+  return `Error: Task "${title}" could not be cancelled`;
+};

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,6 @@
 import { createContext } from 'react';
 import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
-
 import promiseMiddleware from 'redux-promise-middleware';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 


### PR DESCRIPTION
This PR adds the ability to delete/cancel an executed (or in progress) task via Completed Tasks Table (https://marvelapp.com/prototype/6da50b0/screen/84773746) and via Complete Tasks Details (https://marvelapp.com/prototype/6da50b0/screen/84773747).

Deleting a task via the Completed Tasks Table should cause a loading state on the table and a re-render if the delete is successful. An unsuccessful delete results in toast alert.

Deleting a task via the Completed Tasks Details should cause the user to go back to the Completed Tasks Table if the delete is successful. An unsuccessful delete results in toast alert.

I have some commented out code for cancelling because it's not currently supported, but we plan to have support. I don't want to rewrite the code later, so I commented it out so I can turn it on later.

Make sure to test this on completed tasks and running tasks. In order to test a running task, make sure to run the "Run the insights-client" task and that should give you enough time before it completes. Let me know if you need to know which system to run it on.