### PR TITLE
[ADVISOR-2612] Fix jobs table pagination

### DIFF
--- a/api.js
+++ b/api.js
@@ -61,8 +61,13 @@ export const fetchExecutedTask = (id, jobs_path = '') => {
   return getTasks(EXECUTED_TASK_ROOT.concat(idPath));
 };
 
-export const fetchExecutedTaskJobs = (id) => {
-  return fetchExecutedTask(id, '/jobs');
+export const fetchExecutedTaskJobs = (id, path) => {
+  let jobPath = '/jobs';
+  if (path) {
+    jobPath += path;
+  }
+
+  return fetchExecutedTask(id, jobPath);
 };
 
 export const fetchSystems = (path) => {

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -61,7 +61,8 @@ const CompletedTaskDetails = () => {
       setNotification(taskDetails);
       setError(taskDetails);
     } else {
-      const taskJobs = await fetchExecutedTaskJobs(id);
+      const path = `?limit=${Math.pow(2, 31) - 1}&offset=0`;
+      const taskJobs = await fetchExecutedTaskJobs(id, path);
 
       if (isError(taskJobs)) {
         setNotification(taskJobs);

--- a/src/SmartComponents/CompletedTasksTable/__tests__/__snapshots__/CompletedTasksTable.tests.js.snap
+++ b/src/SmartComponents/CompletedTasksTable/__tests__/__snapshots__/CompletedTasksTable.tests.js.snap
@@ -1559,11 +1559,11 @@ exports[`CompletedTasksTable should render correctly 1`] = `
               class="pf-c-options-menu__toggle-text"
             >
               <b>
-                1 - 10
+                1 - 5
               </b>
                of 
               <b>
-                0
+                5
               </b>
                
             </span>
@@ -1665,11 +1665,17 @@ exports[`CompletedTasksTable should render correctly 1`] = `
             <input
               aria-label="Current page"
               class="pf-c-form-control"
+              disabled=""
               max="1"
               min="1"
               type="number"
               value="1"
             />
+            <span
+              aria-hidden="true"
+            >
+              of 1
+            </span>
           </div>
           <div
             class="pf-c-pagination__nav-control"

--- a/src/Utilities/hooks/useTableTools/Components/TasksTables.js
+++ b/src/Utilities/hooks/useTableTools/Components/TasksTables.js
@@ -35,7 +35,7 @@ const TasksTables = ({
       <TableToolbar isFooter results={-1} selected={-1}>
         <Pagination
           variant={PaginationVariant.bottom}
-          /*{...toolbarProps.pagination}*/
+          {...toolbarProps.pagination}
         />
       </TableToolbar>
 

--- a/src/Utilities/hooks/useTableTools/Components/__tests__/__snapshots__/TasksTables.tests.js.snap
+++ b/src/Utilities/hooks/useTableTools/Components/__tests__/__snapshots__/TasksTables.tests.js.snap
@@ -443,11 +443,11 @@ exports[`TasksTables should render correctly 1`] = `
             class="pf-c-options-menu__toggle-text"
           >
             <b>
-              1 - 10
+              1 - 2
             </b>
              of 
             <b>
-              0
+              2
             </b>
              
           </span>
@@ -549,11 +549,17 @@ exports[`TasksTables should render correctly 1`] = `
           <input
             aria-label="Current page"
             class="pf-c-form-control"
+            disabled=""
             max="1"
             min="1"
             type="number"
             value="1"
           />
+          <span
+            aria-hidden="true"
+          >
+            of 1
+          </span>
         </div>
         <div
           class="pf-c-pagination__nav-control"
@@ -883,7 +889,7 @@ exports[`TasksTables should render empty 1`] = `
             class="pf-c-options-menu__toggle-text"
           >
             <b>
-              1 - 10
+              0 - 0
             </b>
              of 
             <b>
@@ -989,11 +995,17 @@ exports[`TasksTables should render empty 1`] = `
           <input
             aria-label="Current page"
             class="pf-c-form-control"
-            max="1"
+            disabled=""
+            max="0"
             min="1"
             type="number"
-            value="1"
+            value="0"
           />
+          <span
+            aria-hidden="true"
+          >
+            of 0
+          </span>
         </div>
         <div
           class="pf-c-pagination__nav-control"


### PR DESCRIPTION
Select a completed task and it should load the jobs table. The pagination is now fixed. If you don't have a task with more than 10 systems, simply run one.