### PR TITLE
Change run end to minutes

### DIFF
--- a/src/Utilities/helpers.js
+++ b/src/Utilities/helpers.js
@@ -31,7 +31,7 @@ export const getTimeDiff = ([start, end]) => {
             moment(renderRunDateTime(start), 'DD MMM YYYY HH:mm')
           )
         )
-        .asHours()} hours)`
+        .asMinutes()} min)`
     );
   }
 };


### PR DESCRIPTION
Before, on the Completed task details page, the "Run end" value was calculated in hours. Accordingg to the mocks, it should be in munutes.