### PR TITLE
Fix button order on completed task details

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -85,18 +85,18 @@ export const COMPLETED_INFO_BUTTONS = (slug, openTaskModal) => {
   return [
     {
       children: (
+        <Button variant="primary" ouiaId="download-report-button">
+          Download report
+        </Button>
+      ),
+    },
+    {
+      children: (
         <RunTaskButton
           openTaskModal={openTaskModal}
           slug={slug}
           variant="secondary"
         />
-      ),
-    },
-    {
-      children: (
-        <Button variant="primary" ouiaId="download-report-button">
-          Download report
-        </Button>
       ),
     },
   ];


### PR DESCRIPTION
The Download report button should be to the left of Run task again.