### PR TITLE
Add cancel button to run task modal

### DIFF
--- a/src/SmartComponents/RunTaskModal/RunTaskModal.js
+++ b/src/SmartComponents/RunTaskModal/RunTaskModal.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Flex, FlexItem, Modal } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Modal } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import SystemTable from '../SystemTable/SystemTable';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
@@ -20,15 +20,22 @@ const RunTaskModal = ({
   slug,
   title,
 }) => {
-  const [selectedIds, setSelectedIds] = useState();
+  const [selectedIds, setSelectedIds] = useState(selectedSystems);
 
   useEffect(() => {
-    setSelectedIds(selectedSystems);
-  }, [selectedSystems]);
+    if (isOpen) {
+      setSelectedIds(selectedSystems);
+    }
+  }, [isOpen]);
 
   useEffect(() => {
     setSelectedIds([]);
   }, [slug]);
+
+  const cancelModal = () => {
+    setSelectedIds([]);
+    setModalOpened(false);
+  };
 
   const selectIds = (_event, _isSelected, _index, entity) => {
     let newSelectedIds = [...selectedIds];
@@ -47,6 +54,23 @@ const RunTaskModal = ({
       isOpen={isOpen}
       onClose={() => setModalOpened(false)}
       width={'70%'}
+      actions={[
+        <ExecuteTaskButton
+          key="execute-task-button"
+          ids={selectedIds}
+          setModalOpened={setModalOpened}
+          slug={slug}
+          title={title}
+          variant="primary"
+        />,
+        <Button
+          key="cancel-execute-task-button"
+          variant="link"
+          onClick={() => cancelModal()}
+        >
+          Cancel
+        </Button>,
+      ]}
     >
       {error ? (
         <EmptyStateDisplay
@@ -78,13 +102,6 @@ const RunTaskModal = ({
           <br />
           <b>Systems to run tasks on</b>
           <SystemTable selectedIds={selectedIds} selectIds={selectIds} />
-          <ExecuteTaskButton
-            ids={selectedIds}
-            setModalOpened={setModalOpened}
-            slug={slug}
-            title={title}
-            variant="primary"
-          />
         </React.Fragment>
       )}
     </Modal>

--- a/src/SmartComponents/TasksPage/TasksPage.js
+++ b/src/SmartComponents/TasksPage/TasksPage.js
@@ -60,6 +60,7 @@ const TasksPage = ({ tab }) => {
         description={activeTask.description}
         error={error}
         isOpen={runTaskModalOpened}
+        selectedSystems={[]}
         setModalOpened={setRunTaskModalOpened}
         slug={activeTask.slug}
         title={activeTask.title}


### PR DESCRIPTION
Cancel button should close the modal and remove any selected systems. If opening the modal from the run task again button, after selecting additional systems, and then cancelling, it should reopen with only the original pre-selected systems selected.