### PR TITLE
[ADVISOR-2647] Add run task again to completd kebab

### DIFF
--- a/api.js
+++ b/api.js
@@ -66,12 +66,7 @@ export const fetchExecutedTask = (id, jobs_path = '') => {
 };
 
 export const fetchExecutedTaskJobs = (id, path) => {
-  let jobPath = '/jobs';
-  if (path) {
-    jobPath += path;
-  }
-
-  return fetchExecutedTask(id, jobPath);
+  return fetchExecutedTask(id, `/jobs${path}`);
 };
 
 export const fetchSystems = (path = '') => {

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -15,7 +15,6 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import columns, { exportableColumns } from './Columns';
-import { fetchExecutedTask, fetchExecutedTaskJobs } from '../../../api';
 import * as Filters from './Filters';
 import {
   COMPLETED_INFO_PANEL,
@@ -32,7 +31,11 @@ import EmptyStateDisplay from '../../PresentationalComponents/EmptyStateDisplay/
 import RunTaskModal from '../RunTaskModal/RunTaskModal';
 import DeleteCancelTaskModal from '../../PresentationalComponents/DeleteCancelTaskModal/DeleteCancelTaskModal';
 import { emptyRows } from '../../PresentationalComponents/NoResultsTable/NoResultsTable';
-import { dispatchNotification } from '../../Utilities/Dispatcher';
+import {
+  getSelectedSystems,
+  fetchTask,
+  fetchTaskJobs,
+} from '../taskDetailsHelpers';
 
 const CompletedTaskDetails = () => {
   const { id } = useParams();
@@ -50,46 +53,17 @@ const CompletedTaskDetails = () => {
   const [isCancel, setIsCancel] = useState(false);
   const history = useHistory();
 
-  const getSelectedSystems = () => {
-    return completedTaskJobs.map((job) => job.system);
-  };
-
   const fetchData = async () => {
-    let taskDetails = await fetchExecutedTask(id);
+    const fetchedTaskDetails = await fetchTask(id, setError);
 
-    if (isError(taskDetails)) {
-      setNotification(taskDetails);
-      setError(taskDetails);
-    } else {
-      const path = `?limit=${Math.pow(2, 31) - 1}&offset=0`;
-      const taskJobs = await fetchExecutedTaskJobs(id, path);
+    if (Object.keys(fetchedTaskDetails).length) {
+      const fetchedTaskJobs = await fetchTaskJobs(fetchedTaskDetails, setError);
 
-      if (isError(taskJobs)) {
-        setNotification(taskJobs);
-        setError(taskJobs);
-      } else {
-        taskDetails.messages_count = taskJobs.data.filter((item) => {
-          return item.results.message !== 'No vulnerability found.';
-        }).length;
-        taskDetails.system_count = taskJobs.data.length;
-        await setCompletedTaskDetails(taskDetails);
-        await setCompletedTaskJobs(taskJobs.data);
+      if (fetchedTaskJobs.length) {
+        await setCompletedTaskDetails(fetchedTaskDetails);
+        await setCompletedTaskJobs(fetchedTaskJobs);
       }
     }
-  };
-
-  const isError = (result) => {
-    return result?.response?.status && result?.response?.status !== 200;
-  };
-
-  const setNotification = (result) => {
-    dispatchNotification({
-      variant: 'danger',
-      title: 'Error',
-      description: result.message,
-      dismissable: true,
-      autoDismiss: false,
-    });
   };
 
   useEffect(() => {
@@ -97,7 +71,7 @@ const CompletedTaskDetails = () => {
   }, []);
 
   useEffect(() => {
-    setSelectedSystems(getSelectedSystems());
+    setSelectedSystems(getSelectedSystems(completedTaskJobs));
   }, [completedTaskJobs]);
 
   useEffect(async () => {
@@ -117,7 +91,7 @@ const CompletedTaskDetails = () => {
   return (
     <div>
       <RunTaskModal
-        description={completedTaskDetails.description}
+        description={completedTaskDetails.task_description}
         error={error}
         isOpen={runTaskModalOpened}
         selectedSystems={selectedSystems}

--- a/src/SmartComponents/CompletedTasksTable/CompletedTasksTable.js
+++ b/src/SmartComponents/CompletedTasksTable/CompletedTasksTable.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { ExclamationCircleIcon, WrenchIcon } from '@patternfly/react-icons';
 import columns, { exportableColumns } from './Columns';
-import { fetchExecutedTasks } from '../../../api';
 import * as Filters from './Filters';
 import { renderRunDateTime } from '../../Utilities/helpers';
 import {
@@ -9,26 +8,61 @@ import {
   EMPTY_COMPLETED_TASKS_MESSAGE,
   EMPTY_COMPLETED_TASKS_TITLE,
   LOADING_COMPLETED_TASKS_TABLE,
+  TASK_LOADING_CONTENT,
   TASKS_TABLE_DEFAULTS,
 } from '../../constants';
+import { fetchExecutedTasks } from '../../../api';
 import { emptyRows } from '../../PresentationalComponents/NoResultsTable/NoResultsTable';
-import { dispatchNotification } from '../../Utilities/Dispatcher';
 import TasksTables from '../../Utilities/hooks/useTableTools/Components/TasksTables';
 import EmptyStateDisplay from '../../PresentationalComponents/EmptyStateDisplay/EmptyStateDisplay';
 import DeleteCancelTaskModal from '../../PresentationalComponents/DeleteCancelTaskModal/DeleteCancelTaskModal';
 import useActionResolver from './hooks/useActionResolvers';
+import {
+  createNotification,
+  fetchTask,
+  fetchTaskJobs,
+  getSelectedSystems,
+  isError,
+} from '../taskDetailsHelpers';
+import RunTaskModal from '../RunTaskModal/RunTaskModal';
 
 const CompletedTasksTable = () => {
   const filters = Object.values(Filters);
   const [completedTasks, setCompletedTasks] = useState(
     LOADING_COMPLETED_TASKS_TABLE
   );
+  const [completedTaskDetails, setCompletedTaskDetails] =
+    useState(TASK_LOADING_CONTENT);
   const [error, setError] = useState();
+  const [taskError, setTaskError] = useState();
   const [isDelete, setIsDelete] = useState(false);
   const [isCancel, setIsCancel] = useState(false);
   const [isDeleteCancelModalOpened, setIsDeleteCancelModalOpened] =
     useState(false);
   const [taskDetails, setTaskDetails] = useState({});
+  const [runTaskModalOpened, setRunTaskModalOpened] = useState(false);
+  const [selectedSystems, setSelectedSystems] = useState([]);
+
+  const fetchTaskDetails = async (id) => {
+    setTaskError();
+    setRunTaskModalOpened(true);
+    const fetchedTaskDetails = await fetchTask(id, setTaskError);
+
+    if (Object.keys(fetchedTaskDetails).length) {
+      const fetchedTaskJobs = await fetchTaskJobs(
+        fetchedTaskDetails,
+        setTaskError
+      );
+
+      if (fetchedTaskJobs.length) {
+        setSelectedSystems(getSelectedSystems(fetchedTaskJobs));
+        await setCompletedTaskDetails(fetchedTaskDetails);
+      }
+    } else {
+      setRunTaskModalOpened(false);
+      await setCompletedTaskDetails({});
+    }
+  };
 
   const fetchData = async () => {
     const path = `?limit=1000&offset=0`;
@@ -37,25 +71,18 @@ const CompletedTasksTable = () => {
     setTasks(result);
   };
 
-  const createNotification = (result) => {
-    dispatchNotification({
-      variant: 'danger',
-      title: 'Error',
-      description: result.message,
-      dismissable: true,
-      autoDismiss: false,
-    });
-  };
-
   const handleCancelOrDeleteTask = async (task) => {
     await setTaskDetails(task);
     setIsDeleteCancelModalOpened(true);
   };
 
-  const actionResolver = useActionResolver(handleCancelOrDeleteTask);
+  const actionResolver = useActionResolver(
+    handleCancelOrDeleteTask,
+    fetchTaskDetails
+  );
 
   const setTasks = async (result) => {
-    if (result?.response?.status && result?.response?.status !== 200) {
+    if (isError(result)) {
       createNotification(result);
       setError(result);
     } else {
@@ -84,6 +111,15 @@ const CompletedTasksTable = () => {
 
   return (
     <React.Fragment>
+      <RunTaskModal
+        description={completedTaskDetails.task_description}
+        error={taskError}
+        isOpen={runTaskModalOpened}
+        selectedSystems={selectedSystems}
+        setModalOpened={setRunTaskModalOpened}
+        slug={completedTaskDetails.task_slug}
+        title={completedTaskDetails.task_title}
+      />
       <DeleteCancelTaskModal
         id={taskDetails.id}
         isOpen={isDeleteCancelModalOpened}

--- a/src/SmartComponents/CompletedTasksTable/hooks/useActionResolvers.js
+++ b/src/SmartComponents/CompletedTasksTable/hooks/useActionResolvers.js
@@ -1,19 +1,14 @@
-const useActionResolver = (handleTask) => {
-  const onClick = (apiCall, task) => {
-    apiCall(task);
+const useActionResolver = (handleTask, fetchTaskDetails) => {
+  const onClick = (funcCall, task) => {
+    funcCall(task);
   };
 
   return (/*row*/) => [
-    /*{
-      title: 'Download report',
-      onClick: (_event, _index, task) =>
-        onClick(`/executed_task/${task.id}/delete`, task),
-    },
     {
       title: 'Run this task again',
       onClick: (_event, _index, task) =>
-        onClick(`/executed_task/${task.id}/delete`, task),
-    },*/
+        onClick(fetchTaskDetails, task.task.title.props.id),
+    },
     {
       title: 'Delete',
       /*row.task.title.props.status === 'Completed' ||

--- a/src/SmartComponents/RunTaskModal/RunTaskModal.js
+++ b/src/SmartComponents/RunTaskModal/RunTaskModal.js
@@ -29,8 +29,8 @@ const RunTaskModal = ({
   }, [isOpen]);
 
   useEffect(() => {
-    setSelectedIds([]);
-  }, [slug]);
+    setSelectedIds(selectedSystems);
+  }, [selectedSystems]);
 
   const cancelModal = () => {
     setSelectedIds([]);
@@ -88,7 +88,7 @@ const RunTaskModal = ({
             </FlexItem>
           </Flex>
           <Flex style={{ paddingBottom: '8px' }}>
-            <FlexItem>{description}</FlexItem>
+            <FlexItem style={{ width: '100%' }}>{description}</FlexItem>
           </Flex>
           <Flex>
             <FlexItem>

--- a/src/SmartComponents/taskDetailsHelpers.js
+++ b/src/SmartComponents/taskDetailsHelpers.js
@@ -1,0 +1,47 @@
+import { dispatchNotification } from '../Utilities/Dispatcher';
+import { fetchExecutedTask, fetchExecutedTaskJobs } from '../../api';
+
+export const getSelectedSystems = (completedTaskJobs) => {
+  return completedTaskJobs.map((job) => job.system);
+};
+
+export const isError = (result) => {
+  return result?.response?.status && result?.response?.status !== 200;
+};
+
+export const createNotification = (result) => {
+  dispatchNotification({
+    variant: 'danger',
+    title: 'Error',
+    description: result.message,
+    dismissable: true,
+    autoDismiss: false,
+  });
+};
+
+export const fetchTask = async (id, setError) => {
+  let taskDetails = await fetchExecutedTask(id);
+
+  if (isError(taskDetails)) {
+    createNotification(taskDetails);
+    setError(taskDetails);
+  } else {
+    return taskDetails;
+  }
+};
+
+export const fetchTaskJobs = async (taskDetails, setError) => {
+  let path = `?limit=1000&offset=0`;
+  const taskJobs = await fetchExecutedTaskJobs(taskDetails.id, path);
+
+  if (isError(taskJobs)) {
+    createNotification(taskJobs);
+    setError(taskJobs);
+  } else {
+    taskDetails.messages_count = taskJobs.data.filter((item) => {
+      return item.results.message !== 'No vulnerability found.';
+    }).length;
+    taskDetails.system_count = taskJobs.data.length;
+    return taskJobs.data;
+  }
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
-import { Button } from '@patternfly/react-core';
 import { PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { dispatchNotification } from './Utilities/Dispatcher';
 import { getTimeDiff, renderRunDateTime } from './Utilities/helpers';
@@ -100,13 +99,6 @@ export const COMPLETED_INFO_BUTTONS = (
   setModalOpened
 ) => {
   return [
-    {
-      children: (
-        <Button variant="primary" ouiaId="download-report-button">
-          Download report
-        </Button>
-      ),
-    },
     {
       children: (
         <RunTaskButton
@@ -218,6 +210,11 @@ export const LOADING_CONTENT = [
   { title: <Skeleton size={SkeletonSize.md} /> },
   { description: <Skeleton size={SkeletonSize.md} /> },
 ];
+
+export const TASK_LOADING_CONTENT = {
+  task_title: <Skeleton size={SkeletonSize.sm} />,
+  task_description: <Skeleton size={SkeletonSize.md} />,
+};
 
 export const LOADING_INFO_PANEL = {
   system_count: <Skeleton size={SkeletonSize.md} />,


### PR DESCRIPTION
Add "Run task again" option to kebab on Completed Tasks table. This required some refactoring for the other instances of the RunTaskModal.

To test, you'll need to check the functionality of the RunTaskModal via the following 3 locations:
- Available Tasks
- Completed Tasks table - kebab
- Completed Task Details

Make sure to try to:
- Run the task again
- Add systems and cancel - reopening should still show original selections
- Remove systems and cancel - reopening should still show original selections
- Any other ways you can think to break it.

You may occasionally get an error resulting from trying to load task job details on a system that has since been deleted. This is a bug we are aware of. It is a good test of how the modal handles the errors though, so use it to your advantage.