### PR TITLE
[ADVISOR-2652] Add status filter to jobs table

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -15,7 +15,7 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import columns, { exportableColumns } from './Columns';
-import * as Filters from './Filters';
+import { statusFilters, systemFilter } from './Filters';
 import {
   COMPLETED_INFO_PANEL,
   COMPLETED_INFO_PANEL_FLEX_PROPS,
@@ -39,7 +39,6 @@ import {
 
 const CompletedTaskDetails = () => {
   const { id } = useParams();
-  const filters = Object.values(Filters);
   const [completedTaskDetails, setCompletedTaskDetails] =
     useState(LOADING_INFO_PANEL);
   const [completedTaskJobs, setCompletedTaskJobs] =
@@ -172,7 +171,7 @@ const CompletedTaskDetails = () => {
                 columns={columns}
                 items={completedTaskJobs}
                 filters={{
-                  filterConfig: filters,
+                  filterConfig: [...statusFilters, ...systemFilter],
                 }}
                 options={{
                   ...TASKS_TABLE_DEFAULTS,

--- a/src/SmartComponents/CompletedTaskDetails/Filters.js
+++ b/src/SmartComponents/CompletedTaskDetails/Filters.js
@@ -1,10 +1,28 @@
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 
-export const systemFilter = {
-  type: conditionalFilterType.text,
-  label: 'System',
-  filter: (jobs, value) =>
-    jobs.filter((job) =>
-      job.display_name.toLowerCase().includes(value.toLowerCase())
-    ),
-};
+export const systemFilter = [
+  {
+    type: conditionalFilterType.text,
+    label: 'System',
+    filter: (jobs, value) =>
+      jobs.filter((job) =>
+        job.display_name.toLowerCase().includes(value.toLowerCase())
+      ),
+  },
+];
+
+export const statusFilters = [
+  {
+    type: conditionalFilterType.checkbox,
+    label: 'Status',
+    filter: (jobs, value) =>
+      jobs.filter((job) => value.includes(job.status.toLowerCase())),
+    items: [
+      { label: 'Running', value: 'running' },
+      { label: 'Success', value: 'success' },
+      { label: 'Failure', value: 'failure' },
+      { label: 'Timeout', value: 'timeout' },
+      { label: 'Cancelled', value: 'cancelled' },
+    ],
+  },
+];


### PR DESCRIPTION
When you go to the executed task details page, you now have additional filters on the jobs table. You can now filter on the status of the job in conjunction with the system filter.