### PR TITLE
[ADVISOR-2668] Add info bar to run task modal

### DIFF
--- a/src/SmartComponents/RunTaskModal/RunTaskModal.js
+++ b/src/SmartComponents/RunTaskModal/RunTaskModal.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Flex, FlexItem, Modal } from '@patternfly/react-core';
+import { Alert, Button, Flex, FlexItem, Modal } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import SystemTable from '../SystemTable/SystemTable';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import {
   AVAILABLE_TASKS_ROOT,
+  INFO_ALERT_SYSTEMS,
   TASKS_API_ROOT,
   TASK_ERROR,
 } from '../../constants';
@@ -100,7 +101,10 @@ const RunTaskModal = ({
             </FlexItem>
           </Flex>
           <br />
-          <b>Systems to run tasks on</b>
+          <div style={{ paddingBottom: '8px' }}>
+            <b>Systems to run tasks on</b>
+          </div>
+          <Alert variant="info" isInline title={INFO_ALERT_SYSTEMS} />
           <SystemTable selectedIds={selectedIds} selectIds={selectIds} />
         </React.Fragment>
       )}

--- a/src/constants.js
+++ b/src/constants.js
@@ -50,6 +50,8 @@ export const EMPTY_COMPLETED_TASKS_MESSAGE = [
   '',
   'To use a task, navigate to the "Available tasks" tab and choose a task to run.',
 ];
+export const INFO_ALERT_SYSTEMS =
+  'Eligible systems include systems connected to console.redhat.com with rhc, or Satellite with Cloud Connector.';
 
 /**
  * Flex constants


### PR DESCRIPTION
This PR adds an info bar to the run task modal describing which eligible systems are being displayed.