### PR TITLE
Fix refetch after run task again

### DIFF
--- a/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
+++ b/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
@@ -8,6 +8,7 @@ import { EXECUTE_TASK_NOTIFICATION } from '../../constants';
 const ExecuteTaskButton = ({
   classname,
   ids,
+  setIsRunTaskAgain,
   setModalOpened,
   slug,
   title,
@@ -33,6 +34,9 @@ const ExecuteTaskButton = ({
         autoDismiss: false,
       });
     } else {
+      if (setIsRunTaskAgain) {
+        setIsRunTaskAgain(true);
+      }
       EXECUTE_TASK_NOTIFICATION(title, ids, result.data.id);
     }
   };
@@ -53,6 +57,7 @@ const ExecuteTaskButton = ({
 ExecuteTaskButton.propTypes = {
   classname: propTypes.string,
   ids: propTypes.array,
+  setIsRunTaskAgain: propTypes.func,
   setModalOpened: propTypes.func,
   slug: propTypes.string,
   title: propTypes.string,

--- a/src/SmartComponents/CompletedTasksTable/CompletedTasksTable.js
+++ b/src/SmartComponents/CompletedTasksTable/CompletedTasksTable.js
@@ -37,6 +37,7 @@ const CompletedTasksTable = () => {
   const [taskError, setTaskError] = useState();
   const [isDelete, setIsDelete] = useState(false);
   const [isCancel, setIsCancel] = useState(false);
+  const [isRunTaskAgain, setIsRunTaskAgain] = useState(false);
   const [isDeleteCancelModalOpened, setIsDeleteCancelModalOpened] =
     useState(false);
   const [taskDetails, setTaskDetails] = useState({});
@@ -96,18 +97,25 @@ const CompletedTasksTable = () => {
     }
   };
 
+  const refetchData = async () => {
+    await setCompletedTasks(LOADING_COMPLETED_TASKS_TABLE);
+    fetchData();
+  };
+
   useEffect(() => {
     fetchData();
   }, []);
 
   useEffect(async () => {
     if (isDelete || isCancel) {
-      await setCompletedTasks(LOADING_COMPLETED_TASKS_TABLE);
-      fetchData();
+      await refetchData();
       setIsDelete(false);
       setIsCancel(false);
+    } else if (isRunTaskAgain) {
+      await refetchData();
+      setIsRunTaskAgain(false);
     }
-  }, [isCancel, isDelete]);
+  }, [isCancel, isDelete, isRunTaskAgain]);
 
   return (
     <React.Fragment>
@@ -116,6 +124,7 @@ const CompletedTasksTable = () => {
         error={taskError}
         isOpen={runTaskModalOpened}
         selectedSystems={selectedSystems}
+        setIsRunTaskAgain={setIsRunTaskAgain}
         setModalOpened={setRunTaskModalOpened}
         slug={completedTaskDetails.task_slug}
         title={completedTaskDetails.task_title}

--- a/src/SmartComponents/RunTaskModal/RunTaskModal.js
+++ b/src/SmartComponents/RunTaskModal/RunTaskModal.js
@@ -16,6 +16,7 @@ const RunTaskModal = ({
   error,
   isOpen,
   selectedSystems,
+  setIsRunTaskAgain,
   setModalOpened,
   slug,
   title,
@@ -58,6 +59,7 @@ const RunTaskModal = ({
         <ExecuteTaskButton
           key="execute-task-button"
           ids={selectedIds}
+          setIsRunTaskAgain={setIsRunTaskAgain}
           setModalOpened={setModalOpened}
           slug={slug}
           title={title}
@@ -113,6 +115,7 @@ RunTaskModal.propTypes = {
   error: propTypes.object,
   isOpen: propTypes.bool,
   selectedSystems: propTypes.array,
+  setIsRunTaskAgain: propTypes.func,
   setModalOpened: propTypes.func,
   slug: propTypes.string,
   title: propTypes.string,


### PR DESCRIPTION
Before, if you ran a task again from the completed tasks table, using the kebab on the right, you would be directed back to the completed tasks table after the run task again modal was closed; but the table didn't refetch the data to show you the new task being run.

To repro:

- Go to completed tasks tab (it will help if you sort the table by systems so you can find the new tasks you will soon create more easily)
- Choose a task to run again
- Click the kebab on the right column of the table
- Select "Run this task again" from the dropdown menu
- When the modal opens, select an additional system to help differntiate this task from the new one
- Click "Execute"

This PR creates a fetch after a task has been run again from the completed tasks table.