### PR TITLE
[ADVISOR-2676] Add bulk select to systems table

### DIFF
--- a/src/SmartComponents/RunTaskModal/RunTaskModal.js
+++ b/src/SmartComponents/RunTaskModal/RunTaskModal.js
@@ -9,6 +9,7 @@ import {
   TASKS_API_ROOT,
   TASK_ERROR,
 } from '../../constants';
+import { fetchSystems } from '../../../api';
 import EmptyStateDisplay from '../../PresentationalComponents/EmptyStateDisplay/EmptyStateDisplay';
 import ExecuteTaskButton from '../../PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton';
 
@@ -37,6 +38,34 @@ const RunTaskModal = ({
   const cancelModal = () => {
     setSelectedIds([]);
     setModalOpened(false);
+  };
+
+  const bulkSelectIds = async (type, options) => {
+    let newSelectedIds = [...selectedIds];
+
+    switch (type) {
+      case 'none': {
+        setSelectedIds([]);
+        break;
+      }
+
+      case 'page': {
+        options.items.forEach((item) => {
+          if (!newSelectedIds.includes(item.id)) {
+            newSelectedIds.push(item.id);
+          }
+        });
+
+        setSelectedIds(newSelectedIds);
+        break;
+      }
+
+      case 'all': {
+        let results = await fetchSystems(`?limit=${options.total}&offset=0`);
+        setSelectedIds(results.data.map(({ id }) => id));
+        break;
+      }
+    }
   };
 
   const selectIds = (_event, _isSelected, _index, entity) => {
@@ -107,7 +136,11 @@ const RunTaskModal = ({
             <b>Systems to run tasks on</b>
           </div>
           <Alert variant="info" isInline title={INFO_ALERT_SYSTEMS} />
-          <SystemTable selectedIds={selectedIds} selectIds={selectIds} />
+          <SystemTable
+            bulkSelectIds={bulkSelectIds}
+            selectedIds={selectedIds}
+            selectIds={selectIds}
+          />
         </React.Fragment>
       )}
     </Modal>
@@ -115,7 +148,7 @@ const RunTaskModal = ({
 };
 
 RunTaskModal.propTypes = {
-  description: propTypes.string,
+  description: propTypes.any,
   error: propTypes.object,
   isOpen: propTypes.bool,
   selectedSystems: propTypes.array,

--- a/src/SmartComponents/SystemTable/__tests__/SystemTable.tests.js
+++ b/src/SmartComponents/SystemTable/__tests__/SystemTable.tests.js
@@ -48,7 +48,7 @@ describe('SystemTable', () => {
     const { asFragment } = render(
       <MemoryRouter keyLength={0}>
         <Provider store={store}>
-          <SystemTable />
+          <SystemTable selectedIds={[]} />
         </Provider>
       </MemoryRouter>
     );

--- a/src/SmartComponents/SystemTable/helpers.js
+++ b/src/SmartComponents/SystemTable/helpers.js
@@ -38,3 +38,13 @@ export const buildFilterSortString = (
   let filterString = buildFilterString(filters);
   return `?${limitOffsetString}${sortString}${filterString}`;
 };
+
+export const findCheckedValue = (total, selected) => {
+  if (selected === total && total > 0) {
+    return true;
+  } else if (selected > 0 && selected < total) {
+    return null;
+  } else {
+    return false;
+  }
+};

--- a/src/SmartComponents/SystemTable/hooks.js
+++ b/src/SmartComponents/SystemTable/hooks.js
@@ -1,7 +1,7 @@
 import { fetchSystems } from '../../../api';
 import { buildFilterSortString } from './helpers';
 
-export const useGetEntities = (selectedIds) => {
+export const useGetEntities = (onComplete, { selectedIds }) => {
   return async (
     _items,
     { page = 1, per_page: perPage, orderBy, orderDirection, filters }
@@ -21,6 +21,8 @@ export const useGetEntities = (selectedIds) => {
       data,
       meta: { count },
     } = fetchedEntities || {};
+
+    onComplete && onComplete(fetchedEntities);
 
     return {
       results: data.map((entity) => ({


### PR DESCRIPTION
Test bulk select in the following locations:

- Available tasks -> "Run task" button
- Completed tasks -> table kebab -> "Run this task again" menu item
- Completed tasks -> select task -> "Run this task again" button in header

Note the following behavior expectations:

- Select none, select page, and select all should be the options.
- If anything is selected, clicking the bulk select checkbox should deselect all things.
- If nothing is selected, clicking the bulk select checkbox should select all things.

When testing from the "Run this task again" options, preselected systems will be passed in. Verify that making selections, then cancelling the modal, then opening it again provides the original selections. Also, test for any additional things that you think might break it.