### PR TITLE
[ADVISOR-2705] Disable delete when task is running

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -142,7 +142,7 @@ const CompletedTaskDetails = () => {
                 flexContents={COMPLETED_INFO_BUTTONS(
                   completedTaskDetails.task_slug,
                   setRunTaskModalOpened,
-                  //completedTaskDetails.status,
+                  completedTaskDetails.status,
                   setIsDeleteCancelModalOpened
                 )}
                 flexProps={COMPLETED_INFO_BUTTONS_FLEX_PROPS}

--- a/src/SmartComponents/CompletedTaskDetailsKebab/CompletedTaskDetailsKebab.js
+++ b/src/SmartComponents/CompletedTaskDetailsKebab/CompletedTaskDetailsKebab.js
@@ -7,7 +7,7 @@ import {
   KebabToggle,
 } from '@patternfly/react-core';
 
-const CompletedTaskDetailsKebab = ({ /*status,*/ setModalOpened }) => {
+const CompletedTaskDetailsKebab = ({ status, setModalOpened }) => {
   const [isOpen, setIsOpen] = useState(false);
   const createDropdownItems = () => {
     //let type = status === 'Running' ? 'cancel' : 'delete';
@@ -18,6 +18,7 @@ const CompletedTaskDetailsKebab = ({ /*status,*/ setModalOpened }) => {
         component="button"
         data-ouia-component-id={`${type}-task-dropdown-item`}
         onClick={() => setModalOpened(true)}
+        isDisabled={status !== 'Completed'}
       >
         {type[0].toUpperCase() + type.slice(1)}
       </DropdownItem>,

--- a/src/SmartComponents/CompletedTasksTable/hooks/useActionResolvers.js
+++ b/src/SmartComponents/CompletedTasksTable/hooks/useActionResolvers.js
@@ -3,7 +3,7 @@ const useActionResolver = (handleTask, fetchTaskDetails) => {
     funcCall(task);
   };
 
-  return (/*row*/) => [
+  return (row) => [
     {
       title: 'Run this task again',
       onClick: (_event, _index, task) =>
@@ -11,6 +11,7 @@ const useActionResolver = (handleTask, fetchTaskDetails) => {
     },
     {
       title: 'Delete',
+      isDisabled: row.task.title.props.status !== 'Completed',
       /*row.task.title.props.status === 'Completed' ||
         row.task.title.props.status === 'Cancelled'
           ? 'Delete'

--- a/src/constants.js
+++ b/src/constants.js
@@ -97,7 +97,7 @@ export const COMPLETED_INFO_PANEL = [
 export const COMPLETED_INFO_BUTTONS = (
   slug,
   openTaskModal,
-  //status,
+  status,
   setModalOpened
 ) => {
   return [
@@ -114,7 +114,7 @@ export const COMPLETED_INFO_BUTTONS = (
     {
       children: (
         <CompletedTaskDetailsKebab
-          //status={status}
+          status={status}
           setModalOpened={setModalOpened}
         />
       ),


### PR DESCRIPTION
Before, if a task was running, you could delete it during the run. Now, we don't want to allow a deletion until the run is complete.

To test, run a task (preferrably the "Run the insights-client", and then try to delete that task via the Executed tasks table kebab and on the task details page in the top right kebab.

With this fix, it should be disabled.