### PR TITLE
[ADVISOR-2704] Fix breadcrumb link

### DIFF
--- a/src/PresentationalComponents/BreadcrumbLinkItem/BreadcrumbLinkItem.js
+++ b/src/PresentationalComponents/BreadcrumbLinkItem/BreadcrumbLinkItem.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { BreadcrumbItem } from '@patternfly/react-core';
+
+const RouterLink = ({ href, ...props }) => {
+  return <Link {...props} to={href} />;
+};
+
+RouterLink.propTypes = {
+  href: propTypes.string,
+};
+
+const BreadcrumbLinkItem = ({ children, ...props }) => (
+  <BreadcrumbItem {...props} component={RouterLink}>
+    {children}
+  </BreadcrumbItem>
+);
+
+BreadcrumbLinkItem.propTypes = {
+  children: propTypes.node,
+};
+
+export default BreadcrumbLinkItem;

--- a/src/SmartComponents/CompletedTaskDetails/Columns.js
+++ b/src/SmartComponents/CompletedTaskDetails/Columns.js
@@ -3,7 +3,14 @@ import propTypes from 'prop-types';
 import { renderColumnComponent } from '../../Utilities/helpers';
 
 const SystemNameCell = ({ system, display_name }, index) => (
-  <a key={`system-title-${index}`} href={`/insights/inventory/${system}`}>
+  <a
+    key={`system-title-${index}`}
+    href={
+      insights.chrome.isBeta()
+        ? `/beta/insights/inventory/${system}`
+        : `/insights/inventory/${system}`
+    }
+  >
     {display_name}
   </a>
 );

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -31,6 +31,7 @@ import EmptyStateDisplay from '../../PresentationalComponents/EmptyStateDisplay/
 import RunTaskModal from '../RunTaskModal/RunTaskModal';
 import DeleteCancelTaskModal from '../../PresentationalComponents/DeleteCancelTaskModal/DeleteCancelTaskModal';
 import { emptyRows } from '../../PresentationalComponents/NoResultsTable/NoResultsTable';
+import BreadcrumbLinkItem from '../../PresentationalComponents/BreadcrumbLinkItem/BreadcrumbLinkItem';
 import {
   getSelectedSystems,
   fetchTask,
@@ -120,9 +121,7 @@ const CompletedTaskDetails = () => {
         <React.Fragment>
           <PageHeader>
             <Breadcrumb ouiaId="completed-tasks-details-breadcrumb">
-              <BreadcrumbItem to="/beta/insights/tasks/executed">
-                Tasks
-              </BreadcrumbItem>
+              <BreadcrumbLinkItem to="/executed">Tasks</BreadcrumbLinkItem>
               <BreadcrumbItem isActive>
                 {completedTaskDetails.task_title}
               </BreadcrumbItem>


### PR DESCRIPTION
Before, if you were on `/insights/tasks/executed/{id}` and then click the "Tasks" breadcrumb link, you would be redirected to `/beta/insights/tasks/executed` instead of `/insights/tasks/executed`.

This PR properly redirects you to `beta` when you're on `beta`, and stable when you're on stable.