### PR TITLE
[ADVISOR-2710] Fix empty state bugs

### DIFF
--- a/src/PresentationalComponents/NoResultsTable/NoResultsTable.js
+++ b/src/PresentationalComponents/NoResultsTable/NoResultsTable.js
@@ -31,7 +31,7 @@ export const emptyRows = (type) => {
         {
           title: () => <NoResultsTable type={type} />, // eslint-disable-line
           props: {
-            colSpan: 3,
+            colSpan: 100,
           },
         },
       ],

--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -113,7 +113,7 @@ const SystemTable = ({ bulkSelectIds, selectedIds, selectIds }) => {
       tableProps={{
         canSelectAll: false,
         isStickyHeader: true,
-        onSelect: selectIds,
+        onSelect: items.length ? selectIds : null,
       }}
     />
   );

--- a/src/Utilities/hooks/useTableTools/Components/__tests__/__snapshots__/TasksTables.tests.js.snap
+++ b/src/Utilities/hooks/useTableTools/Components/__tests__/__snapshots__/TasksTables.tests.js.snap
@@ -991,7 +991,7 @@ exports[`TasksTables should render empty 1`] = `
       >
         <td
           class="pf-m-width-35"
-          colspan="3"
+          colspan="100"
           data-key="0"
           data-label="Task"
         >


### PR DESCRIPTION
In `NoResultsTable.js` in `emptyRows `function you're hardcoding colspan: 3 which does not cause any immediate problems, but imagine you added new columns to table that's using it or used it for a larger table, then the empty state would be off center, you can either pass exact amount of columns, or simply set the colspan to 100, so you virtually never run out, we use second option in both Vulnerabilities and it works wonders.

If a table items are selectable with checkboxes, then empty state has checkbox as well. To test, go to systems table and enter a filter that causes no results. You'll see a checkbox on the empty state.

These two issues are fixed in this PR.