### PR TITLE
[ADVISOR-2712] Fix Run date/time sorting

### DIFF
--- a/src/SmartComponents/CompletedTasksTable/Columns.js
+++ b/src/SmartComponents/CompletedTasksTable/Columns.js
@@ -39,8 +39,9 @@ export const RunDateTimeColumn = {
   props: {
     width: 20,
   },
-  sortByProp: 'run_date_time',
+  sortByProp: 'end_time',
   renderExport: (task) => task.run_date_time,
+  renderFunc: (_, _empty, result) => result.run_date_time,
 };
 
 export const exportableColumns = [


### PR DESCRIPTION
If you sort by Run date/time on completed task table you'll notice it sorts by month instead instead of month/day. So descending should sort - Aug 22 -> Aug 20 -> Aug 3 -> July 31 -> July 15.

The bug is that it actually sorts it like so - Aug 3 -> Aug 20 -> Aug 22 -> July 15 -> July 31. So it ends up sorting descending by month and ascending by day.

This PR fixes this issue.