### PR TITLE
[ADVISOR-2723] Add RBAC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@patternfly/react-table": "4.71.16",
         "@redhat-cloud-services/frontend-components": "^3.8.7",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.5",
-        "@redhat-cloud-services/frontend-components-utilities": "^3.2.14",
+        "@redhat-cloud-services/frontend-components-utilities": "^3.2.24",
         "axios": "^0.27.0",
         "classnames": "^2.3.1",
         "react": "17.0.2",
@@ -2888,11 +2888,11 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities": {
-      "version": "3.2.14",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.2.14.tgz",
-      "integrity": "sha512-i9IS3um36CQ699Mj0wDjS/kDjzKWKBxRwEyr1lJ4yiePSYdZLtvW8fPcfDdTMl7y2CuBnLP5vyu2bER/GznUZw==",
+      "version": "3.2.24",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.2.24.tgz",
+      "integrity": "sha512-7FDAnJ8+LbQY6w+d0WTIFaxObkY6bIzKRGcCBtqw/safntqqcRg1fKRTy/sHNrWisgEFHkOJ6XxlsHtBLgmWfw==",
       "dependencies": {
-        "@redhat-cloud-services/types": "0.0.1",
+        "@redhat-cloud-services/types": "^0.0.5",
         "@sentry/browser": "^5.4.0",
         "awesome-debounce-promise": "^2.1.0",
         "axios": "^0.25.0",
@@ -2909,6 +2909,11 @@
         "react-redux": ">=5.0.7",
         "react-router-dom": ">=4.2.2"
       }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/@redhat-cloud-services/types": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.5.tgz",
+      "integrity": "sha512-K2EgxRwszLzvch2nh72wNm8HOlcp6ljTNzUT3bcSfHRNN0poUHtslfcaJTE9EHbWglIH4rwKEhHkHQJGGtcexw=="
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/axios": {
       "version": "0.25.0",
@@ -18232,11 +18237,11 @@
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
-      "version": "3.2.14",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.2.14.tgz",
-      "integrity": "sha512-i9IS3um36CQ699Mj0wDjS/kDjzKWKBxRwEyr1lJ4yiePSYdZLtvW8fPcfDdTMl7y2CuBnLP5vyu2bER/GznUZw==",
+      "version": "3.2.24",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.2.24.tgz",
+      "integrity": "sha512-7FDAnJ8+LbQY6w+d0WTIFaxObkY6bIzKRGcCBtqw/safntqqcRg1fKRTy/sHNrWisgEFHkOJ6XxlsHtBLgmWfw==",
       "requires": {
-        "@redhat-cloud-services/types": "0.0.1",
+        "@redhat-cloud-services/types": "^0.0.5",
         "@sentry/browser": "^5.4.0",
         "awesome-debounce-promise": "^2.1.0",
         "axios": "^0.25.0",
@@ -18245,6 +18250,11 @@
         "react-content-loader": ">=3.4.1"
       },
       "dependencies": {
+        "@redhat-cloud-services/types": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.5.tgz",
+          "integrity": "sha512-K2EgxRwszLzvch2nh72wNm8HOlcp6ljTNzUT3bcSfHRNN0poUHtslfcaJTE9EHbWglIH4rwKEhHkHQJGGtcexw=="
+        },
         "axios": {
           "version": "0.25.0",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@patternfly/react-table": "4.71.16",
     "@redhat-cloud-services/frontend-components": "^3.8.7",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.5",
-    "@redhat-cloud-services/frontend-components-utilities": "^3.2.14",
+    "@redhat-cloud-services/frontend-components-utilities": "^3.2.24",
     "axios": "^0.27.0",
     "classnames": "^2.3.1",
     "react": "17.0.2",

--- a/src/PresentationalComponents/WithPermission/WithPermission.js
+++ b/src/PresentationalComponents/WithPermission/WithPermission.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
+
+const WithPermission = ({ children, requiredPermissions = [] }) => {
+  const { hasAccess, isLoading } = usePermissions('tasks', requiredPermissions);
+
+  if (!isLoading) {
+    return hasAccess ? children : <NotAuthorized serviceName="Tasks" />;
+  } else {
+    return '';
+  }
+};
+
+WithPermission.propTypes = {
+  children: propTypes.node,
+  requiredPermissions: propTypes.array,
+};
+
+export default WithPermission;

--- a/src/PresentationalComponents/WithPermission/__tests__/WithPermission.tests.js
+++ b/src/PresentationalComponents/WithPermission/__tests__/WithPermission.tests.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import WithPermission from '../WithPermission';
+
+jest.mock('@redhat-cloud-services/frontend-components-utilities/RBACHook');
+
+describe('WithPermission', () => {
+  const props = {
+    requiredPermissions: ['tasks:*:*'],
+  };
+
+  it('should render child with permissions', () => {
+    usePermissions.mockImplementation(() => ({
+      hasAccess: true,
+      isLoading: false,
+    }));
+
+    const { asFragment } = render(
+      <WithPermission {...props}>
+        <div aria-label="child"></div>
+      </WithPermission>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+    expect(screen.getByLabelText('child')).toBeInTheDocument();
+  });
+
+  it('should not render child without permissions', () => {
+    usePermissions.mockImplementation(() => ({
+      hasAccess: false,
+      isLoading: false,
+    }));
+
+    const { asFragment } = render(
+      <WithPermission {...props}>
+        <div aria-label="child"></div>
+      </WithPermission>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should wait to render on loading permissions', () => {
+    usePermissions.mockImplementation(() => ({
+      hasAccess: false,
+      isLoading: true,
+    }));
+
+    const { asFragment } = render(
+      <WithPermission {...props}>
+        <div aria-label="child"></div>
+      </WithPermission>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render with no required permissions', () => {
+    props.requiredPermissions = undefined;
+    usePermissions.mockImplementation(() => ({
+      hasAccess: false,
+      isLoading: false,
+    }));
+
+    const { asFragment } = render(
+      <WithPermission {...props}>
+        <div aria-label="child"></div>
+      </WithPermission>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/PresentationalComponents/WithPermission/__tests__/__snapshots__/WithPermission.tests.js.snap
+++ b/src/PresentationalComponents/WithPermission/__tests__/__snapshots__/WithPermission.tests.js.snap
@@ -1,0 +1,123 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WithPermission should not render child without permissions 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-c-empty-state ins-c-not-authorized "
+  >
+    <div
+      class="pf-c-empty-state__content"
+    >
+      <svg
+        aria-hidden="true"
+        class="pf-c-empty-state__icon"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 448 512"
+        width="1em"
+      >
+        <path
+          d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+        />
+      </svg>
+      <h5
+        class="pf-c-title pf-m-lg"
+        data-ouia-component-id="OUIA-Generated-Title-1"
+        data-ouia-component-type="PF4/Title"
+        data-ouia-safe="true"
+      >
+        You do not have access to Tasks
+      </h5>
+      <div
+        class="pf-c-empty-state__body"
+      >
+        Contact your organization administrator(s) for more information or visit 
+        <a
+          href="./settings/my-user-access"
+        >
+          My User Access
+        </a>
+          to learn more about your permissions.
+      </div>
+      <a
+        aria-disabled="false"
+        class="pf-c-button pf-m-primary"
+        data-ouia-component-id="OUIA-Generated-Button-primary-1"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        href="."
+      >
+        Go to landing page
+      </a>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`WithPermission should render child with permissions 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="child"
+  />
+</DocumentFragment>
+`;
+
+exports[`WithPermission should render with no required permissions 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-c-empty-state ins-c-not-authorized "
+  >
+    <div
+      class="pf-c-empty-state__content"
+    >
+      <svg
+        aria-hidden="true"
+        class="pf-c-empty-state__icon"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 448 512"
+        width="1em"
+      >
+        <path
+          d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+        />
+      </svg>
+      <h5
+        class="pf-c-title pf-m-lg"
+        data-ouia-component-id="OUIA-Generated-Title-2"
+        data-ouia-component-type="PF4/Title"
+        data-ouia-safe="true"
+      >
+        You do not have access to Tasks
+      </h5>
+      <div
+        class="pf-c-empty-state__body"
+      >
+        Contact your organization administrator(s) for more information or visit 
+        <a
+          href="./settings/my-user-access"
+        >
+          My User Access
+        </a>
+          to learn more about your permissions.
+      </div>
+      <a
+        aria-disabled="false"
+        class="pf-c-button pf-m-primary"
+        data-ouia-component-id="OUIA-Generated-Button-primary-2"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        href="."
+      >
+        Go to landing page
+      </a>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`WithPermission should wait to render on loading permissions 1`] = `<DocumentFragment />`;

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,6 +1,43 @@
 import React, { Suspense, lazy } from 'react';
+import PropTypes from 'prop-types';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { Bullseye, Spinner } from '@patternfly/react-core';
+import WithPermission from './PresentationalComponents/WithPermission/WithPermission';
+
+const PermissionRouter = (route) => {
+  const {
+    component: Component,
+    isExact,
+    path,
+    props = {},
+    requiredPermissions,
+  } = route;
+
+  const routeProps = {
+    isExact,
+    path,
+  };
+
+  const componentProps = {
+    ...props,
+    route: { ...route },
+  };
+
+  return (
+    <Route {...routeProps}>
+      <WithPermission requiredPermissions={requiredPermissions}>
+        <Component {...componentProps} />
+      </WithPermission>
+    </Route>
+  );
+};
+
+PermissionRouter.propTypes = {
+  component: PropTypes.node,
+  isExact: PropTypes.bool,
+  path: PropTypes.string,
+  props: PropTypes.object,
+};
 
 const TasksPage = lazy(() =>
   import(
@@ -14,6 +51,36 @@ const CompletedTaskDetails = lazy(() =>
   )
 );
 
+const tasksRoutes = [
+  {
+    path: '/executed/:id',
+    isExact: true,
+    requiredPermissions: ['tasks:*:*'],
+    component: CompletedTaskDetails,
+  },
+  {
+    path: '/available',
+    isExact: true,
+    requiredPermissions: ['tasks:*:*'],
+    component: TasksPage,
+    props: { tab: 0 },
+  },
+  {
+    path: '/executed',
+    isExact: true,
+    requiredPermissions: ['tasks:*:*'],
+    component: TasksPage,
+    props: { tab: 1 },
+  },
+  {
+    path: '/',
+    isExact: true,
+    requiredPermissions: ['tasks:*:*'],
+    component: TasksPage,
+    props: { tab: 0 },
+  },
+];
+
 /**
  * the Switch component changes routes depending on the path.
  *
@@ -22,22 +89,21 @@ const CompletedTaskDetails = lazy(() =>
  *      path - https://prod.foo.redhat.com:1337/insights/advisor/rules
  *      component - component to be rendered when a route has been chosen.
  */
-export const Routes = () => (
-  <Suspense
-    fallback={
-      <Bullseye>
-        <Spinner />
-      </Bullseye>
-    }
-  >
-    <Switch>
-      <Route exact path="/" render={() => <TasksPage tab={0} />} />
-      <Route exact path="/available" render={() => <TasksPage tab={0} />} />
-      <Route exact path="/executed" render={() => <TasksPage tab={1} />} />
-      <Route exact path="/executed/:id" component={CompletedTaskDetails} />
-      <Route>
-        <Redirect to="/" />
-      </Route>
-    </Switch>
-  </Suspense>
-);
+export const Routes = () => {
+  return (
+    <Suspense
+      fallback={
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
+      }
+    >
+      <Switch>
+        {tasksRoutes.map(PermissionRouter)}
+        <Route>
+          <Redirect to="/" />
+        </Route>
+      </Switch>
+    </Suspense>
+  );
+};

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -37,6 +37,8 @@ import {
   fetchTask,
   fetchTaskJobs,
 } from '../completedTaskDetailsHelpers';
+import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 
 const CompletedTaskDetails = () => {
   const { id } = useParams();
@@ -52,6 +54,10 @@ const CompletedTaskDetails = () => {
   const [isDelete, setIsDelete] = useState(false);
   const [isCancel, setIsCancel] = useState(false);
   const history = useHistory();
+  const { hasAccess, isLoading } = usePermissions('inventory', [
+    'inventory:*:*',
+    'inventory:*:read',
+  ]);
 
   const fetchData = async () => {
     const fetchedTaskDetails = await fetchTask(id, setError);
@@ -164,24 +170,28 @@ const CompletedTaskDetails = () => {
             </Card>
             <br />
             <Card>
-              <TasksTables
-                label={`${completedTaskDetails.id}-completed-jobs`}
-                ouiaId={`${completedTaskDetails.id}-completed-jobs-table`}
-                columns={columns}
-                items={completedTaskJobs}
-                filters={{
-                  filterConfig: [...statusFilters, ...systemFilter],
-                }}
-                options={{
-                  ...TASKS_TABLE_DEFAULTS,
-                  exportable: {
-                    ...TASKS_TABLE_DEFAULTS.exportable,
-                    columns: exportableColumns,
-                  },
-                }}
-                emptyRows={emptyRows('jobs')}
-                isStickyHeader
-              />
+              {!isLoading && hasAccess ? (
+                <TasksTables
+                  label={`${completedTaskDetails.id}-completed-jobs`}
+                  ouiaId={`${completedTaskDetails.id}-completed-jobs-table`}
+                  columns={columns}
+                  items={completedTaskJobs}
+                  filters={{
+                    filterConfig: [...statusFilters, ...systemFilter],
+                  }}
+                  options={{
+                    ...TASKS_TABLE_DEFAULTS,
+                    exportable: {
+                      ...TASKS_TABLE_DEFAULTS.exportable,
+                      columns: exportableColumns,
+                    },
+                  }}
+                  emptyRows={emptyRows('jobs')}
+                  isStickyHeader
+                />
+              ) : (
+                <NotAuthorized serviceName="Inventory" />
+              )}
             </Card>
           </Main>
         </React.Fragment>

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/CompletedTaskDetails.tests.js
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/CompletedTaskDetails.tests.js
@@ -24,6 +24,13 @@ import {
 import * as dispatcher from '../../../Utilities/Dispatcher';
 
 jest.mock('../../../../api');
+jest.mock(
+  '@redhat-cloud-services/frontend-components-utilities/RBACHook',
+  () => ({
+    esModule: true,
+    usePermissions: () => ({ hasAccess: true, isLoading: false }),
+  })
+);
 
 describe('CompletedTaskDetails', () => {
   const store = init().getStore();


### PR DESCRIPTION
This PR adds RBAC security to the frontend. At this point, we only have `tasks:*:*`, `inventory:*:*` and `inventory:*:read`. I block access to every route of the app if a user doesn't have `tasks:*:*` and I only block the SystemsTable when a user doesn't have `inventory:*:*` OR `inventory:*:read`.

If you don't have experience setting up RBAC permissions, I can help with showing you how to do it in order to properly test this. You can surely just set `hasAccess` manually in the code, but that doesn't quite have the same effect as setting RBAC perms. Let me know if you need guidance.