### PR TITLE
Fix run task button issue

### DIFF
--- a/src/PresentationalComponents/RunTaskButton/RunTaskButton.js
+++ b/src/PresentationalComponents/RunTaskButton/RunTaskButton.js
@@ -14,7 +14,7 @@ const RunTaskButton = ({
       aria-label={`${slug}-run-task-button`}
       className={classname}
       variant={variant}
-      onClick={() => openTaskModal(true)}
+      onClick={() => openTaskModal(true, slug)}
     >
       {isFirst ? 'Run task' : 'Run task again'}
     </Button>

--- a/src/PresentationalComponents/RunTaskButton/__tests__/RunTaskButton.tests.js
+++ b/src/PresentationalComponents/RunTaskButton/__tests__/RunTaskButton.tests.js
@@ -51,6 +51,6 @@ describe('RunTaskButton', () => {
     await waitFor(() =>
       userEvent.click(screen.getByLabelText('taska-run-task-button'))
     );
-    expect(props.openTaskModal).toHaveBeenCalledWith(true);
+    expect(props.openTaskModal).toHaveBeenCalledWith(true, 'taska');
   });
 });

--- a/src/SmartComponents/TasksPage/TasksPage.js
+++ b/src/SmartComponents/TasksPage/TasksPage.js
@@ -37,7 +37,7 @@ const TasksPage = ({ tab }) => {
     setTab(index);
   };
 
-  const openTaskModal = async (slug) => {
+  const openTaskModal = async (value, slug) => {
     const task = await fetchAvailableTask(slug);
     if (task?.response?.status && task?.response?.status !== 200) {
       setError(task);
@@ -52,7 +52,7 @@ const TasksPage = ({ tab }) => {
       setActiveTask(task);
     }
 
-    setRunTaskModalOpened(true);
+    setRunTaskModalOpened(value);
   };
 
   return (


### PR DESCRIPTION
Before, if you clicked on available task tab and click the "Run this task" button on a task, it will error out. Now, this button should open the modal and display the task information and system table.

This action should be the same for the "Run this task again" button via the completed task details page.