### PR TITLE
add pr_check and build_deploy scripts

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# --------------------------------------------
+# Export vars for helper scripts to use
+# --------------------------------------------
+# name of app-sre "application" folder this component lives in; needs to match for quay
+export COMPONENT="tasks-frontend"
+# IMAGE should match the quay repo set by app.yaml in app-interface
+export IMAGE="quay.io/cloudservices/tasks-frontend"
+export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
+export APP_ROOT=$(pwd)
+export NODE_BUILD_VERSION=16
+COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
+
+set -exv
+# source is preferred to | bash -s in this case to avoid a subshell
+source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
+BUILD_RESULTS=$?
+
+# Stubbed out for now
+mkdir -p $WORKSPACE/artifacts
+cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF
+
+# teardown_docker
+exit $BUILD_RESULTS

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# --------------------------------------------
+# Export vars for helper scripts to use
+# --------------------------------------------
+# name of app-sre "application" folder this component lives in; needs to match for quay
+export COMPONENT="tasks-frontend"
+# IMAGE should match the quay repo set by app.yaml in app-interface
+export IMAGE="quay.io/cloudservices/tasks-frontend"
+export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
+export APP_ROOT=$(pwd)
+export NODE_BUILD_VERSION=16
+COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
+
+# --------------------------------------------
+# Options that must be configured by app owner
+# --------------------------------------------
+# IQE tests for patchman ui is not set yet. We can comment out config for it for now
+# IQE_PLUGINS=""
+# IQE_MARKER_EXPRESSION=""
+# IQE_FILTER_EXPRESSION=""
+
+set -exv
+# source is preferred to | bash -s in this case to avoid a subshell
+source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
+BUILD_RESULTS=$?
+
+# Stubbed out for now
+mkdir -p $WORKSPACE/artifacts
+cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF
+
+# teardown_docker
+exit $BUILD_RESULTS


### PR DESCRIPTION
This adds pr_check and build_deploy scripts for containerizing tasks-frontend. Currently, these scripts do not get auto-triggered until containerization is finished.

Reference: https://consoledot.pages.redhat.com/docs/dev/getting-started/frontend-migration.html#_quay_repo