### PR TITLE
[ADVISOR-2670] Add cancel task

### DIFF
--- a/src/PresentationalComponents/DeleteCancelTaskModal/DeleteCancelTaskModal.js
+++ b/src/PresentationalComponents/DeleteCancelTaskModal/DeleteCancelTaskModal.js
@@ -2,23 +2,26 @@ import React from 'react';
 import { Button, Modal } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import {
-  //CANCEL_TASK_BODY,
-  //CANCEL_TASK_ERROR,
+  CANCEL_NON_SATELLITE_TASK_BODY,
+  CANCEL_TASK_BODY,
+  CANCEL_TASK_ERROR,
   DELETE_TASK_BODY,
   DELETE_TASK_ERROR,
+  EXISTING_RESULTS_STRING,
 } from '../../constants';
-import { /*cancelExecutedTask,*/ deleteExecutedTask } from '../../../api';
+import { cancelExecutedTask, deleteExecutedTask } from '../../../api';
 import { dispatchNotification } from '../../Utilities/Dispatcher';
 import { isError } from '../../SmartComponents/completedTaskDetailsHelpers';
 
 const DeleteCancelTaskModal = ({
   id,
+  isOnlySatelliteConnected,
   isOpen,
-  //setIsCancel,
+  setIsCancel,
   setIsDelete,
   setModalOpened,
   startTime,
-  //status,
+  status,
   title,
 }) => {
   const createNotification = (message) => {
@@ -42,7 +45,7 @@ const DeleteCancelTaskModal = ({
   };
 
   const renderButtons = () => {
-    return [
+    let actions = [
       <Button
         aria-label="delete-task-button"
         key="delete-task-button"
@@ -64,30 +67,8 @@ const DeleteCancelTaskModal = ({
         Cancel
       </Button>,
     ];
-    /*let actions;
 
-    if (status === 'Completed') {
-      actions = [
-        <Button
-          key="delete-task-button"
-          ouiaId="delete-task-modal-button"
-          variant="danger"
-          onClick={() =>
-            handleTask(deleteExecutedTask, DELETE_TASK_ERROR, setIsDelete)
-          }
-        >
-          Delete task
-        </Button>,
-        <Button
-          key="cancel"
-          ouiaId="cancel-delete-modal-button"
-          variant="link"
-          onClick={() => setModalOpened(false)}
-        >
-          Cancel
-        </Button>,
-      ];
-    } else if (status === 'Running') {
+    if (status === 'Running') {
       actions = [
         <Button
           key="cancel-task-button"
@@ -120,30 +101,44 @@ const DeleteCancelTaskModal = ({
       ];
     }
 
-    return actions;*/
+    return actions;
+  };
+
+  const renderCancelBody = () => {
+    return (
+      <div>
+        <span>
+          {isOnlySatelliteConnected
+            ? CANCEL_TASK_BODY(startTime, title)
+            : CANCEL_NON_SATELLITE_TASK_BODY(startTime, title)}
+        </span>
+        <br />
+        <br />
+        <span>{EXISTING_RESULTS_STRING()}</span>
+      </div>
+    );
   };
 
   return (
     <Modal
       aria-label="cancel-delete-task-modal"
-      //title={`${status === 'Completed' ? 'Delete' : 'Cancel'} this task?`}
-      title="Delete this task?"
+      title={`${status === 'Running' ? 'Cancel' : 'Delete'} this task?`}
       titleIconVariant="warning"
       isOpen={isOpen}
       onClose={() => setModalOpened(false)}
       width={'50%'}
       actions={renderButtons()}
     >
-      {/*status === 'Completed'
-        ? DELETE_TASK_BODY(startTime, title)
-        : CANCEL_TASK_BODY(startTime, title)*/}
-      {DELETE_TASK_BODY(startTime, title)}
+      {status === 'Running'
+        ? renderCancelBody()
+        : DELETE_TASK_BODY(startTime, title)}
     </Modal>
   );
 };
 
 DeleteCancelTaskModal.propTypes = {
   id: propTypes.number,
+  isOnlySatelliteConnected: propTypes.bool,
   isOpen: propTypes.bool,
   setIsCancel: propTypes.func,
   setIsDelete: propTypes.func,

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -36,6 +36,7 @@ import {
   getSelectedSystems,
   fetchTask,
   fetchTaskJobs,
+  onlySatelliteConnected,
 } from '../completedTaskDetailsHelpers';
 
 const CompletedTaskDetails = () => {
@@ -101,6 +102,7 @@ const CompletedTaskDetails = () => {
       />
       <DeleteCancelTaskModal
         id={completedTaskDetails.id}
+        isOnlySatelliteConnected={onlySatelliteConnected(completedTaskJobs)}
         isOpen={isDeleteCancelModalOpened}
         setIsCancel={setIsCancel}
         setIsDelete={setIsDelete}

--- a/src/SmartComponents/CompletedTaskDetailsKebab/CompletedTaskDetailsKebab.js
+++ b/src/SmartComponents/CompletedTaskDetailsKebab/CompletedTaskDetailsKebab.js
@@ -10,8 +10,7 @@ import {
 const CompletedTaskDetailsKebab = ({ status, setModalOpened }) => {
   const [isOpen, setIsOpen] = useState(false);
   const createDropdownItems = () => {
-    //let type = status === 'Running' ? 'cancel' : 'delete';
-    let type = 'delete';
+    let type = status === 'Running' ? 'cancel' : 'delete';
     return [
       <DropdownItem
         aria-label={`${type}-task-kebab-button`}
@@ -19,7 +18,6 @@ const CompletedTaskDetailsKebab = ({ status, setModalOpened }) => {
         component="button"
         data-ouia-component-id={`${type}-task-dropdown-item`}
         onClick={() => setModalOpened(true)}
-        isDisabled={status !== 'Completed'}
       >
         {type[0].toUpperCase() + type.slice(1)}
       </DropdownItem>,

--- a/src/SmartComponents/CompletedTaskDetailsKebab/__tests__/__snapshots__/CompletedTaskDetailsKebab.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetailsKebab/__tests__/__snapshots__/CompletedTaskDetailsKebab.tests.js.snap
@@ -39,16 +39,16 @@ exports[`AvailableTasks should render Delete disabled 1`] = `
         role="menuitem"
       >
         <button
-          aria-disabled="true"
-          aria-label="delete-task-kebab-button"
-          class="pf-m-disabled pf-c-dropdown__menu-item"
-          data-ouia-component-id="delete-task-dropdown-item"
+          aria-disabled="false"
+          aria-label="cancel-task-kebab-button"
+          class="pf-c-dropdown__menu-item"
+          data-ouia-component-id="cancel-task-dropdown-item"
           data-ouia-component-type="PF4/DropdownItem"
           data-ouia-safe="true"
           tabindex="-1"
           type="button"
         >
-          Delete
+          Cancel
         </button>
       </li>
     </ul>

--- a/src/SmartComponents/CompletedTasksTable/CompletedTasksTable.js
+++ b/src/SmartComponents/CompletedTasksTable/CompletedTasksTable.js
@@ -23,6 +23,7 @@ import {
   fetchTaskJobs,
   getSelectedSystems,
   isError,
+  onlySatelliteConnected,
 } from '../completedTaskDetailsHelpers';
 import RunTaskModal from '../RunTaskModal/RunTaskModal';
 
@@ -43,6 +44,8 @@ const CompletedTasksTable = () => {
   const [taskDetails, setTaskDetails] = useState({});
   const [runTaskModalOpened, setRunTaskModalOpened] = useState(false);
   const [selectedSystems, setSelectedSystems] = useState([]);
+  const [isOnlySatelliteConnected, setIsOnlySatelliteConnected] =
+    useState(false);
 
   const fetchTaskDetails = async (id) => {
     setTaskError();
@@ -54,6 +57,8 @@ const CompletedTasksTable = () => {
         fetchedTaskDetails,
         setTaskError
       );
+
+      setIsOnlySatelliteConnected(onlySatelliteConnected(fetchedTaskJobs));
 
       if (fetchedTaskJobs.length) {
         setSelectedSystems(getSelectedSystems(fetchedTaskJobs));
@@ -131,6 +136,7 @@ const CompletedTasksTable = () => {
       />
       <DeleteCancelTaskModal
         id={taskDetails.id}
+        isOnlySatelliteConnected={isOnlySatelliteConnected}
         isOpen={isDeleteCancelModalOpened}
         setIsCancel={setIsCancel}
         setIsDelete={setIsDelete}

--- a/src/SmartComponents/CompletedTasksTable/hooks/useActionResolvers.js
+++ b/src/SmartComponents/CompletedTasksTable/hooks/useActionResolvers.js
@@ -10,12 +10,11 @@ const useActionResolver = (handleTask, fetchTaskDetails) => {
         onClick(fetchTaskDetails, task.task.title.props.id),
     },
     {
-      title: 'Delete',
-      isDisabled: row.task.title.props.status !== 'Completed',
-      /*row.task.title.props.status === 'Completed' ||
+      title:
+        row.task.title.props.status === 'Completed' ||
         row.task.title.props.status === 'Cancelled'
           ? 'Delete'
-          : 'Cancel',*/
+          : 'Cancel',
       onClick: (_event, _index, task) => {
         onClick(handleTask, task.task.title.props);
       },

--- a/src/SmartComponents/completedTaskDetailsHelpers.js
+++ b/src/SmartComponents/completedTaskDetailsHelpers.js
@@ -46,3 +46,7 @@ export const fetchTaskJobs = async (taskDetails, setError) => {
     return taskJobs.data;
   }
 };
+
+export const onlySatelliteConnected = (jobs) => {
+  return !jobs.some((job) => job.connection_type !== 'satellite');
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -312,8 +312,22 @@ export const DELETE_TASK_ERROR = (title) => {
   return `Error: Task "${title}" could not be deleted`;
 };
 
+export const EXISTING_RESULTS_STRING = () => {
+  return 'Any existing results will be available.';
+};
+
 export const CANCEL_TASK_BODY = (startTime, title) => {
-  return `Cancelling the ${startTime} run of "${title}" will stop any analysis in progress. Any existing results will be available.`;
+  return `Cancelling the ${moment
+    .utc(startTime)
+    .format(
+      'MMM DD YYYY'
+    )} run of "${title}" will stop any analysis in progress.`;
+};
+
+export const CANCEL_NON_SATELLITE_TASK_BODY = (startTime, title) => {
+  return CANCEL_TASK_BODY(startTime, title).concat(
+    ' Tasks running on systems connected with rhc cannot be cancelled.'
+  );
 };
 
 export const CANCEL_TASK_ERROR = (title) => {


### PR DESCRIPTION
This PR allows a task, that has not been completed, to be cancelled. If a task status is "Running", the kebab dropdown on the completed tasks table should include "Cancel" instead of delete. The same is true if you view the details page of a completed task. The kebab in the right of the top header should include "Cancel" instead of delete.

After clicking cancel, there are a number of things you will see in the modal. You will have the option to:
- Cancel a task - this will simply cancel but leave all details of the completed task in the table
- Cancel and delete a task - this will remove the task from your table and the backend will handle cancelling and deleting.

Additionally, a task can only cancel jobs on systems that are connected via Satellite. A system with any other means of connection cannot be cancelled. Therefore, when entering the cancel modal, if any system is NOT connected via Satellite, there will be a sentence in the modal body stating, "Tasks running on systems connected with rhc cannot be cancelled." Likewise, if a task is running on systems ONLY connected via Satellite, that sentence will not be visible.

Now, at this point, cancelling isn't working properly. The backend is not able to properly cancel a task. So, when you cancel a task, you'll notice the task returns a status of "Cancelled", but the jobs will still say they are "Running". This much is normal. What we would expect is to eventually see those jobs return as "Cancelled" if they are connected via Satellite, and some other status if they are connected via rhc. But what currently happens is all systems finish their runs and the status of the task completes and the "Run end" value includes a successful run completion time.

The frontend code should work fine when the backend code is implemented.