### PR TITLE
Fix error in deploy script

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -20,12 +20,12 @@ objects:
       image: ${IMAGE}:${IMAGE_TAG}
       navItems:
         - expandable: true
-        title: Toolkit
-        routes:
-          - appId: "tasks"
-            title: "Tasks"
-            href: "/insights/toolkit/tasks"
-            product: "Red Hat Insights"
+          title: Toolkit
+          routes:
+            - appId: "tasks"
+              title: "Tasks"
+              href: "/insights/toolkit/tasks"
+              product: "Red Hat Insights"
       module:
         manifestLocation: "/apps/tasks/fed-mods.json"
         modules:


### PR DESCRIPTION
QE found an error with the deploy script and I think it is just a spacing issue.

```
    raise ParserError("while parsing a block collection", self.marks[-1],
yaml.parser.ParserError: while parsing a block collection
  in "<byte string>", line 22, column 9:
            - expandable: true
            ^
expected <block end>, but found '?'
  in "<byte string>", line 23, column 9:
            title: Toolkit
            ^
ERROR: deploy failed: while parsing a block collection
  in "<byte string>", line 22, column 9:
            - expandable: true
            ^
expected <block end>, but found '?'
  in "<byte string>", line 23, column 9:
            title: Toolkit
            ^
```