### PR TITLE
fix(RHCLOUD-20293): updates the url for quay repo

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -40,4 +40,4 @@ parameters:
   - name: IMAGE_TAG
     required: true
   - name: IMAGE
-    value: https://quay.io/repository/cloudservices/tasks-frontend
+    value: quay.io/cloudservices/tasks-frontend


### PR DESCRIPTION
This fixes the URL  for the quay repo to be able to deploy the tasks-frontend container into the Ephemeral Environment. The URL should point to the  page where list of image tags are listed, not to a landing repo page.