### PR TITLE
[ADVISOR-2851] Remove "Cancelled" from jobs filter

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/Filters.js
+++ b/src/SmartComponents/CompletedTaskDetails/Filters.js
@@ -22,7 +22,6 @@ export const statusFilters = [
       { label: 'Success', value: 'success' },
       { label: 'Failure', value: 'failure' },
       { label: 'Timeout', value: 'timeout' },
-      { label: 'Cancelled', value: 'cancelled' },
     ],
   },
 ];


### PR DESCRIPTION
Find a completed task and view the status filter for the jobs table. The dropdown should no longer include "Cancelled" in the list.