### PR TITLE
[ADVISOR-2855] Rework job message logic

### DIFF
--- a/src/PresentationalComponents/SplitMessages/SplitMessages.js
+++ b/src/PresentationalComponents/SplitMessages/SplitMessages.js
@@ -3,21 +3,26 @@ import { Split, SplitItem } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import propTypes from 'prop-types';
 
-const SplitMessages = ({ content }) => {
+const SplitMessages = ({ alert, content }) => {
   return (
     <Split>
-      <SplitItem style={{ paddingRight: '8px' }}>
-        <ExclamationCircleIcon color="#C9190B" />
-      </SplitItem>
-      <SplitItem style={{ paddingRight: '16px' }}>
-        <span style={{ color: '#C9190B' }}>Alert</span>
-      </SplitItem>
+      {alert ? (
+        <React.Fragment>
+          <SplitItem style={{ paddingRight: '8px' }}>
+            <ExclamationCircleIcon color="#C9190B" />
+          </SplitItem>
+          <SplitItem style={{ paddingRight: '16px' }}>
+            <span style={{ color: '#C9190B' }}>Alert</span>
+          </SplitItem>
+        </React.Fragment>
+      ) : null}
       <SplitItem color="#A30000">{content}</SplitItem>
     </Split>
   );
 };
 
 SplitMessages.propTypes = {
+  alert: propTypes.bool,
   content: propTypes.string,
 };
 

--- a/src/SmartComponents/CompletedTaskDetails/Columns.js
+++ b/src/SmartComponents/CompletedTaskDetails/Columns.js
@@ -57,12 +57,17 @@ export const MessageColumn = {
     }
   },
   renderFunc: (_, _empty, job) => {
-    if (job.results.message && job.results.alert) {
-      return <SplitMessages content={job.results.message} />;
+    if (job.results.message) {
+      return (
+        <SplitMessages
+          content={job.results.message}
+          alert={job.results.alert}
+        />
+      );
     } else if (job.status === 'Failure') {
-      return <SplitMessages content={JOB_FAILED_MESSAGE} />;
+      return <SplitMessages content={JOB_FAILED_MESSAGE} alert={true} />;
     } else if (job.status === 'Timeout') {
-      return <SplitMessages content={JOB_TIMED_OUT_MESSAGE} />;
+      return <SplitMessages content={JOB_TIMED_OUT_MESSAGE} alert={true} />;
     } else if (job.status === 'Running') {
       return <span style={{ color: '#72767B' }}>No result yet</span>;
     }


### PR DESCRIPTION
There were scenarios where a Successful job would complete with no alert, but did contain a message. The logic I was using wasn't showing those types of messages. Now this PR does show those messages.

Let me know if you want help on choosing the completed tasks that will get the information you need to review this PR.