### PR TITLE
Update tabs and add status filter

### DIFF
--- a/src/PresentationalComponents/TasksTabs/__tests__/TasksTabs.tests.js
+++ b/src/PresentationalComponents/TasksTabs/__tests__/TasksTabs.tests.js
@@ -30,7 +30,7 @@ describe('TasksTabs', () => {
   it('should update tab index', async () => {
     render(<TasksTabs {...props} />);
 
-    userEvent.click(screen.getByText('Completed tasks'));
+    userEvent.click(screen.getByText('Activity'));
     await waitFor(() =>
       expect(props.updateTab).toHaveBeenCalledWith(expect.anything(), 1)
     );

--- a/src/PresentationalComponents/TasksTabs/__tests__/__snapshots__/TasksTabs.tests.js.snap
+++ b/src/PresentationalComponents/TasksTabs/__tests__/__snapshots__/TasksTabs.tests.js.snap
@@ -44,7 +44,7 @@ exports[`TasksTabs should render correctly 1`] = `
           <span
             class="pf-c-tabs__item-text"
           >
-            Available tasks
+            Available
           </span>
         </button>
       </li>
@@ -61,7 +61,7 @@ exports[`TasksTabs should render correctly 1`] = `
           <span
             class="pf-c-tabs__item-text"
           >
-            Completed tasks
+            Activity
           </span>
         </button>
       </li>

--- a/src/SmartComponents/CompletedTasksTable/CompletedTasksTable.js
+++ b/src/SmartComponents/CompletedTasksTable/CompletedTasksTable.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ExclamationCircleIcon, WrenchIcon } from '@patternfly/react-icons';
 import columns, { exportableColumns } from './Columns';
-import * as Filters from './Filters';
+import { nameFilter, statusFilter } from './Filters';
 import { renderRunDateTime } from '../../Utilities/helpers';
 import {
   COMPLETED_TASKS_ERROR,
@@ -28,7 +28,6 @@ import {
 import RunTaskModal from '../RunTaskModal/RunTaskModal';
 
 const CompletedTasksTable = () => {
-  const filters = Object.values(Filters);
   const [completedTasks, setCompletedTasks] = useState(
     LOADING_COMPLETED_TASKS_TABLE
   );
@@ -143,12 +142,12 @@ const CompletedTasksTable = () => {
         status={taskDetails.status}
         title={taskDetails.task_title}
       />
-      <div aria-label="completed-tasks">
+      <div aria-label="activity">
         {error ? (
           <EmptyStateDisplay
             icon={ExclamationCircleIcon}
             color="#c9190b"
-            title={'Completed tasks cannot be displayed'}
+            title={'Activities cannot be displayed'}
             text={COMPLETED_TASKS_ERROR}
             error={`Error ${error?.response?.status}: ${error?.message}`}
           />
@@ -161,12 +160,12 @@ const CompletedTasksTable = () => {
           />
         ) : (
           <TasksTables
-            label="completed-tasks-table"
-            ouiaId="completed-tasks-table"
+            label="activity-table"
+            ouiaId="activity-table"
             columns={columns}
             items={completedTasks}
             filters={{
-              filterConfig: filters,
+              filterConfig: [...nameFilter, ...statusFilter],
             }}
             options={{
               ...TASKS_TABLE_DEFAULTS,

--- a/src/SmartComponents/CompletedTasksTable/Filters.js
+++ b/src/SmartComponents/CompletedTasksTable/Filters.js
@@ -1,10 +1,25 @@
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 
-export const nameFilter = {
-  type: conditionalFilterType.text,
-  label: 'Task',
-  filter: (tasks, value) =>
-    tasks.filter((task) =>
-      task.task_title.toLowerCase().includes(value.toLowerCase())
-    ),
-};
+export const nameFilter = [
+  {
+    type: conditionalFilterType.text,
+    label: 'Task',
+    filter: (tasks, value) =>
+      tasks.filter((task) =>
+        task.task_title.toLowerCase().includes(value.toLowerCase())
+      ),
+  },
+];
+
+export const statusFilter = [
+  {
+    type: conditionalFilterType.checkbox,
+    label: 'Status',
+    filter: (tasks, value) =>
+      tasks.filter((task) => value.includes(task.status.toLowerCase())),
+    items: [
+      { label: 'Completed', value: 'completed' },
+      { label: 'Running', value: 'running' },
+    ],
+  },
+];

--- a/src/SmartComponents/CompletedTasksTable/__tests__/__snapshots__/CompletedTasksTable.tests.js.snap
+++ b/src/SmartComponents/CompletedTasksTable/__tests__/__snapshots__/CompletedTasksTable.tests.js.snap
@@ -3,7 +3,7 @@
 exports[`CompletedTasksTable should export 1`] = `
 <DocumentFragment>
   <div
-    aria-label="completed-tasks"
+    aria-label="activity"
   >
     <div
       class="pf-c-toolbar  ins-c-primary-toolbar"
@@ -27,6 +27,68 @@ exports[`CompletedTasksTable should export 1`] = `
               <div
                 class="pf-l-split ins-c-conditional-filter"
               >
+                <div
+                  class="pf-l-split__item"
+                >
+                  <div
+                    class="pf-c-dropdown ins-c-conditional-filter__group"
+                    data-ouia-component-id="ConditionalFilter"
+                    data-ouia-component-type="PF4/Dropdown"
+                    data-ouia-safe="true"
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-label="Conditional filter"
+                      class="pf-c-dropdown__toggle"
+                      data-ouia-component-id="ConditionalFilter"
+                      data-ouia-component-type="PF4/DropdownToggle"
+                      data-ouia-safe="true"
+                      id="pf-dropdown-toggle-id-17"
+                      type="button"
+                    >
+                      <span
+                        class="pf-c-dropdown__toggle-text"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                          />
+                        </svg>
+                        <span
+                          class="ins-c-conditional-filter__value-selector"
+                        >
+                          Task
+                        </span>
+                      </span>
+                      <span
+                        class="pf-c-dropdown__toggle-icon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                </div>
                 <div
                   class="pf-l-split__item pf-m-fill"
                 >
@@ -77,7 +139,7 @@ exports[`CompletedTasksTable should export 1`] = `
                 data-ouia-component-id="Export"
                 data-ouia-component-type="PF4/DropdownToggle"
                 data-ouia-safe="true"
-                id="pf-dropdown-toggle-id-10"
+                id="pf-dropdown-toggle-id-18"
                 type="button"
               >
                 <span>
@@ -97,7 +159,7 @@ exports[`CompletedTasksTable should export 1`] = `
                 </span>
               </button>
               <ul
-                aria-labelledby="pf-dropdown-toggle-id-10"
+                aria-labelledby="pf-dropdown-toggle-id-18"
                 class="pf-c-dropdown__menu"
                 role="menu"
               >
@@ -292,9 +354,9 @@ exports[`CompletedTasksTable should export 1`] = `
       </div>
     </div>
     <table
-      aria-label="completed-tasks-table"
+      aria-label="activity-table"
       class="pf-c-table pf-m-grid-md"
-      data-ouia-component-id="completed-tasks-table"
+      data-ouia-component-id="activity-table"
       data-ouia-component-type="PF4/Table"
       data-ouia-safe="true"
       role="grid"
@@ -793,7 +855,7 @@ exports[`CompletedTasksTable should export 1`] = `
 exports[`CompletedTasksTable should render correctly 1`] = `
 <DocumentFragment>
   <div
-    aria-label="completed-tasks"
+    aria-label="activity"
   >
     <div
       class="pf-c-toolbar  ins-c-primary-toolbar"
@@ -817,6 +879,68 @@ exports[`CompletedTasksTable should render correctly 1`] = `
               <div
                 class="pf-l-split ins-c-conditional-filter"
               >
+                <div
+                  class="pf-l-split__item"
+                >
+                  <div
+                    class="pf-c-dropdown ins-c-conditional-filter__group"
+                    data-ouia-component-id="ConditionalFilter"
+                    data-ouia-component-type="PF4/Dropdown"
+                    data-ouia-safe="true"
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      aria-label="Conditional filter"
+                      class="pf-c-dropdown__toggle"
+                      data-ouia-component-id="ConditionalFilter"
+                      data-ouia-component-type="PF4/DropdownToggle"
+                      data-ouia-safe="true"
+                      id="pf-dropdown-toggle-id-2"
+                      type="button"
+                    >
+                      <span
+                        class="pf-c-dropdown__toggle-text"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                          />
+                        </svg>
+                        <span
+                          class="ins-c-conditional-filter__value-selector"
+                        >
+                          Task
+                        </span>
+                      </span>
+                      <span
+                        class="pf-c-dropdown__toggle-icon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                </div>
                 <div
                   class="pf-l-split__item pf-m-fill"
                 >
@@ -867,7 +991,7 @@ exports[`CompletedTasksTable should render correctly 1`] = `
                 data-ouia-component-id="Export"
                 data-ouia-component-type="PF4/DropdownToggle"
                 data-ouia-safe="true"
-                id="pf-dropdown-toggle-id-1"
+                id="pf-dropdown-toggle-id-3"
                 type="button"
               >
                 <span>
@@ -919,9 +1043,9 @@ exports[`CompletedTasksTable should render correctly 1`] = `
       </div>
     </div>
     <table
-      aria-label="completed-tasks-table"
+      aria-label="activity-table"
       class="pf-c-table pf-m-grid-md"
-      data-ouia-component-id="completed-tasks-table"
+      data-ouia-component-id="activity-table"
       data-ouia-component-type="PF4/Table"
       data-ouia-safe="true"
       role="grid"

--- a/src/SmartComponents/TasksPage/__tests__/TasksPage.tests.js
+++ b/src/SmartComponents/TasksPage/__tests__/TasksPage.tests.js
@@ -48,11 +48,11 @@ describe('TasksPage', () => {
       </MemoryRouter>
     );
 
-    await userEvent.click(screen.getByText('Completed tasks'));
+    await userEvent.click(screen.getByText('Activity'));
     await waitFor(() =>
-      expect(screen.getByLabelText('completed-tasks')).toBeInTheDocument()
+      expect(screen.getByLabelText('activity')).toBeInTheDocument()
     );
-    await userEvent.click(screen.getByText('Available tasks'));
+    await userEvent.click(screen.getByText('Available'));
     await waitFor(() =>
       expect(screen.getByLabelText('available-tasks')).toBeInTheDocument()
     );

--- a/src/SmartComponents/TasksPage/__tests__/__snapshots__/TasksPage.tests.js.snap
+++ b/src/SmartComponents/TasksPage/__tests__/__snapshots__/TasksPage.tests.js.snap
@@ -85,7 +85,7 @@ exports[`TasksPage should render correctly 1`] = `
           <span
             class="pf-c-tabs__item-text"
           >
-            Available tasks
+            Available
           </span>
         </button>
       </li>
@@ -102,7 +102,7 @@ exports[`TasksPage should render correctly 1`] = `
           <span
             class="pf-c-tabs__item-text"
           >
-            Completed tasks
+            Activity
           </span>
         </button>
       </li>

--- a/src/constants.js
+++ b/src/constants.js
@@ -26,13 +26,13 @@ const ACCESS_REDHAT_DOT_COM =
   'https://access.redhat.com/documentation/en-us/red_hat_insights/';
 const YEAR = `${today.getFullYear()}/html/`;
 
-export const TASKS_PAGE_TABS = ['Available tasks', 'Completed tasks'];
+export const TASKS_PAGE_TABS = ['Available', 'Activity'];
 export const TASKS_ERROR = [
   'Available tasks cannot be displayed at this time. Please retry and if the problem persists contact your system administrator.',
   '',
 ];
 export const COMPLETED_TASKS_ERROR = [
-  'Completed tasks connot be displayed at this time. Please return and if the problem persists contact your system administrator.',
+  'Activities connot be displayed at this time. Please return and if the problem persists contact your system administrator.',
   '',
 ];
 export const TASK_ERROR = [


### PR DESCRIPTION
Tabs have been renamed from 'Available tasks' and 'Completed tasks' to 'Available' and 'Activity'.

We have also added a status filter to the activity table. In a later PR I will rename all instance of Completed tasks to Activites.