### PR TITLE
[ADVISOR-2864] Fix deleted system in Run task again

### DIFF
--- a/src/SmartComponents/completedTaskDetailsHelpers.js
+++ b/src/SmartComponents/completedTaskDetailsHelpers.js
@@ -2,7 +2,14 @@ import { dispatchNotification } from '../Utilities/Dispatcher';
 import { fetchExecutedTask, fetchExecutedTaskJobs } from '../../api';
 
 export const getSelectedSystems = (completedTaskJobs) => {
-  return completedTaskJobs.map((job) => job.system);
+  let systemIds = [];
+  completedTaskJobs.forEach((job) => {
+    if (job.display_name) {
+      systemIds.push(job.system);
+    }
+  });
+
+  return systemIds;
 };
 
 export const isError = (result) => {


### PR DESCRIPTION
To repro:

- Find a completed task with a deleted system
- Click the Run task again button in the top right
- Click the Execute task button

Notice when you load the systems table, the count in the bulk select includes the deleted system, but the actual number of selected items is lower than that number.

When you click to execute the task, you will get an error because you submitted an id that no longer exists.

This PR fixes both of these issues.