### PR TITLE
Show job details with success and 0 inhibitors

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -36,7 +36,7 @@ import {
   getSelectedSystems,
   fetchTask,
   fetchTaskJobs,
-  hasAlert,
+  hasDetails,
 } from '../completedTaskDetailsHelpers';
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
@@ -190,7 +190,7 @@ const CompletedTaskDetails = () => {
                       ...TASKS_TABLE_DEFAULTS.exportable,
                       columns: exportableColumns,
                     },
-                    detailsComponent: hasAlert(completedTaskJobs)
+                    detailsComponent: hasDetails(completedTaskJobs)
                       ? JobResultsDetails
                       : null,
                   }}

--- a/src/SmartComponents/completedTaskDetailsHelpers.js
+++ b/src/SmartComponents/completedTaskDetailsHelpers.js
@@ -59,8 +59,8 @@ export const fetchTaskJobs = async (taskDetails, setError) => {
   }
 };
 
-export const hasAlert = (completedTaskJobs) => {
+export const hasDetails = (completedTaskJobs) => {
   return completedTaskJobs.some(
-    (job) => job.status === 'Success' && job.results.alert
+    (job) => job.status === 'Success' && job.results.report_json
   );
 };


### PR DESCRIPTION
Before, if a job completed successfully but had 0 inibitors out of n potential problems, the expandable row showing the problems for that job would not populate. This PR fixes that.