### PR TITLE
Fix system table load error

### DIFF
--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -24,7 +24,7 @@ const SystemTable = ({ bulkSelectIds, selectedIds, selectIds }) => {
 
   useEffect(() => {
     dispatch({
-      type: 'SELECT_ENTITY',
+      type: 'SELECT_ENTITIES',
       payload: {
         selected: selectedIds,
       },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -41,7 +41,7 @@ export const entitiesReducer = () =>
       page: 1,
       perPage: 10,
     }),
-    ['SELECT_ENTITY']: (state, { payload: { selected } }) => {
+    ['SELECT_ENTITIES']: (state, { payload: { selected } }) => {
       return {
         ...state,
         rows: selectRows(state.rows || [], selected),


### PR DESCRIPTION
To repro:

- Navigate to "Activity" tab
- refresh page
- click a kebab on a task and click "Run this task again"

The modal should open and then close. If you try again, the page will error out.

You can get the inventory table to load if you open the run task modal from the "Available" tab first, and then open via "Run this task again"