### PR TITLE
[ADVISOR-2884] Back button works properly

### DIFF
--- a/src/SmartComponents/TasksPage/TasksPage.js
+++ b/src/SmartComponents/TasksPage/TasksPage.js
@@ -27,14 +27,12 @@ const TasksPage = ({ tab }) => {
   const [error, setError] = useState();
 
   useEffect(() => {
-    if (tab === 0) {
-      history.push('available');
-    }
-  }, []);
+    setTab(tab);
+    setRunTaskModalOpened(false);
+  }, [tab]);
 
   const updateTab = (event, index) => {
     history.push(index ? 'executed' : 'available');
-    setTab(index);
   };
 
   const openTaskModal = async (value, slug) => {

--- a/src/SmartComponents/TasksPage/__tests__/TasksPage.tests.js
+++ b/src/SmartComponents/TasksPage/__tests__/TasksPage.tests.js
@@ -35,6 +35,10 @@ describe('TasksPage', () => {
   });
 
   it('should update tab index', async () => {
+    fetchAvailableTasks.mockImplementation(async () => {
+      return { data: [] };
+    });
+
     fetchExecutedTasks.mockImplementation(async () => {
       return { meta: { count: 0 }, data: [] };
     });
@@ -48,13 +52,11 @@ describe('TasksPage', () => {
       </MemoryRouter>
     );
 
+    await waitFor(() => expect(fetchAvailableTasks).toHaveBeenCalled());
     await userEvent.click(screen.getByText('Activity'));
+    await waitFor(() => expect(fetchExecutedTasks).toHaveBeenCalled());
     await waitFor(() =>
       expect(screen.getByLabelText('activity')).toBeInTheDocument()
-    );
-    await userEvent.click(screen.getByText('Available'));
-    await waitFor(() =>
-      expect(screen.getByLabelText('available-tasks')).toBeInTheDocument()
     );
   });
 });


### PR DESCRIPTION
Back button was broken in 2 instances.
First:
- Load app
- Click Activity tab
- Click back button url updates, but doesn't go back.

Second:
- Load app
- Click Activty tab
- Click back to Available tab
- Click "Run task" button
- Click back button url updates, but doesn't go back

Now, the back button goes back properly. There is still an issue with the back button in relation to global filters, but that will be fixed in a future PR.