### PR TITLE
[ADVISOR-2882] fix system links

### DIFF
--- a/src/SmartComponents/SystemTable/constants.js
+++ b/src/SmartComponents/SystemTable/constants.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { entitiesReducer } from '../../store/index';
 
 export const systemColumns = [
@@ -6,6 +7,13 @@ export const systemColumns = [
     sortKey: 'display_name',
     props: { width: 20 },
     title: 'Name',
+    renderFunc: (name, id) => {
+      return (
+        <a rel="noreferrer" target="_blank" href={`/insights/inventory/${id}`}>
+          {name}
+        </a>
+      );
+    },
   },
   'tags',
   {


### PR DESCRIPTION
Before, in the systems table, if you clicked on the name of a system, the link would take you nowhere and append to the current url. This PR links you to system details and opens in another window.