### PR TITLE
fix: Temp fix for 502 error on Activity Table

### DIFF
--- a/src/SmartComponents/ActivityTable/ActivityTable.js
+++ b/src/SmartComponents/ActivityTable/ActivityTable.js
@@ -62,7 +62,7 @@ const ActivityTable = () => {
   };
 
   const fetchData = async () => {
-    const path = `?limit=1000&offset=0`;
+    const path = `?limit=500&offset=0`;
     const result = await fetchExecutedTasks(path);
 
     setTasks(result);


### PR DESCRIPTION
This PR is a temporary fix for the 502 error you get from trying to access the Activity Tab on the tasks page. Now, the table properly loads data.