### PR TITLE
fix(ADVISOR-3118): remove async in useEffect calls

### DIFF
--- a/src/SmartComponents/ActivityTable/ActivityTable.js
+++ b/src/SmartComponents/ActivityTable/ActivityTable.js
@@ -104,13 +104,13 @@ const ActivityTable = () => {
     fetchData();
   }, []);
 
-  useEffect(async () => {
+  useEffect(() => {
     if (isDelete || isCancel) {
-      await refetchData();
+      refetchData();
       setIsDelete(false);
       setIsCancel(false);
     } else if (isRunTaskAgain) {
-      await refetchData();
+      refetchData();
       setIsRunTaskAgain(false);
     }
   }, [isCancel, isDelete, isRunTaskAgain]);

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -96,16 +96,14 @@ const CompletedTaskDetails = () => {
     setSelectedSystems(getSelectedSystems(completedTaskJobs));
   }, [completedTaskJobs]);
 
-  useEffect(async () => {
+  useEffect(() => {
     if (isDelete) {
       history.push('/executed');
       setIsDelete(false);
     }
 
     if (isCancel) {
-      await setCompletedTaskDetails(LOADING_INFO_PANEL);
-      await setCompletedTaskJobs(LOADING_JOBS_TABLE);
-      await fetchData();
+      fetchData();
       setIsCancel(false);
     }
   }, [isCancel, isDelete]);


### PR DESCRIPTION
ActivityTable and CompletedTaskDetails were failing because of async calls. This PR fixes those issues and those pages should work fine now.