### PR TITLE
fix(RHIF-200): Show empty state by default

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -95,7 +95,7 @@ const INVENTORY_TOTAL_FETCH_URL = '/api/inventory/v1/hosts';
  *      component - component to be rendered when a route has been chosen.
  */
 export const Routes = () => {
-  const [hasSystems, setHasSystems] = useState(true);
+  const [hasSystems, setHasSystems] = useState(false);
   useEffect(() => {
     try {
       axios


### PR DESCRIPTION
[Ticket](https://issues.redhat.com/browse/RHIF-200)

Just a small fix so this is consistent between apps
If the request fails, user will still see the empty state like in other apps