### PR TITLE
feat(HMS-1925):Add Centos preconversion support

### DIFF
--- a/src/PresentationalComponents/SplitMessages/SplitMessages.js
+++ b/src/PresentationalComponents/SplitMessages/SplitMessages.js
@@ -23,7 +23,8 @@ const SplitMessages = ({ alert, content }) => {
 
 SplitMessages.propTypes = {
   alert: propTypes.bool,
-  content: propTypes.string,
+  //content: propTypes.string,
+  content: propTypes.any,
 };
 
 export default SplitMessages;

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -24,7 +24,7 @@ const PermissionRouter = (route) => {
   };
 
   return (
-    <Route {...routeProps}>
+    <Route key={path} {...routeProps}>
       <WithPermission requiredPermissions={requiredPermissions}>
         <Component {...componentProps} />
       </WithPermission>

--- a/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
+++ b/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
@@ -49,7 +49,7 @@ const AvailableTasksTable = ({ availableTasks, error, openTaskModal }) => {
                         <a
                           href={`${TASKS_API_ROOT}${AVAILABLE_TASKS_ROOT}/${task.slug}/playbook`}
                         >
-                          Download preview of playbook
+                          Preview of a script to be executed on the host(s)
                         </a>
                       </FlexItem>
                       <FlexItem>

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -16,6 +16,7 @@ import {
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import columns, { exportableColumns } from './Columns';
 import { statusFilters, systemFilter } from './Filters';
+import {convert2rhel_task_jobs ,convert2rhel_task_details, upgrade_leapp_task} from '../CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures';
 import {
   COMPLETED_INFO_PANEL,
   COMPLETED_INFO_PANEL_FLEX_PROPS,
@@ -41,6 +42,7 @@ import {
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import JobResultsDetails from './JobResultsDetails/JobResultsDetails';
+
 
 const CompletedTaskDetails = () => {
   const { id } = useParams();

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import TasksTables from '../../Utilities/hooks/useTableTools/Components/TasksTables';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
@@ -16,7 +16,6 @@ import {
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import columns, { exportableColumns } from './Columns';
 import { statusFilters, systemFilter } from './Filters';
-import {convert2rhel_task_jobs ,convert2rhel_task_details, upgrade_leapp_task} from '../CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures';
 import {
   COMPLETED_INFO_PANEL,
   COMPLETED_INFO_PANEL_FLEX_PROPS,
@@ -42,7 +41,6 @@ import {
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import JobResultsDetails from './JobResultsDetails/JobResultsDetails';
-
 
 const CompletedTaskDetails = () => {
   const { id } = useParams();
@@ -74,10 +72,8 @@ const CompletedTaskDetails = () => {
       const fetchedTaskJobs = await fetchTaskJobs(fetchedTaskDetails, setError);
 
       if (fetchedTaskJobs.length) {
-        // await setCompletedTaskDetails(fetchedTaskDetails);
-        await setCompletedTaskDetails(convert2rhel_task_details)
-        await setCompletedTaskJobs(convert2rhel_task_jobs)
-        // await setCompletedTaskJobs(fetchedTaskJobs);
+        await setCompletedTaskDetails(fetchedTaskDetails);
+        await setCompletedTaskJobs(fetchedTaskJobs);
       }
     }
     setTableLoading(false);
@@ -91,19 +87,32 @@ const CompletedTaskDetails = () => {
     setSelectedSystems(getSelectedSystems(completedTaskJobs));
   }, [completedTaskJobs]);
 
-  useEffect(async () => {
+  useEffect(() => {
     if (isDelete) {
       history.push('/executed');
       setIsDelete(false);
     }
 
     if (isCancel) {
-      await setCompletedTaskDetails(LOADING_INFO_PANEL);
-      await setCompletedTaskJobs(LOADING_JOBS_TABLE);
-      await fetchData();
+      setCompletedTaskDetails(LOADING_INFO_PANEL);
+      setCompletedTaskJobs(LOADING_JOBS_TABLE);
+      fetchData();
       setIsCancel(false);
     }
   }, [isCancel, isDelete]);
+
+  const JobResultsRow = useMemo(
+    () =>
+      function Row(props) {
+        return (
+          <JobResultsDetails
+            taskSlug={completedTaskDetails.task_slug}
+            {...props}
+          />
+        );
+      },
+    [completedTaskJobs]
+  );
 
   return (
     <div>
@@ -199,7 +208,7 @@ const CompletedTaskDetails = () => {
                     detailsComponent: completedTaskJobs.some((job) =>
                       hasDetails(job)
                     )
-                      ? JobResultsDetails
+                      ? JobResultsRow
                       : undefined,
                   }}
                   emptyRows={emptyRows('jobs')}

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -74,8 +74,10 @@ const CompletedTaskDetails = () => {
       const fetchedTaskJobs = await fetchTaskJobs(fetchedTaskDetails, setError);
 
       if (fetchedTaskJobs.length) {
-        await setCompletedTaskDetails(fetchedTaskDetails);
-        await setCompletedTaskJobs(fetchedTaskJobs);
+        // await setCompletedTaskDetails(fetchedTaskDetails);
+        await setCompletedTaskDetails(convert2rhel_task_details)
+        await setCompletedTaskJobs(convert2rhel_task_jobs)
+        // await setCompletedTaskJobs(fetchedTaskJobs);
       }
     }
     setTableLoading(false);

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -1,46 +1,33 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { Grid, GridItem } from '@patternfly/react-core';
-import {
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  InfoCircleIcon,
-} from '@patternfly/react-icons';
 import EntryRowLabel from './EntryRowLabel';
-import {severity_map} from '../TaskEntries';
+import severityMap from '../TaskEntries';
 
-// const task_slug = "Leapp"
-const task_slug = "Convert2RHEL"
-
-const EntryDetails = ({ entry, mapping }) => {
-  const { detail, diagnosis, key, severity, summary, title } = entry;
-
-  console.log(severity, "severity_value")
-  console.log(severity_map["Convert2RHEL"][severity], "severity")
+const EntryDetails = ({ entry, taskConstantMapper }) => {
+  const { detail, key, severity, summary, title } = entry;
 
   const getLabelType = () => {
-          return (
-              <EntryRowLabel color={severity_map[task_slug][severity]["color"]} icon={severity_map[task_slug][severity]["icon"]} text={severity_map[task_slug][severity]["text"]}/>)
+    return (
+      <EntryRowLabel
+        color={
+          severityMap[taskConstantMapper][severity.toLowerCase()][
+            'severityColor'
+          ]
+        }
+        icon={severityMap[taskConstantMapper][severity.toLowerCase()]['icon']}
+        text={severityMap[taskConstantMapper][severity.toLowerCase()]['text']}
+      />
+    );
   };
 
   const renderDiagnosisDetails = () => {
-    return detail.diagnosis.map((diagnosis, index) => {
-      let diagnosisKey = `diagnosis-${index}`;
-      return (
-        <div key={diagnosisKey}>
-          {index > 0 ? (
-            <span>
-              <br />
-            </span>
-          ) : null}
-          <span style={{ fontFamily: 'overpass-mono' }}>
-            {diagnosis.context}
-          </span>
-        </div>
-      );
-    });
+    return (
+      <div>
+        <span>{detail.diagnosis.context}</span>
+      </div>
+    );
   };
-
 
   const renderRemediationsDetails = () => {
     return detail.remediations.map((remediation, index) => {
@@ -60,14 +47,20 @@ const EntryDetails = ({ entry, mapping }) => {
     });
   };
 
-
   const createGrid = (itemOneContent, itemTwoContent) => {
     return (
       <Grid hasGutter className="entry-detail-title">
         <GridItem span={2} className="entry-detail-content">
           {itemOneContent}
         </GridItem>
-        <GridItem xl2={5} xl={5} l={6} m={7} sm={8} style={{ whiteSpace: 'pre-line' }}>
+        <GridItem
+          xl2={5}
+          xl={5}
+          l={6}
+          m={7}
+          sm={8}
+          style={{ whiteSpace: 'pre-line' }}
+        >
           {typeof itemTwoContent === 'function'
             ? itemTwoContent()
             : itemTwoContent}
@@ -80,7 +73,7 @@ const EntryDetails = ({ entry, mapping }) => {
     return (
       <React.Fragment>
         {createGrid('Summary', summary)}
-        {detail?.diagnosis
+        {detail?.diagnosis?.context
           ? createGrid('Diagnosis', renderDiagnosisDetails)
           : null}
         {detail?.remediations
@@ -100,9 +93,9 @@ const EntryDetails = ({ entry, mapping }) => {
   );
 };
 
-
 EntryDetails.propTypes = {
   entry: propTypes.object,
+  taskConstantMapper: propTypes.string,
 };
 
 export default EntryDetails;

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -7,32 +7,71 @@ import {
   InfoCircleIcon,
 } from '@patternfly/react-icons';
 import EntryRowLabel from './EntryRowLabel';
+// import {LeappEntryDetails, Convert2RHELEntryDetails} from '../TaskEntries';
 
-const EntryDetails = ({ entry }) => {
+const task_slug = "Convert2RHEL"
+
+const EntryDetails = ({ entry, mapping }) => {
   const { detail, diagnosis, key, severity, summary, title } = entry;
 
+// we have severities that need to be used somehow and need to be mapped here
+  var severity_map = {
+      "Convert2RHEL": {
+          "high": {
+              "text": "Inhibitor",
+              "color": "red",
+              "icon": "<ExclamationCircleIcon/>"
+          },
+          "low": {
+              "text": "Warning",
+              "color": "orange",
+              "icon": "<ExclamationTriangleIcon/>"
+          },
+          "info": {
+              "text": "Info",
+              "color": "blue",
+              "icon": "<InfoCircleIcon/>"
+          },
+          "skip": {
+              "text": "Skipped",
+              "color": "red",
+              "icon": "<ExclamationCircleIcon/>"
+          },
+          "overridable": {
+              "text": "Overridable",
+              "color": "red",
+              "icon": "<ExclamationcCircleIcon/>"
+          }
+      },
+      "Leapp": {
+          "high": {
+              "text": "High risk",
+              "color": "red",
+              "icon": "<ExclamationCircleIcon/>"
+          },
+          "low": {
+              "text": "Low risk",
+              "color": "orange",
+              "icon": "<ExclamationTriangleIcon/>"
+          },
+          "info": {
+              "text": "Info",
+              "color": "blue",
+              "icon": "<InfoCircleIcon/>"
+          }
+      }
+  }
+
+  console.log(severity, "severity_value")
+  console.log(severity_map["Convert2RHEL"][severity], "severity")
+
   const getLabelType = () => {
-    if (severity === 'info') {
-      return (
-        <EntryRowLabel color="blue" icon={<InfoCircleIcon />} text="Info" />
-      );
-    } else if (severity === 'low') {
-      return (
-        <EntryRowLabel
-          color="orange"
-          icon={<ExclamationTriangleIcon />}
-          text="Warning"
-        />
-      );
-    } else if (severity === 'high') {
-      return (
-        <EntryRowLabel
-          color="red"
-          icon={<ExclamationCircleIcon />}
-          text="Error"
-        />
-      );
-    }
+
+
+          return (
+              <EntryRowLabel color={severity_map[task_slug][severity]["color"]} icon={severity_map[task_slug][severity]["icon"]} text={severity_map[task_slug][severity]["text"]}/>)
+
+
   };
 
   const renderDiagnosisDetails = () => {
@@ -111,6 +150,7 @@ const EntryDetails = ({ entry }) => {
     </React.Fragment>
   );
 };
+
 
 EntryDetails.propTypes = {
   entry: propTypes.object,

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -9,7 +9,7 @@ import {
 import EntryRowLabel from './EntryRowLabel';
 
 const EntryDetails = ({ entry }) => {
-  const { detail, key, severity, summary, title } = entry;
+  const { detail, diagnosis, key, severity, summary, title } = entry;
 
   const getLabelType = () => {
     if (severity === 'info') {
@@ -21,7 +21,7 @@ const EntryDetails = ({ entry }) => {
         <EntryRowLabel
           color="orange"
           icon={<ExclamationTriangleIcon />}
-          text="Low risk"
+          text="Warning"
         />
       );
     } else if (severity === 'high') {
@@ -29,11 +29,30 @@ const EntryDetails = ({ entry }) => {
         <EntryRowLabel
           color="red"
           icon={<ExclamationCircleIcon />}
-          text="High risk"
+          text="Error"
         />
       );
     }
   };
+
+  const renderDiagnosisDetails = () => {
+    return detail.diagnosis.map((diagnosis, index) => {
+      let diagnosisKey = `diagnosis-${index}`;
+      return (
+        <div key={diagnosisKey}>
+          {index > 0 ? (
+            <span>
+              <br />
+            </span>
+          ) : null}
+          <span style={{ fontFamily: 'overpass-mono' }}>
+            {diagnosis.context}
+          </span>
+        </div>
+      );
+    });
+  };
+
 
   const renderRemediationsDetails = () => {
     return detail.remediations.map((remediation, index) => {
@@ -53,13 +72,14 @@ const EntryDetails = ({ entry }) => {
     });
   };
 
+
   const createGrid = (itemOneContent, itemTwoContent) => {
     return (
       <Grid hasGutter className="entry-detail-title">
         <GridItem span={2} className="entry-detail-content">
           {itemOneContent}
         </GridItem>
-        <GridItem xl2={5} xl={5} l={6} m={7} sm={8}>
+        <GridItem xl2={5} xl={5} l={6} m={7} sm={8} style={{ whiteSpace: 'pre-line' }}>
           {typeof itemTwoContent === 'function'
             ? itemTwoContent()
             : itemTwoContent}
@@ -72,6 +92,9 @@ const EntryDetails = ({ entry }) => {
     return (
       <React.Fragment>
         {createGrid('Summary', summary)}
+        {detail?.diagnosis
+          ? createGrid('Diagnosis', renderDiagnosisDetails)
+          : null}
         {detail?.remediations
           ? createGrid('Remediation', renderRemediationsDetails)
           : null}

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -7,61 +7,13 @@ import {
   InfoCircleIcon,
 } from '@patternfly/react-icons';
 import EntryRowLabel from './EntryRowLabel';
-// import {LeappEntryDetails, Convert2RHELEntryDetails} from '../TaskEntries';
+import {severity_map} from '../TaskEntries';
 
 // const task_slug = "Leapp"
 const task_slug = "Convert2RHEL"
 
 const EntryDetails = ({ entry, mapping }) => {
   const { detail, diagnosis, key, severity, summary, title } = entry;
-
-// we have severities that need to be used somehow and need to be mapped here
-  const severity_map = {
-      "Convert2RHEL": {
-          "Error": {
-              "text": "Inhibitor",
-              "color": "red",
-              "icon": <ExclamationCircleIcon/>
-          },
-          "Warning": {
-              "text": "Warning",
-              "color": "orange",
-              "icon": <ExclamationTriangleIcon/>
-          },
-          "Info": {
-              "text": "Info",
-              "color": "blue",
-              "icon": <InfoCircleIcon/>
-          },
-          "skip": {
-              "text": "Skipped",
-              "color": "red",
-              "icon": <ExclamationCircleIcon/>
-          },
-          "overridable": {
-              "text": "Overridable",
-              "color": "red",
-              "icon": <ExclamationCircleIcon/>
-          }
-      },
-      "Leapp": {
-          "high": {
-              "text": "High risk",
-              "color": "red",
-              "icon": <ExclamationCircleIcon/>
-          },
-          "low": {
-              "text": "Low risk",
-              "color": "orange",
-              "icon": <ExclamationTriangleIcon/>
-          },
-          "info": {
-              "text": "Info",
-              "color": "blue",
-              "icon": <InfoCircleIcon/>
-          }
-      }
-  }
 
   console.log(severity, "severity_value")
   console.log(severity_map["Convert2RHEL"][severity], "severity")

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -9,7 +9,8 @@ import {
 import EntryRowLabel from './EntryRowLabel';
 // import {LeappEntryDetails, Convert2RHELEntryDetails} from '../TaskEntries';
 
-const task_slug = "Leapp"
+// const task_slug = "Leapp"
+const task_slug = "Convert2RHEL"
 
 const EntryDetails = ({ entry, mapping }) => {
   const { detail, diagnosis, key, severity, summary, title } = entry;
@@ -17,17 +18,17 @@ const EntryDetails = ({ entry, mapping }) => {
 // we have severities that need to be used somehow and need to be mapped here
   const severity_map = {
       "Convert2RHEL": {
-          "high": {
+          "Error": {
               "text": "Inhibitor",
               "color": "red",
               "icon": <ExclamationCircleIcon/>
           },
-          "low": {
+          "Warning": {
               "text": "Warning",
               "color": "orange",
               "icon": <ExclamationTriangleIcon/>
           },
-          "info": {
+          "Info": {
               "text": "Info",
               "color": "blue",
               "icon": <InfoCircleIcon/>

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -9,55 +9,55 @@ import {
 import EntryRowLabel from './EntryRowLabel';
 // import {LeappEntryDetails, Convert2RHELEntryDetails} from '../TaskEntries';
 
-const task_slug = "Convert2RHEL"
+const task_slug = "Leapp"
 
 const EntryDetails = ({ entry, mapping }) => {
   const { detail, diagnosis, key, severity, summary, title } = entry;
 
 // we have severities that need to be used somehow and need to be mapped here
-  var severity_map = {
+  const severity_map = {
       "Convert2RHEL": {
           "high": {
               "text": "Inhibitor",
               "color": "red",
-              "icon": "<ExclamationCircleIcon/>"
+              "icon": <ExclamationCircleIcon/>
           },
           "low": {
               "text": "Warning",
               "color": "orange",
-              "icon": "<ExclamationTriangleIcon/>"
+              "icon": <ExclamationTriangleIcon/>
           },
           "info": {
               "text": "Info",
               "color": "blue",
-              "icon": "<InfoCircleIcon/>"
+              "icon": <InfoCircleIcon/>
           },
           "skip": {
               "text": "Skipped",
               "color": "red",
-              "icon": "<ExclamationCircleIcon/>"
+              "icon": <ExclamationCircleIcon/>
           },
           "overridable": {
               "text": "Overridable",
               "color": "red",
-              "icon": "<ExclamationcCircleIcon/>"
+              "icon": <ExclamationCircleIcon/>
           }
       },
       "Leapp": {
           "high": {
               "text": "High risk",
               "color": "red",
-              "icon": "<ExclamationCircleIcon/>"
+              "icon": <ExclamationCircleIcon/>
           },
           "low": {
               "text": "Low risk",
               "color": "orange",
-              "icon": "<ExclamationTriangleIcon/>"
+              "icon": <ExclamationTriangleIcon/>
           },
           "info": {
               "text": "Info",
               "color": "blue",
-              "icon": "<InfoCircleIcon/>"
+              "icon": <InfoCircleIcon/>
           }
       }
   }
@@ -66,12 +66,8 @@ const EntryDetails = ({ entry, mapping }) => {
   console.log(severity_map["Convert2RHEL"][severity], "severity")
 
   const getLabelType = () => {
-
-
           return (
               <EntryRowLabel color={severity_map[task_slug][severity]["color"]} icon={severity_map[task_slug][severity]["icon"]} text={severity_map[task_slug][severity]["text"]}/>)
-
-
   };
 
   const renderDiagnosisDetails = () => {

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
@@ -8,41 +8,42 @@ import {
 
 const EntryRow = ({ severity, title }) => {
   const renderIcon = () => {
-    if (severity === 'info') {
+    if (severity === 'Info') {
       return (
         <span style={{ marginRight: '8px' }}>
           <InfoCircleIcon color="#2B9AF3" />
         </span>
       );
-    } else if (severity === 'low') {
+    } else if (severity === 'Warning') {
       return (
         <span style={{ marginRight: '8px' }}>
           <ExclamationTriangleIcon color="#F0AB00" />
         </span>
       );
-    } else if (severity === 'high') {
+    } else if (severity === 'Error') {
       return (
         <span style={{ marginRight: '8px' }}>
           <ExclamationCircleIcon color="#C9190B" />
+
         </span>
       );
     }
   };
 
   const renderTitle = () => {
-    if (severity === 'info') {
+    if (severity === 'Info') {
       return (
         <span style={{ color: '#002952' }}>
           <strong>{title}</strong>
         </span>
       );
-    } else if (severity === 'low') {
+    } else if (severity === 'Warning') {
       return (
         <span style={{ color: '#795000' }}>
           <strong>{title}</strong>
         </span>
       );
-    } else if (severity === 'high') {
+    } else if (severity === 'Error') {
       return (
         <span style={{ color: '#A30000' }}>
           <strong>{title}</strong>

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
@@ -1,55 +1,25 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import {
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  InfoCircleIcon,
-} from '@patternfly/react-icons';
+import {severity_map} from '../TaskEntries';
 
+// const task_slug = "Leapp"
+const task_slug = "Convert2RHEL"
 const EntryRow = ({ severity, title }) => {
+  console.log(title, "title")
   const renderIcon = () => {
-    if (severity === 'Info') {
-      return (
-        <span style={{ marginRight: '8px' }}>
-          <InfoCircleIcon color="#2B9AF3" />
-        </span>
-      );
-    } else if (severity === 'Warning') {
-      return (
-        <span style={{ marginRight: '8px' }}>
-          <ExclamationTriangleIcon color="#F0AB00" />
-        </span>
-      );
-    } else if (severity === 'Error') {
-      return (
-        <span style={{ marginRight: '8px' }}>
-          <ExclamationCircleIcon color="#C9190B" />
-
-        </span>
-      );
-    }
+    return (
+      <span style={{ marginRight: '8px' }}>
+        {severity_map[task_slug][severity]["icon"]}
+      </span>
+    );
   };
 
   const renderTitle = () => {
-    if (severity === 'Info') {
       return (
-        <span style={{ color: '#002952' }}>
+        <span style={{color: severity_map[task_slug][severity]["color"]}}>
           <strong>{title}</strong>
         </span>
       );
-    } else if (severity === 'Warning') {
-      return (
-        <span style={{ color: '#795000' }}>
-          <strong>{title}</strong>
-        </span>
-      );
-    } else if (severity === 'Error') {
-      return (
-        <span style={{ color: '#A30000' }}>
-          <strong>{title}</strong>
-        </span>
-      );
-    }
   };
 
   return (
@@ -64,5 +34,6 @@ EntryRow.propTypes = {
   severity: propTypes.string,
   title: propTypes.string,
 };
+
 
 export default EntryRow;

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
@@ -1,25 +1,29 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import {severity_map} from '../TaskEntries';
+import severityMap from '../TaskEntries';
 
-// const task_slug = "Leapp"
-const task_slug = "Convert2RHEL"
-const EntryRow = ({ severity, title }) => {
-  console.log(title, "title")
+const EntryRow = ({ severity, taskConstantMapper, title }) => {
   const renderIcon = () => {
     return (
       <span style={{ marginRight: '8px' }}>
-        {severity_map[task_slug][severity]["icon"]}
+        {severityMap[taskConstantMapper][severity.toLowerCase()]['icon']}
       </span>
     );
   };
 
   const renderTitle = () => {
-      return (
-        <span style={{color: severity_map[task_slug][severity]["color"]}}>
-          <strong>{title}</strong>
-        </span>
-      );
+    return (
+      <span
+        style={{
+          color:
+            severityMap[taskConstantMapper][severity.toLowerCase()][
+              'titleColor'
+            ],
+        }}
+      >
+        <strong>{title}</strong>
+      </span>
+    );
   };
 
   return (
@@ -32,8 +36,8 @@ const EntryRow = ({ severity, title }) => {
 
 EntryRow.propTypes = {
   severity: propTypes.string,
+  taskConstantMapper: propTypes.string,
   title: propTypes.string,
 };
-
 
 export default EntryRow;

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobResultsDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobResultsDetails.js
@@ -3,8 +3,8 @@ import propTypes from 'prop-types';
 import { TableComposable, Tbody, Tr, Td } from '@patternfly/react-table';
 import { buildResultsRows } from './jobResultsDetailsHelpers';
 
-const JobResultsDetails = ({ item }) => {
-  const rowPairs = buildResultsRows(item.results.report_json.entries);
+const JobResultsDetails = ({ taskSlug, item }) => {
+  const rowPairs = buildResultsRows(item.results.report_json.entries, taskSlug);
   let rowIndex = 0;
 
   const [expanded, setExpanded] = useState(
@@ -80,6 +80,7 @@ const JobResultsDetails = ({ item }) => {
 
 JobResultsDetails.propTypes = {
   item: propTypes.object,
+  taskSlug: propTypes.string,
 };
 
 export default JobResultsDetails;

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/jobResultsDetailsHelpers.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/jobResultsDetailsHelpers.js
@@ -5,15 +5,15 @@ import EntryDetails from './EntryDetails';
 const sortBySeverity = (entries) => {
   let sortedEntries = entries.sort((a, b) => {
     if (
-      (a.severity === 'high' && b.severity !== 'high') ||
-      (a.severity === 'low' && b.severity === 'info')
+      (a.severity === 'Error' && b.severity !== 'Error') ||
+      (a.severity === 'Warning' && b.severity === 'Info')
     ) {
       return -1;
     }
 
     if (
-      (b.severity === 'high' && a.severity !== 'high') ||
-      (b.severity === 'low' && a.severity === 'info')
+      (b.severity === 'Error' && a.severity !== 'Error') ||
+      (b.severity === 'Warning' && a.severity === 'Info')
     ) {
       return 1;
     }

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/jobResultsDetailsHelpers.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/jobResultsDetailsHelpers.js
@@ -1,20 +1,19 @@
 import React from 'react';
 import EntryRow from './EntryRow';
 import EntryDetails from './EntryDetails';
+import severityMap from '../TaskEntries';
 
-const sortBySeverity = (entries) => {
+const sortBySeverity = (entries, taskConstantMapper) => {
   let sortedEntries = entries.sort((a, b) => {
-    if (
-      (a.severity === 'Error' && b.severity !== 'Error') ||
-      (a.severity === 'Warning' && b.severity === 'Info')
-    ) {
+    let aSeverity =
+      severityMap[taskConstantMapper][a.severity.toLowerCase()].severityLevel;
+    let bSeverity =
+      severityMap[taskConstantMapper][b.severity.toLowerCase()].severityLevel;
+    if (aSeverity > bSeverity) {
       return -1;
     }
 
-    if (
-      (b.severity === 'Error' && a.severity !== 'Error') ||
-      (b.severity === 'Warning' && a.severity === 'Info')
-    ) {
+    if (bSeverity > aSeverity) {
       return 1;
     }
 
@@ -24,14 +23,32 @@ const sortBySeverity = (entries) => {
   return sortedEntries;
 };
 
-export const buildResultsRows = (entries) => {
+export const buildResultsRows = (entries, taskSlug) => {
+  let taskConstantMapper = taskSlug.toLowerCase().replace(/-/g, '');
   let rows = [];
-  let sortedEntries = sortBySeverity(entries);
+  let sortedEntries = sortBySeverity(
+    entries,
+    `${taskConstantMapper}SeverityMap`
+  );
   sortedEntries.forEach((entry) => {
-    rows.push({
-      parent: <EntryRow severity={entry.severity} title={entry.title} />,
-      child: <EntryDetails entry={entry} />,
-    });
+    // this line to be removed
+    if (entry.severity.toLowerCase() !== 'success') {
+      rows.push({
+        parent: (
+          <EntryRow
+            severity={entry.severity}
+            title={entry.title}
+            taskConstantMapper={`${taskConstantMapper}SeverityMap`}
+          />
+        ),
+        child: (
+          <EntryDetails
+            entry={entry}
+            taskConstantMapper={`${taskConstantMapper}SeverityMap`}
+          />
+        ),
+      });
+    }
   });
 
   return rows;

--- a/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
+++ b/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
@@ -1,0 +1,58 @@
+import {ExclamationCircleIcon, ExclamationTriangleIcon, InfoCircleIcon} from "@patternfly/react-icons";
+import React from 'react';
+
+
+export const severity_map = {
+      "Convert2RHEL": {
+          "Error": {
+              "text": "Inhibitor",
+              "color": "red",
+              "icon": <ExclamationCircleIcon color='red'/>,
+              "level": 3000
+          },
+          "Overridable": {
+              "text": "Overridable",
+              "color": "red",
+              "icon": <ExclamationCircleIcon color='red'/>,
+              "level": 2500
+          },
+          "Skip": {
+              "text": "Skipped",
+              "color": "red",
+              "icon": <ExclamationCircleIcon color='red'/>,
+              "level": 2000
+          },
+          "Warning": {
+              "text": "Warning",
+              "color": "orange",
+              "icon": <ExclamationTriangleIcon color='orange'/>,
+              "level": 1500
+          },
+          "Info": {
+              "text": "Info",
+              "color": "blue",
+              "icon": <InfoCircleIcon color='blue'/>,
+              "level": 1000
+          },
+      },
+      "Leapp": {
+          "high": {
+              "text": "High risk",
+              "color": "red",
+              "icon": <ExclamationCircleIcon/>,
+              "level": 3000
+          },
+          "low": {
+              "text": "Low risk",
+              "color": "orange",
+              "icon": <ExclamationTriangleIcon/>,
+              "level": 1500
+          },
+          "info": {
+              "text": "Info",
+              "color": "blue",
+              "icon": <InfoCircleIcon/>,
+              "level": 1000
+          }
+      }
+  }

--- a/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
+++ b/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
@@ -1,58 +1,127 @@
-import {ExclamationCircleIcon, ExclamationTriangleIcon, InfoCircleIcon} from "@patternfly/react-icons";
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon,
+  CheckCircleIcon,
+} from '@patternfly/react-icons';
 import React from 'react';
 
+const converttorhelpreanalysisSeverityMap = {
+  error: {
+    text: 'Inhibitor',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2500,
+  },
+  overridable: {
+    text: 'Overridable',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2000,
+  },
+  skip: {
+    text: 'Skipped',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 1500,
+  },
+  warning: {
+    text: 'Warning',
+    icon: <ExclamationTriangleIcon color="#F0AB00" />,
+    titleColor: '#795000',
+    severityColor: 'orange',
+    severityLevel: 1000,
+  },
+  info: {
+    text: 'Info',
+    icon: <InfoCircleIcon color="#2B9AF3" />,
+    titleColor: '#002952',
+    severityColor: 'blue',
+    severityLevel: 500,
+  },
+  success: {
+    text: 'Success',
+    icon: <CheckCircleIcon color="green" />,
+    titleColor: 'green',
+    severityColor: 'green',
+    severityLevel: 0,
+  },
+};
 
-export const severity_map = {
-      "Convert2RHEL": {
-          "Error": {
-              "text": "Inhibitor",
-              "color": "red",
-              "icon": <ExclamationCircleIcon color='red'/>,
-              "level": 3000
-          },
-          "Overridable": {
-              "text": "Overridable",
-              "color": "red",
-              "icon": <ExclamationCircleIcon color='red'/>,
-              "level": 2500
-          },
-          "Skip": {
-              "text": "Skipped",
-              "color": "red",
-              "icon": <ExclamationCircleIcon color='red'/>,
-              "level": 2000
-          },
-          "Warning": {
-              "text": "Warning",
-              "color": "orange",
-              "icon": <ExclamationTriangleIcon color='orange'/>,
-              "level": 1500
-          },
-          "Info": {
-              "text": "Info",
-              "color": "blue",
-              "icon": <InfoCircleIcon color='blue'/>,
-              "level": 1000
-          },
-      },
-      "Leapp": {
-          "high": {
-              "text": "High risk",
-              "color": "red",
-              "icon": <ExclamationCircleIcon/>,
-              "level": 3000
-          },
-          "low": {
-              "text": "Low risk",
-              "color": "orange",
-              "icon": <ExclamationTriangleIcon/>,
-              "level": 1500
-          },
-          "info": {
-              "text": "Info",
-              "color": "blue",
-              "icon": <InfoCircleIcon/>,
-              "level": 1000
-          }
-      }
-  }
+const converttorhelpreanalysisstageSeverityMap = {
+  error: {
+    text: 'Inhibitor',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2500,
+  },
+  overridable: {
+    text: 'Overridable',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2000,
+  },
+  skip: {
+    text: 'Skipped',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 1500,
+  },
+  warning: {
+    text: 'Warning',
+    icon: <ExclamationTriangleIcon color="#F0AB00" />,
+    titleColor: '#795000',
+    severityColor: 'orange',
+    severityLevel: 1000,
+  },
+  info: {
+    text: 'Info',
+    icon: <InfoCircleIcon color="#2B9AF3" />,
+    titleColor: '#002952',
+    severityColor: 'blue',
+    severityLevel: 500,
+  },
+  success: {
+    text: 'Success',
+    icon: <CheckCircleIcon color="green" />,
+    titleColor: 'green',
+    severityColor: 'green',
+    severityLevel: 0,
+  },
+};
+
+const leapppreupgradeSeverityMap = {
+  high: {
+    text: 'High risk',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 1500,
+  },
+  low: {
+    text: 'Low risk',
+    icon: <ExclamationTriangleIcon color="#F0AB00" />,
+    titleColor: '#795000',
+    severityColor: 'orange',
+    severityLevel: 1000,
+  },
+  info: {
+    text: 'Info',
+    icon: <InfoCircleIcon color="#2B9AF3" />,
+    titleColor: '#002952',
+    severityColor: 'blue',
+    severityLevel: 500,
+  },
+};
+
+export default {
+  converttorhelpreanalysisSeverityMap,
+  converttorhelpreanalysisstageSeverityMap,
+  leapppreupgradeSeverityMap,
+};

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
@@ -59,14 +59,13 @@ export const upgrade_leapp_task = {
   systems_count: 5,
 };
 
-
 export const convert2rhel_task_details = {
   id: 2909,
   alerts_count: 3,
-  task_slug: 'convert2rhel-preconversion',
+  task_slug: 'convert-to-rhel-preanalysis',
   task_title: 'Convert to RHEL Preanalysis',
   task_description:
-      'For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.',
+    'For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.',
   start_time: '2023-06-01T19:58:51.330433Z',
   end_time: '2023-07-16T20:30:24.772008Z',
   initiated_by: 'insights-qa',
@@ -74,7 +73,6 @@ export const convert2rhel_task_details = {
   system_count: 2,
   systems_count: 2,
 };
-
 
 export const leapp_task_jobs = [
   {
@@ -350,7 +348,8 @@ export const convert2rhel_task_jobs = [
     system: 'f1356a99-754d-4219-9g25-fccb2cc6e2f2',
     status: 'Success',
     results: {
-      message: 'No inhibtors found, conversion will run smoothly for this system.',
+      message:
+        'No inhibtors found, conversion should run smoothly for this system.',
     },
     updated_on: '2022-08-08T18:19:50.898540Z',
     display_name: 'centos7-test-device-1',
@@ -360,47 +359,35 @@ export const convert2rhel_task_jobs = [
     system: 'f1356a99-754d-4219-9g25-fccb2cc53bee',
     status: 'Success',
     results: {
-
-      alert: true,
+      alert: false,
       report: '',
-      message: 'Your system has 2 inhibitors out of 3 potential problems.',
+      message: 'Your system has 3 inhibitors out of 3 potential problems.',
       report_json: {
         entries: [
-          {
-            id: 'SECURE_BOOT_DETECTED',
-            key: 'DBUS_IS_RUNNING::SECURE_BOOT_DETECTED',
-            tags: [],
-            actor: 'DBUS_IS_RUNNING',
-            title: 'Dbus is running check skip',
-            summary:
-              'Skipping the check because we have been asked not to subscribe this system to RHSM',
-            audience: 'sysadmin',
-            hostname: 'dan-laptop',
-            severity: 'Warning',
-            timeStamp: '2022-10-12T17:16:44.065672Z',
-          },
           {
             id: 'INVALID_KERNEL_VERSION',
             key: 'IS_LOADED_KERNEL_LATEST::INVALID_KERNEL_VERSION',
             tags: [],
             actor: 'IS_LOADED_KERNEL_LATEST',
-            title: 'The version of the loaded kernel is different from the latest version',
-
+            title:
+              'The version of the loaded kernel is different from the latest version',
             detail: {
               diagnosis: [
                 {
-                  context: 'Latest kernel version available in updates: 3.10.0-1160.90.1.el7\n Loaded kernel version: 3.10.0-1160.88.1.el7',
+                  context:
+                    'Latest kernel version available in updates: 3.10.0-1160.90.1.el7\n Loaded kernel version: 3.10.0-1160.88.1.el7',
                 },
               ],
               remediations: [
                 {
                   type: 'hint',
                   context:
-                    "To proceed with the conversion, update the kernel version by executing the following steps:\n\n1. yum install kernel-3.10.0-1160.90.1.el7 -y\n2. reboot",
+                    'To proceed with the conversion, update the kernel version by executing the following steps:\n\n1. yum install kernel-3.10.0-1160.90.1.el7 -y\n2. reboot',
                 },
               ],
             },
-            summary: 'The version of the loaded kernel is different from the latest version in the enabled system repositories.',
+            summary:
+              'The version of the loaded kernel is different from the latest version in the enabled system repositories.',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
             severity: 'Error',
@@ -416,7 +403,8 @@ export const convert2rhel_task_jobs = [
             detail: {
               diagnosis: [
                 {
-                  context: 'In order to continue the conversion, secure boot must be disabled',
+                  context:
+                    'In order to continue the conversion, secure boot must be disabled',
                 },
               ],
               remediations: [
@@ -427,23 +415,40 @@ export const convert2rhel_task_jobs = [
                 },
               ],
             },
-            summary: 'The conversion with secure boot is currently not possible.',
+            summary:
+              'The conversion with secure boot is currently not possible.',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
             severity: 'Error',
             timeStamp: '2022-10-12T17:16:47.104093Z',
           },
           {
-            id: 'REPOSITORY_FILE_PACKAGES_REMOVED',
-            key: 'REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED',
+            id: 'PACKAGE_UP_TO_DATE_CHECK_FAIL',
+            key: 'PACKAGE_UPDATES::PACKAGE_UP_TO_DATE_CHECK_FAIL',
             tags: [],
-            actor: 'REMOVE_REPOSITORY_FILES_PACKAGES',
-            flags: [],
-            title: 'Repository file package removal',
-            summary: 'The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3',
+            actor: 'PACKAGE_UPDATES',
+            flags: ['inhibitor'],
+            title: 'Package up to date check fail',
+            detail: {
+              diagnosis: [
+                {
+                  context:
+                    'There was an error while checking whether the installed packages are up-to-date. Having an updated system is an important prerequisite for a successful conversion.',
+                },
+              ],
+              remediations: [
+                {
+                  type: 'hint',
+                  context:
+                    'Consider verifyng the system is up to date manually before proceeding with the conversion.',
+                },
+              ],
+            },
+            summary:
+              'The conversion with secure boot is currently not possible.',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
-            severity: 'Info',
+            severity: 'Overridable',
             timeStamp: '2022-10-12T17:16:47.104093Z',
           },
         ],
@@ -456,25 +461,46 @@ export const convert2rhel_task_jobs = [
   {
     executed_task: 2909,
     system: 'f1356a99-754d-4219-9g25-fccb2cc6e2f2',
-    status: 'Failure',
+    status: 'Success',
     results: {
-      message: 'There was an error during script execution, the checks could not be run',
+      message:
+        'No inhibtors found, conversion should run smoothly for this system.',
+      report_json: {
+        entries: [
+          {
+            id: 'REPOSITORY_FILE_PACKAGES_REMOVED',
+            key: 'REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED',
+            tags: [],
+            actor: 'REMOVE_REPOSITORY_FILES_PACKAGES',
+            flags: [],
+            title: 'Repository file package removal',
+            summary:
+              'The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'Info',
+            timeStamp: '2022-10-12T17:16:47.104093Z',
+          },
+          {
+            id: 'SECURE_BOOT_DETECTED',
+            key: 'DBUS_IS_RUNNING::SECURE_BOOT_DETECTED',
+            tags: [],
+            actor: 'DBUS_IS_RUNNING',
+            title: 'Dbus is running check skip',
+            summary:
+              'Skipping the check because we have been asked not to subscribe this system to RHSM',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'Warning',
+            timeStamp: '2022-10-12T17:16:44.065672Z',
+          },
+        ],
+      },
     },
     updated_on: '2022-08-08T18:19:50.898540Z',
-    display_name: 'centos7-test-device-1',
+    display_name: 'centos7-test-device-3',
   },
 ];
-
-
-export const convert2rhel_task_main_page = [
-    {
-      slug: "foo",
-      title: "Preconversion analysis utility",
-      description: "For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.",
-      publish_date: "2022-10-05T00:00:00Z"
-    },
-  ];
-
 
 export const running_task = {
   id: 217,

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
@@ -376,7 +376,7 @@ export const convert2rhel_task_jobs = [
               'Skipping the check because we have been asked not to subscribe this system to RHSM',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
-            severity: 'low',
+            severity: 'Warning',
             timeStamp: '2022-10-12T17:16:44.065672Z',
           },
           {
@@ -403,7 +403,7 @@ export const convert2rhel_task_jobs = [
             summary: 'The version of the loaded kernel is different from the latest version in the enabled system repositories.',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
-            severity: 'high',
+            severity: 'Error',
             timeStamp: '2022-10-12T17:16:44.255785Z',
           },
           {
@@ -430,7 +430,7 @@ export const convert2rhel_task_jobs = [
             summary: 'The conversion with secure boot is currently not possible.',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
-            severity: 'high',
+            severity: 'Error',
             timeStamp: '2022-10-12T17:16:47.104093Z',
           },
           {
@@ -443,7 +443,7 @@ export const convert2rhel_task_jobs = [
             summary: 'The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
-            severity: 'info',
+            severity: 'Info',
             timeStamp: '2022-10-12T17:16:47.104093Z',
           },
         ],

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
@@ -59,6 +59,23 @@ export const upgrade_leapp_task = {
   systems_count: 5,
 };
 
+
+export const convert2rhel_task_details = {
+  id: 2909,
+  alerts_count: 3,
+  task_slug: 'convert2rhel-preconversion',
+  task_title: 'Convert to RHEL Preanalysis',
+  task_description:
+      'For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.',
+  start_time: '2023-06-01T19:58:51.330433Z',
+  end_time: '2023-07-16T20:30:24.772008Z',
+  initiated_by: 'insights-qa',
+  status: 'Running',
+  system_count: 2,
+  systems_count: 2,
+};
+
+
 export const leapp_task_jobs = [
   {
     executed_task: 235,
@@ -326,6 +343,138 @@ export const leapp_task_jobs = [
     display_name: 'dl-test-device-4',
   },
 ];
+
+export const convert2rhel_task_jobs = [
+  {
+    executed_task: 2909,
+    system: 'f1356a99-754d-4219-9g25-fccb2cc6e2f2',
+    status: 'Success',
+    results: {
+      message: 'No inhibtors found, conversion will run smoothly for this system.',
+    },
+    updated_on: '2022-08-08T18:19:50.898540Z',
+    display_name: 'centos7-test-device-1',
+  },
+  {
+    executed_task: 2909,
+    system: 'f1356a99-754d-4219-9g25-fccb2cc53bee',
+    status: 'Success',
+    results: {
+
+      alert: true,
+      report: '',
+      message: 'Your system has 2 inhibitors out of 3 potential problems.',
+      report_json: {
+        entries: [
+          {
+            id: 'SECURE_BOOT_DETECTED',
+            key: 'DBUS_IS_RUNNING::SECURE_BOOT_DETECTED',
+            tags: [],
+            actor: 'DBUS_IS_RUNNING',
+            title: 'Dbus is running check skip',
+            summary:
+              'Skipping the check because we have been asked not to subscribe this system to RHSM',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'low',
+            timeStamp: '2022-10-12T17:16:44.065672Z',
+          },
+          {
+            id: 'INVALID_KERNEL_VERSION',
+            key: 'IS_LOADED_KERNEL_LATEST::INVALID_KERNEL_VERSION',
+            tags: [],
+            actor: 'IS_LOADED_KERNEL_LATEST',
+            title: 'The version of the loaded kernel is different from the latest version',
+
+            detail: {
+              diagnosis: [
+                {
+                  context: 'Latest kernel version available in updates: 3.10.0-1160.90.1.el7\n Loaded kernel version: 3.10.0-1160.88.1.el7',
+                },
+              ],
+              remediations: [
+                {
+                  type: 'hint',
+                  context:
+                    "To proceed with the conversion, update the kernel version by executing the following steps:\n\n1. yum install kernel-3.10.0-1160.90.1.el7 -y\n2. reboot",
+                },
+              ],
+            },
+            summary: 'The version of the loaded kernel is different from the latest version in the enabled system repositories.',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'high',
+            timeStamp: '2022-10-12T17:16:44.255785Z',
+          },
+          {
+            id: 'SECURE_BOOT_DETECTED',
+            key: 'EFI::SECURE_BOOT_DETECTED',
+            tags: [],
+            actor: 'EFI',
+            flags: ['inhibitor'],
+            title: 'Secure boot detected',
+            detail: {
+              diagnosis: [
+                {
+                  context: 'In order to continue the conversion, secure boot must be disabled',
+                },
+              ],
+              remediations: [
+                {
+                  type: 'hint',
+                  context:
+                    'To disable the secure boot, follow the instructions available in this article: https://access.redhat.com/solutions/6753681',
+                },
+              ],
+            },
+            summary: 'The conversion with secure boot is currently not possible.',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'high',
+            timeStamp: '2022-10-12T17:16:47.104093Z',
+          },
+          {
+            id: 'REPOSITORY_FILE_PACKAGES_REMOVED',
+            key: 'REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED',
+            tags: [],
+            actor: 'REMOVE_REPOSITORY_FILES_PACKAGES',
+            flags: [],
+            title: 'Repository file package removal',
+            summary: 'The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'info',
+            timeStamp: '2022-10-12T17:16:47.104093Z',
+          },
+        ],
+        leapp_run_id: 'e7d38746-cfe4-4ec3-8ad5-4e6a16790cf4',
+      },
+    },
+    updated_on: '2022-08-08T18:19:50.898540Z',
+    display_name: 'centos7-test-device-2',
+  },
+  {
+    executed_task: 2909,
+    system: 'f1356a99-754d-4219-9g25-fccb2cc6e2f2',
+    status: 'Failure',
+    results: {
+      message: 'There was an error during script execution, the checks could not be run',
+    },
+    updated_on: '2022-08-08T18:19:50.898540Z',
+    display_name: 'centos7-test-device-1',
+  },
+];
+
+
+export const convert2rhel_task_main_page = [
+    {
+      slug: "foo",
+      title: "Preconversion analysis utility",
+      description: "For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.",
+      publish_date: "2022-10-05T00:00:00Z"
+    },
+  ];
+
 
 export const running_task = {
   id: 217,

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -2074,7 +2074,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#C9190B"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -2108,6 +2108,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
                               </div>
@@ -2124,6 +2125,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -2146,6 +2148,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 ca7a1a66906a7df3da890aa538562708d3ea6ecd
                               </div>
@@ -2250,7 +2253,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#C9190B"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -2284,6 +2287,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 Firewalld has enabled configuration option "AllowZoneDrifiting" which has been removed in RHEL-9. New behavior is as if "AllowZoneDrifiting" was set to "no".
                               </div>
@@ -2300,6 +2304,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -2332,6 +2337,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 5b1cf050e1a877b0358b6e8c612277c591d40c13
                               </div>
@@ -2436,7 +2442,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#C9190B"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -2470,6 +2476,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 VDO devices 'vda, vda1, vda2' require migration to LVM management.After performing the upgrade VDO devices can only be managed via LVM. Any VDO device not currently managed by LVM must be converted to LVM management before upgrading. The data on any VDO device not converted to LVM management will be inaccessible after upgrading.
                               </div>
@@ -2486,6 +2493,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -2508,6 +2516,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 f7c335398cc449f5d7baf4e73255d44c34ad2620
                               </div>
@@ -2612,7 +2621,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#F0AB00"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -2646,6 +2655,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
                               </div>
@@ -2662,6 +2672,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -2684,6 +2695,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
                               </div>
@@ -2788,7 +2800,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#2B9AF3"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -2822,6 +2834,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 SElinux relabeling will be scheduled as the status is permissive/enforcing.
                               </div>
@@ -2838,6 +2851,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                               </div>
@@ -3244,7 +3258,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#C9190B"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -3278,6 +3292,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
                               </div>
@@ -3294,6 +3309,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -3316,6 +3332,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 ca7a1a66906a7df3da890aa538562708d3ea6ecd
                               </div>
@@ -3420,7 +3437,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#F0AB00"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -3454,6 +3471,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
                               </div>
@@ -3470,6 +3488,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -3492,6 +3511,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
                               </div>
@@ -3596,7 +3616,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#F0AB00"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -3630,6 +3650,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 After the upgrade has completed the release of the subscription-manager will be set to 9.0. This will ensure that you will receive and keep the version you choose to upgrade to.
                               </div>
@@ -3646,6 +3667,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -3668,6 +3690,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 747a4ca25303eda17d1891bb85eeb226be14f252
                               </div>
@@ -3772,7 +3795,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#2B9AF3"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -3806,6 +3829,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 SElinux relabeling will be scheduled as the status is permissive/enforcing.
                               </div>
@@ -3822,6 +3846,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                               </div>


### PR DESCRIPTION
This PR mainly makes some components more generic so different types of tasks can display on the same component. We've done this by creating constants that define how each unique task defines its statuses and other data, and then we map the executed task to the constant via the task_slug and pull in the constant.