### PR TITLE
feat(HMS-1925):Add Centos preconversion support

### DIFF
--- a/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
+++ b/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
@@ -49,7 +49,7 @@ const AvailableTasksTable = ({ availableTasks, error, openTaskModal }) => {
                         <a
                           href={`${TASKS_API_ROOT}${AVAILABLE_TASKS_ROOT}/${task.slug}/playbook`}
                         >
-                          Preview of a script to be executed on the host(s)
+                          Download preview of playbook
                         </a>
                       </FlexItem>
                       <FlexItem>

--- a/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
+++ b/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
@@ -49,7 +49,7 @@ const AvailableTasksTable = ({ availableTasks, error, openTaskModal }) => {
                         <a
                           href={`${TASKS_API_ROOT}${AVAILABLE_TASKS_ROOT}/${task.slug}/playbook`}
                         >
-                          Download preview of playbook
+                          Preview of a script to be executed on the host(s)
                         </a>
                       </FlexItem>
                       <FlexItem>

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import TasksTables from '../../Utilities/hooks/useTableTools/Components/TasksTables';
 import {
@@ -15,7 +15,6 @@ import {
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import columns, { exportableColumns } from './Columns';
 import { statusFilters, systemFilter } from './Filters';
-import {convert2rhel_task_jobs ,convert2rhel_task_details, upgrade_leapp_task} from '../CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures';
 import {
   COMPLETED_INFO_PANEL,
   COMPLETED_INFO_PANEL_FLEX_PROPS,
@@ -43,7 +42,6 @@ import { usePermissions } from '@redhat-cloud-services/frontend-components-utili
 import JobResultsDetails from './JobResultsDetails/JobResultsDetails';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
-
 
 const CompletedTaskDetails = () => {
   const { id } = useParams();
@@ -76,10 +74,8 @@ const CompletedTaskDetails = () => {
       const fetchedTaskJobs = await fetchTaskJobs(fetchedTaskDetails, setError);
 
       if (fetchedTaskJobs.length) {
-        // await setCompletedTaskDetails(fetchedTaskDetails);
-        await setCompletedTaskDetails(convert2rhel_task_details)
-        await setCompletedTaskJobs(convert2rhel_task_jobs)
-        // await setCompletedTaskJobs(fetchedTaskJobs);
+        await setCompletedTaskDetails(fetchedTaskDetails);
+        await setCompletedTaskJobs(fetchedTaskJobs);
       }
     }
     setTableLoading(false);
@@ -111,6 +107,19 @@ const CompletedTaskDetails = () => {
       setIsCancel(false);
     }
   }, [isCancel, isDelete]);
+
+  const JobResultsRow = useMemo(
+    () =>
+      function Row(props) {
+        return (
+          <JobResultsDetails
+            taskSlug={completedTaskDetails.task_slug}
+            {...props}
+          />
+        );
+      },
+    [completedTaskJobs]
+  );
 
   return (
     <div>
@@ -206,7 +215,7 @@ const CompletedTaskDetails = () => {
                     detailsComponent: completedTaskJobs.some((job) =>
                       hasDetails(job)
                     )
-                      ? JobResultsDetails
+                      ? JobResultsRow
                       : undefined,
                   }}
                   emptyRows={emptyRows('jobs')}

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -76,8 +76,10 @@ const CompletedTaskDetails = () => {
       const fetchedTaskJobs = await fetchTaskJobs(fetchedTaskDetails, setError);
 
       if (fetchedTaskJobs.length) {
-        await setCompletedTaskDetails(fetchedTaskDetails);
-        await setCompletedTaskJobs(fetchedTaskJobs);
+        // await setCompletedTaskDetails(fetchedTaskDetails);
+        await setCompletedTaskDetails(convert2rhel_task_details)
+        await setCompletedTaskJobs(convert2rhel_task_jobs)
+        // await setCompletedTaskJobs(fetchedTaskJobs);
       }
     }
     setTableLoading(false);

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -15,6 +15,7 @@ import {
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import columns, { exportableColumns } from './Columns';
 import { statusFilters, systemFilter } from './Filters';
+import {convert2rhel_task_jobs ,convert2rhel_task_details, upgrade_leapp_task} from '../CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures';
 import {
   COMPLETED_INFO_PANEL,
   COMPLETED_INFO_PANEL_FLEX_PROPS,
@@ -42,6 +43,7 @@ import { usePermissions } from '@redhat-cloud-services/frontend-components-utili
 import JobResultsDetails from './JobResultsDetails/JobResultsDetails';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+
 
 const CompletedTaskDetails = () => {
   const { id } = useParams();

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -1,46 +1,33 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { Grid, GridItem } from '@patternfly/react-core';
-import {
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  InfoCircleIcon,
-} from '@patternfly/react-icons';
 import EntryRowLabel from './EntryRowLabel';
-import {severity_map} from '../TaskEntries';
+import severityMap from '../TaskEntries';
 
-// const task_slug = "Leapp"
-const task_slug = "Convert2RHEL"
-
-const EntryDetails = ({ entry, mapping }) => {
-  const { detail, diagnosis, key, severity, summary, title } = entry;
-
-  console.log(severity, "severity_value")
-  console.log(severity_map["Convert2RHEL"][severity], "severity")
+const EntryDetails = ({ entry, taskConstantMapper }) => {
+  const { detail, key, severity, summary, title } = entry;
 
   const getLabelType = () => {
-          return (
-              <EntryRowLabel color={severity_map[task_slug][severity]["color"]} icon={severity_map[task_slug][severity]["icon"]} text={severity_map[task_slug][severity]["text"]}/>)
+    return (
+      <EntryRowLabel
+        color={
+          severityMap[taskConstantMapper][severity.toLowerCase()][
+            'severityColor'
+          ]
+        }
+        icon={severityMap[taskConstantMapper][severity.toLowerCase()]['icon']}
+        text={severityMap[taskConstantMapper][severity.toLowerCase()]['text']}
+      />
+    );
   };
 
   const renderDiagnosisDetails = () => {
-    return detail.diagnosis.map((diagnosis, index) => {
-      let diagnosisKey = `diagnosis-${index}`;
-      return (
-        <div key={diagnosisKey}>
-          {index > 0 ? (
-            <span>
-              <br />
-            </span>
-          ) : null}
-          <span style={{ fontFamily: 'overpass-mono' }}>
-            {diagnosis.context}
-          </span>
-        </div>
-      );
-    });
+    return (
+      <div>
+        <span>{detail.diagnosis.context}</span>
+      </div>
+    );
   };
-
 
   const renderRemediationsDetails = () => {
     return detail.remediations.map((remediation, index) => {
@@ -60,14 +47,20 @@ const EntryDetails = ({ entry, mapping }) => {
     });
   };
 
-
   const createGrid = (itemOneContent, itemTwoContent) => {
     return (
       <Grid hasGutter className="entry-detail-title">
         <GridItem span={2} className="entry-detail-content">
           {itemOneContent}
         </GridItem>
-        <GridItem xl2={5} xl={5} l={6} m={7} sm={8} style={{ whiteSpace: 'pre-line' }}>
+        <GridItem
+          xl2={5}
+          xl={5}
+          l={6}
+          m={7}
+          sm={8}
+          style={{ whiteSpace: 'pre-line' }}
+        >
           {typeof itemTwoContent === 'function'
             ? itemTwoContent()
             : itemTwoContent}
@@ -80,7 +73,7 @@ const EntryDetails = ({ entry, mapping }) => {
     return (
       <React.Fragment>
         {createGrid('Summary', summary)}
-        {detail?.diagnosis
+        {detail?.diagnosis?.context
           ? createGrid('Diagnosis', renderDiagnosisDetails)
           : null}
         {detail?.remediations
@@ -100,9 +93,9 @@ const EntryDetails = ({ entry, mapping }) => {
   );
 };
 
-
 EntryDetails.propTypes = {
   entry: propTypes.object,
+  taskConstantMapper: propTypes.string,
 };
 
 export default EntryDetails;

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -7,32 +7,71 @@ import {
   InfoCircleIcon,
 } from '@patternfly/react-icons';
 import EntryRowLabel from './EntryRowLabel';
+// import {LeappEntryDetails, Convert2RHELEntryDetails} from '../TaskEntries';
 
-const EntryDetails = ({ entry }) => {
+const task_slug = "Convert2RHEL"
+
+const EntryDetails = ({ entry, mapping }) => {
   const { detail, diagnosis, key, severity, summary, title } = entry;
 
+// we have severities that need to be used somehow and need to be mapped here
+  var severity_map = {
+      "Convert2RHEL": {
+          "high": {
+              "text": "Inhibitor",
+              "color": "red",
+              "icon": "<ExclamationCircleIcon/>"
+          },
+          "low": {
+              "text": "Warning",
+              "color": "orange",
+              "icon": "<ExclamationTriangleIcon/>"
+          },
+          "info": {
+              "text": "Info",
+              "color": "blue",
+              "icon": "<InfoCircleIcon/>"
+          },
+          "skip": {
+              "text": "Skipped",
+              "color": "red",
+              "icon": "<ExclamationCircleIcon/>"
+          },
+          "overridable": {
+              "text": "Overridable",
+              "color": "red",
+              "icon": "<ExclamationcCircleIcon/>"
+          }
+      },
+      "Leapp": {
+          "high": {
+              "text": "High risk",
+              "color": "red",
+              "icon": "<ExclamationCircleIcon/>"
+          },
+          "low": {
+              "text": "Low risk",
+              "color": "orange",
+              "icon": "<ExclamationTriangleIcon/>"
+          },
+          "info": {
+              "text": "Info",
+              "color": "blue",
+              "icon": "<InfoCircleIcon/>"
+          }
+      }
+  }
+
+  console.log(severity, "severity_value")
+  console.log(severity_map["Convert2RHEL"][severity], "severity")
+
   const getLabelType = () => {
-    if (severity === 'info') {
-      return (
-        <EntryRowLabel color="blue" icon={<InfoCircleIcon />} text="Info" />
-      );
-    } else if (severity === 'low') {
-      return (
-        <EntryRowLabel
-          color="orange"
-          icon={<ExclamationTriangleIcon />}
-          text="Warning"
-        />
-      );
-    } else if (severity === 'high') {
-      return (
-        <EntryRowLabel
-          color="red"
-          icon={<ExclamationCircleIcon />}
-          text="Error"
-        />
-      );
-    }
+
+
+          return (
+              <EntryRowLabel color={severity_map[task_slug][severity]["color"]} icon={severity_map[task_slug][severity]["icon"]} text={severity_map[task_slug][severity]["text"]}/>)
+
+
   };
 
   const renderDiagnosisDetails = () => {
@@ -111,6 +150,7 @@ const EntryDetails = ({ entry }) => {
     </React.Fragment>
   );
 };
+
 
 EntryDetails.propTypes = {
   entry: propTypes.object,

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -9,7 +9,7 @@ import {
 import EntryRowLabel from './EntryRowLabel';
 
 const EntryDetails = ({ entry }) => {
-  const { detail, key, severity, summary, title } = entry;
+  const { detail, diagnosis, key, severity, summary, title } = entry;
 
   const getLabelType = () => {
     if (severity === 'info') {
@@ -21,7 +21,7 @@ const EntryDetails = ({ entry }) => {
         <EntryRowLabel
           color="orange"
           icon={<ExclamationTriangleIcon />}
-          text="Low risk"
+          text="Warning"
         />
       );
     } else if (severity === 'high') {
@@ -29,11 +29,30 @@ const EntryDetails = ({ entry }) => {
         <EntryRowLabel
           color="red"
           icon={<ExclamationCircleIcon />}
-          text="High risk"
+          text="Error"
         />
       );
     }
   };
+
+  const renderDiagnosisDetails = () => {
+    return detail.diagnosis.map((diagnosis, index) => {
+      let diagnosisKey = `diagnosis-${index}`;
+      return (
+        <div key={diagnosisKey}>
+          {index > 0 ? (
+            <span>
+              <br />
+            </span>
+          ) : null}
+          <span style={{ fontFamily: 'overpass-mono' }}>
+            {diagnosis.context}
+          </span>
+        </div>
+      );
+    });
+  };
+
 
   const renderRemediationsDetails = () => {
     return detail.remediations.map((remediation, index) => {
@@ -53,13 +72,14 @@ const EntryDetails = ({ entry }) => {
     });
   };
 
+
   const createGrid = (itemOneContent, itemTwoContent) => {
     return (
       <Grid hasGutter className="entry-detail-title">
         <GridItem span={2} className="entry-detail-content">
           {itemOneContent}
         </GridItem>
-        <GridItem xl2={5} xl={5} l={6} m={7} sm={8}>
+        <GridItem xl2={5} xl={5} l={6} m={7} sm={8} style={{ whiteSpace: 'pre-line' }}>
           {typeof itemTwoContent === 'function'
             ? itemTwoContent()
             : itemTwoContent}
@@ -72,6 +92,9 @@ const EntryDetails = ({ entry }) => {
     return (
       <React.Fragment>
         {createGrid('Summary', summary)}
+        {detail?.diagnosis
+          ? createGrid('Diagnosis', renderDiagnosisDetails)
+          : null}
         {detail?.remediations
           ? createGrid('Remediation', renderRemediationsDetails)
           : null}

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -7,61 +7,13 @@ import {
   InfoCircleIcon,
 } from '@patternfly/react-icons';
 import EntryRowLabel from './EntryRowLabel';
-// import {LeappEntryDetails, Convert2RHELEntryDetails} from '../TaskEntries';
+import {severity_map} from '../TaskEntries';
 
 // const task_slug = "Leapp"
 const task_slug = "Convert2RHEL"
 
 const EntryDetails = ({ entry, mapping }) => {
   const { detail, diagnosis, key, severity, summary, title } = entry;
-
-// we have severities that need to be used somehow and need to be mapped here
-  const severity_map = {
-      "Convert2RHEL": {
-          "Error": {
-              "text": "Inhibitor",
-              "color": "red",
-              "icon": <ExclamationCircleIcon/>
-          },
-          "Warning": {
-              "text": "Warning",
-              "color": "orange",
-              "icon": <ExclamationTriangleIcon/>
-          },
-          "Info": {
-              "text": "Info",
-              "color": "blue",
-              "icon": <InfoCircleIcon/>
-          },
-          "skip": {
-              "text": "Skipped",
-              "color": "red",
-              "icon": <ExclamationCircleIcon/>
-          },
-          "overridable": {
-              "text": "Overridable",
-              "color": "red",
-              "icon": <ExclamationCircleIcon/>
-          }
-      },
-      "Leapp": {
-          "high": {
-              "text": "High risk",
-              "color": "red",
-              "icon": <ExclamationCircleIcon/>
-          },
-          "low": {
-              "text": "Low risk",
-              "color": "orange",
-              "icon": <ExclamationTriangleIcon/>
-          },
-          "info": {
-              "text": "Info",
-              "color": "blue",
-              "icon": <InfoCircleIcon/>
-          }
-      }
-  }
 
   console.log(severity, "severity_value")
   console.log(severity_map["Convert2RHEL"][severity], "severity")

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -9,7 +9,8 @@ import {
 import EntryRowLabel from './EntryRowLabel';
 // import {LeappEntryDetails, Convert2RHELEntryDetails} from '../TaskEntries';
 
-const task_slug = "Leapp"
+// const task_slug = "Leapp"
+const task_slug = "Convert2RHEL"
 
 const EntryDetails = ({ entry, mapping }) => {
   const { detail, diagnosis, key, severity, summary, title } = entry;
@@ -17,17 +18,17 @@ const EntryDetails = ({ entry, mapping }) => {
 // we have severities that need to be used somehow and need to be mapped here
   const severity_map = {
       "Convert2RHEL": {
-          "high": {
+          "Error": {
               "text": "Inhibitor",
               "color": "red",
               "icon": <ExclamationCircleIcon/>
           },
-          "low": {
+          "Warning": {
               "text": "Warning",
               "color": "orange",
               "icon": <ExclamationTriangleIcon/>
           },
-          "info": {
+          "Info": {
               "text": "Info",
               "color": "blue",
               "icon": <InfoCircleIcon/>

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -9,55 +9,55 @@ import {
 import EntryRowLabel from './EntryRowLabel';
 // import {LeappEntryDetails, Convert2RHELEntryDetails} from '../TaskEntries';
 
-const task_slug = "Convert2RHEL"
+const task_slug = "Leapp"
 
 const EntryDetails = ({ entry, mapping }) => {
   const { detail, diagnosis, key, severity, summary, title } = entry;
 
 // we have severities that need to be used somehow and need to be mapped here
-  var severity_map = {
+  const severity_map = {
       "Convert2RHEL": {
           "high": {
               "text": "Inhibitor",
               "color": "red",
-              "icon": "<ExclamationCircleIcon/>"
+              "icon": <ExclamationCircleIcon/>
           },
           "low": {
               "text": "Warning",
               "color": "orange",
-              "icon": "<ExclamationTriangleIcon/>"
+              "icon": <ExclamationTriangleIcon/>
           },
           "info": {
               "text": "Info",
               "color": "blue",
-              "icon": "<InfoCircleIcon/>"
+              "icon": <InfoCircleIcon/>
           },
           "skip": {
               "text": "Skipped",
               "color": "red",
-              "icon": "<ExclamationCircleIcon/>"
+              "icon": <ExclamationCircleIcon/>
           },
           "overridable": {
               "text": "Overridable",
               "color": "red",
-              "icon": "<ExclamationcCircleIcon/>"
+              "icon": <ExclamationCircleIcon/>
           }
       },
       "Leapp": {
           "high": {
               "text": "High risk",
               "color": "red",
-              "icon": "<ExclamationCircleIcon/>"
+              "icon": <ExclamationCircleIcon/>
           },
           "low": {
               "text": "Low risk",
               "color": "orange",
-              "icon": "<ExclamationTriangleIcon/>"
+              "icon": <ExclamationTriangleIcon/>
           },
           "info": {
               "text": "Info",
               "color": "blue",
-              "icon": "<InfoCircleIcon/>"
+              "icon": <InfoCircleIcon/>
           }
       }
   }
@@ -66,12 +66,8 @@ const EntryDetails = ({ entry, mapping }) => {
   console.log(severity_map["Convert2RHEL"][severity], "severity")
 
   const getLabelType = () => {
-
-
           return (
               <EntryRowLabel color={severity_map[task_slug][severity]["color"]} icon={severity_map[task_slug][severity]["icon"]} text={severity_map[task_slug][severity]["text"]}/>)
-
-
   };
 
   const renderDiagnosisDetails = () => {

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
@@ -8,41 +8,42 @@ import {
 
 const EntryRow = ({ severity, title }) => {
   const renderIcon = () => {
-    if (severity === 'info') {
+    if (severity === 'Info') {
       return (
         <span style={{ marginRight: '8px' }}>
           <InfoCircleIcon color="#2B9AF3" />
         </span>
       );
-    } else if (severity === 'low') {
+    } else if (severity === 'Warning') {
       return (
         <span style={{ marginRight: '8px' }}>
           <ExclamationTriangleIcon color="#F0AB00" />
         </span>
       );
-    } else if (severity === 'high') {
+    } else if (severity === 'Error') {
       return (
         <span style={{ marginRight: '8px' }}>
           <ExclamationCircleIcon color="#C9190B" />
+
         </span>
       );
     }
   };
 
   const renderTitle = () => {
-    if (severity === 'info') {
+    if (severity === 'Info') {
       return (
         <span style={{ color: '#002952' }}>
           <strong>{title}</strong>
         </span>
       );
-    } else if (severity === 'low') {
+    } else if (severity === 'Warning') {
       return (
         <span style={{ color: '#795000' }}>
           <strong>{title}</strong>
         </span>
       );
-    } else if (severity === 'high') {
+    } else if (severity === 'Error') {
       return (
         <span style={{ color: '#A30000' }}>
           <strong>{title}</strong>

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
@@ -1,55 +1,25 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import {
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  InfoCircleIcon,
-} from '@patternfly/react-icons';
+import {severity_map} from '../TaskEntries';
 
+// const task_slug = "Leapp"
+const task_slug = "Convert2RHEL"
 const EntryRow = ({ severity, title }) => {
+  console.log(title, "title")
   const renderIcon = () => {
-    if (severity === 'Info') {
-      return (
-        <span style={{ marginRight: '8px' }}>
-          <InfoCircleIcon color="#2B9AF3" />
-        </span>
-      );
-    } else if (severity === 'Warning') {
-      return (
-        <span style={{ marginRight: '8px' }}>
-          <ExclamationTriangleIcon color="#F0AB00" />
-        </span>
-      );
-    } else if (severity === 'Error') {
-      return (
-        <span style={{ marginRight: '8px' }}>
-          <ExclamationCircleIcon color="#C9190B" />
-
-        </span>
-      );
-    }
+    return (
+      <span style={{ marginRight: '8px' }}>
+        {severity_map[task_slug][severity]["icon"]}
+      </span>
+    );
   };
 
   const renderTitle = () => {
-    if (severity === 'Info') {
       return (
-        <span style={{ color: '#002952' }}>
+        <span style={{color: severity_map[task_slug][severity]["color"]}}>
           <strong>{title}</strong>
         </span>
       );
-    } else if (severity === 'Warning') {
-      return (
-        <span style={{ color: '#795000' }}>
-          <strong>{title}</strong>
-        </span>
-      );
-    } else if (severity === 'Error') {
-      return (
-        <span style={{ color: '#A30000' }}>
-          <strong>{title}</strong>
-        </span>
-      );
-    }
   };
 
   return (
@@ -64,5 +34,6 @@ EntryRow.propTypes = {
   severity: propTypes.string,
   title: propTypes.string,
 };
+
 
 export default EntryRow;

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryRow.js
@@ -1,25 +1,29 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import {severity_map} from '../TaskEntries';
+import severityMap from '../TaskEntries';
 
-// const task_slug = "Leapp"
-const task_slug = "Convert2RHEL"
-const EntryRow = ({ severity, title }) => {
-  console.log(title, "title")
+const EntryRow = ({ severity, taskConstantMapper, title }) => {
   const renderIcon = () => {
     return (
       <span style={{ marginRight: '8px' }}>
-        {severity_map[task_slug][severity]["icon"]}
+        {severityMap[taskConstantMapper][severity.toLowerCase()]['icon']}
       </span>
     );
   };
 
   const renderTitle = () => {
-      return (
-        <span style={{color: severity_map[task_slug][severity]["color"]}}>
-          <strong>{title}</strong>
-        </span>
-      );
+    return (
+      <span
+        style={{
+          color:
+            severityMap[taskConstantMapper][severity.toLowerCase()][
+              'titleColor'
+            ],
+        }}
+      >
+        <strong>{title}</strong>
+      </span>
+    );
   };
 
   return (
@@ -32,8 +36,8 @@ const EntryRow = ({ severity, title }) => {
 
 EntryRow.propTypes = {
   severity: propTypes.string,
+  taskConstantMapper: propTypes.string,
   title: propTypes.string,
 };
-
 
 export default EntryRow;

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobResultsDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobResultsDetails.js
@@ -4,12 +4,12 @@ import { TableComposable, Tbody } from '@patternfly/react-table';
 import { buildResultsRows } from './jobResultsDetailsHelpers';
 import ExpandedIssues from './ExpandedIssues';
 
-const JobResultsDetails = ({ item }) => {
+const JobResultsDetails = ({ taskSlug, item }) => {
   const isReportJson = item.results.report_json ? true : false;
 
   const rowPairs = item.results.report_json
-    ? buildResultsRows(item.results.report_json.entries, isReportJson)
-    : buildResultsRows([item.results.report], isReportJson);
+    ? buildResultsRows(item.results.report_json.entries, isReportJson, taskSlug)
+    : buildResultsRows([item.results.report], isReportJson, taskSlug);
 
   return (
     <div>
@@ -30,6 +30,7 @@ const JobResultsDetails = ({ item }) => {
 
 JobResultsDetails.propTypes = {
   item: propTypes.object,
+  taskSlug: propTypes.string,
 };
 
 export default JobResultsDetails;

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/jobResultsDetailsHelpers.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/jobResultsDetailsHelpers.js
@@ -5,15 +5,15 @@ import EntryDetails from './EntryDetails';
 const sortBySeverity = (entries) => {
   let sortedEntries = entries.sort((a, b) => {
     if (
-      (a.severity === 'high' && b.severity !== 'high') ||
-      (a.severity === 'low' && b.severity === 'info')
+      (a.severity === 'Error' && b.severity !== 'Error') ||
+      (a.severity === 'Warning' && b.severity === 'Info')
     ) {
       return -1;
     }
 
     if (
-      (b.severity === 'high' && a.severity !== 'high') ||
-      (b.severity === 'low' && a.severity === 'info')
+      (b.severity === 'Error' && a.severity !== 'Error') ||
+      (b.severity === 'Warning' && a.severity === 'Info')
     ) {
       return 1;
     }

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/jobResultsDetailsHelpers.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/jobResultsDetailsHelpers.js
@@ -1,20 +1,19 @@
 import React from 'react';
 import EntryRow from './EntryRow';
 import EntryDetails from './EntryDetails';
+import severityMap from '../TaskEntries';
 
-const sortBySeverity = (entries) => {
+const sortBySeverity = (entries, taskConstantMapper) => {
   let sortedEntries = entries.sort((a, b) => {
-    if (
-      (a.severity === 'Error' && b.severity !== 'Error') ||
-      (a.severity === 'Warning' && b.severity === 'Info')
-    ) {
+    let aSeverity =
+      severityMap[taskConstantMapper][a.severity.toLowerCase()].severityLevel;
+    let bSeverity =
+      severityMap[taskConstantMapper][b.severity.toLowerCase()].severityLevel;
+    if (aSeverity > bSeverity) {
       return -1;
     }
 
-    if (
-      (b.severity === 'Error' && a.severity !== 'Error') ||
-      (b.severity === 'Warning' && a.severity === 'Info')
-    ) {
+    if (bSeverity > aSeverity) {
       return 1;
     }
 
@@ -24,15 +23,29 @@ const sortBySeverity = (entries) => {
   return sortedEntries;
 };
 
-export const buildResultsRows = (entries, isReportJson) => {
+export const buildResultsRows = (entries, isReportJson, taskSlug) => {
+  let taskConstantMapper = taskSlug.toLowerCase().replace(/-/g, '');
   let rows = [];
   let sortedEntries;
   if (isReportJson) {
-    sortedEntries = sortBySeverity(entries);
-    rows = sortedEntries.map((entry) => ({
-      parent: <EntryRow severity={entry.severity} title={entry.title} />,
-      child: <EntryDetails entry={entry} />,
-    }));
+    sortedEntries = sortBySeverity(entries, `${taskConstantMapper}SeverityMap`);
+    sortedEntries.forEach((entry) => {
+      rows.push({
+        parent: (
+          <EntryRow
+            severity={entry.severity}
+            title={entry.title}
+            taskConstantMapper={`${taskConstantMapper}SeverityMap`}
+          />
+        ),
+        child: (
+          <EntryDetails
+            entry={entry}
+            taskConstantMapper={`${taskConstantMapper}SeverityMap`}
+          />
+        ),
+      });
+    });
   } else {
     sortedEntries = entries;
     rows = sortedEntries[0];

--- a/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
+++ b/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
@@ -1,0 +1,58 @@
+import {ExclamationCircleIcon, ExclamationTriangleIcon, InfoCircleIcon} from "@patternfly/react-icons";
+import React from 'react';
+
+
+export const severity_map = {
+      "Convert2RHEL": {
+          "Error": {
+              "text": "Inhibitor",
+              "color": "red",
+              "icon": <ExclamationCircleIcon color='red'/>,
+              "level": 3000
+          },
+          "Overridable": {
+              "text": "Overridable",
+              "color": "red",
+              "icon": <ExclamationCircleIcon color='red'/>,
+              "level": 2500
+          },
+          "Skip": {
+              "text": "Skipped",
+              "color": "red",
+              "icon": <ExclamationCircleIcon color='red'/>,
+              "level": 2000
+          },
+          "Warning": {
+              "text": "Warning",
+              "color": "orange",
+              "icon": <ExclamationTriangleIcon color='orange'/>,
+              "level": 1500
+          },
+          "Info": {
+              "text": "Info",
+              "color": "blue",
+              "icon": <InfoCircleIcon color='blue'/>,
+              "level": 1000
+          },
+      },
+      "Leapp": {
+          "high": {
+              "text": "High risk",
+              "color": "red",
+              "icon": <ExclamationCircleIcon/>,
+              "level": 3000
+          },
+          "low": {
+              "text": "Low risk",
+              "color": "orange",
+              "icon": <ExclamationTriangleIcon/>,
+              "level": 1500
+          },
+          "info": {
+              "text": "Info",
+              "color": "blue",
+              "icon": <InfoCircleIcon/>,
+              "level": 1000
+          }
+      }
+  }

--- a/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
+++ b/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
@@ -1,58 +1,113 @@
-import {ExclamationCircleIcon, ExclamationTriangleIcon, InfoCircleIcon} from "@patternfly/react-icons";
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon,
+} from '@patternfly/react-icons';
 import React from 'react';
 
+const converttorhelpreanalysisSeverityMap = {
+  error: {
+    text: 'Inhibitor',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2500,
+  },
+  overridable: {
+    text: 'Overridable',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2000,
+  },
+  skip: {
+    text: 'Skipped',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 1500,
+  },
+  warning: {
+    text: 'Warning',
+    icon: <ExclamationTriangleIcon color="#F0AB00" />,
+    titleColor: '#795000',
+    severityColor: 'orange',
+    severityLevel: 1000,
+  },
+  info: {
+    text: 'Info',
+    icon: <InfoCircleIcon color="#2B9AF3" />,
+    titleColor: '#002952',
+    severityColor: 'blue',
+    severityLevel: 500,
+  },
+};
 
-export const severity_map = {
-      "Convert2RHEL": {
-          "Error": {
-              "text": "Inhibitor",
-              "color": "red",
-              "icon": <ExclamationCircleIcon color='red'/>,
-              "level": 3000
-          },
-          "Overridable": {
-              "text": "Overridable",
-              "color": "red",
-              "icon": <ExclamationCircleIcon color='red'/>,
-              "level": 2500
-          },
-          "Skip": {
-              "text": "Skipped",
-              "color": "red",
-              "icon": <ExclamationCircleIcon color='red'/>,
-              "level": 2000
-          },
-          "Warning": {
-              "text": "Warning",
-              "color": "orange",
-              "icon": <ExclamationTriangleIcon color='orange'/>,
-              "level": 1500
-          },
-          "Info": {
-              "text": "Info",
-              "color": "blue",
-              "icon": <InfoCircleIcon color='blue'/>,
-              "level": 1000
-          },
-      },
-      "Leapp": {
-          "high": {
-              "text": "High risk",
-              "color": "red",
-              "icon": <ExclamationCircleIcon/>,
-              "level": 3000
-          },
-          "low": {
-              "text": "Low risk",
-              "color": "orange",
-              "icon": <ExclamationTriangleIcon/>,
-              "level": 1500
-          },
-          "info": {
-              "text": "Info",
-              "color": "blue",
-              "icon": <InfoCircleIcon/>,
-              "level": 1000
-          }
-      }
-  }
+// constant to be removed
+const converttorhelpreanalysisstageSeverityMap = {
+  error: {
+    text: 'Inhibitor',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2500,
+  },
+  overridable: {
+    text: 'Overridable',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2000,
+  },
+  skip: {
+    text: 'Skipped',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 1500,
+  },
+  warning: {
+    text: 'Warning',
+    icon: <ExclamationTriangleIcon color="#F0AB00" />,
+    titleColor: '#795000',
+    severityColor: 'orange',
+    severityLevel: 1000,
+  },
+  info: {
+    text: 'Info',
+    icon: <InfoCircleIcon color="#2B9AF3" />,
+    titleColor: '#002952',
+    severityColor: 'blue',
+    severityLevel: 500,
+  },
+};
+
+const leapppreupgradeSeverityMap = {
+  high: {
+    text: 'High risk',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 1500,
+  },
+  low: {
+    text: 'Low risk',
+    icon: <ExclamationTriangleIcon color="#F0AB00" />,
+    titleColor: '#795000',
+    severityColor: 'orange',
+    severityLevel: 1000,
+  },
+  info: {
+    text: 'Info',
+    icon: <InfoCircleIcon color="#2B9AF3" />,
+    titleColor: '#002952',
+    severityColor: 'blue',
+    severityLevel: 500,
+  },
+};
+
+export default {
+  converttorhelpreanalysisSeverityMap,
+  converttorhelpreanalysisstageSeverityMap,
+  leapppreupgradeSeverityMap,
+};

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
@@ -59,14 +59,13 @@ export const upgrade_leapp_task = {
   systems_count: 5,
 };
 
-
 export const convert2rhel_task_details = {
   id: 2909,
   alerts_count: 3,
-  task_slug: 'convert2rhel-preconversion',
+  task_slug: 'convert-to-rhel-preanalysis',
   task_title: 'Convert to RHEL Preanalysis',
   task_description:
-      'For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.',
+    'For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.',
   start_time: '2023-06-01T19:58:51.330433Z',
   end_time: '2023-07-16T20:30:24.772008Z',
   initiated_by: 'insights-qa',
@@ -74,7 +73,6 @@ export const convert2rhel_task_details = {
   system_count: 2,
   systems_count: 2,
 };
-
 
 export const leapp_task_jobs = [
   {
@@ -363,7 +361,8 @@ export const convert2rhel_task_jobs = [
     system: 'f1356a99-754d-4219-9g25-fccb2cc6e2f2',
     status: 'Success',
     results: {
-      message: 'No inhibtors found, conversion will run smoothly for this system.',
+      message:
+        'No inhibtors found, conversion should run smoothly for this system.',
     },
     updated_on: '2022-08-08T18:19:50.898540Z',
     display_name: 'centos7-test-device-1',
@@ -373,47 +372,35 @@ export const convert2rhel_task_jobs = [
     system: 'f1356a99-754d-4219-9g25-fccb2cc53bee',
     status: 'Success',
     results: {
-
-      alert: true,
+      alert: false,
       report: '',
-      message: 'Your system has 2 inhibitors out of 3 potential problems.',
+      message: 'Your system has 3 inhibitors out of 3 potential problems.',
       report_json: {
         entries: [
-          {
-            id: 'SECURE_BOOT_DETECTED',
-            key: 'DBUS_IS_RUNNING::SECURE_BOOT_DETECTED',
-            tags: [],
-            actor: 'DBUS_IS_RUNNING',
-            title: 'Dbus is running check skip',
-            summary:
-              'Skipping the check because we have been asked not to subscribe this system to RHSM',
-            audience: 'sysadmin',
-            hostname: 'dan-laptop',
-            severity: 'Warning',
-            timeStamp: '2022-10-12T17:16:44.065672Z',
-          },
           {
             id: 'INVALID_KERNEL_VERSION',
             key: 'IS_LOADED_KERNEL_LATEST::INVALID_KERNEL_VERSION',
             tags: [],
             actor: 'IS_LOADED_KERNEL_LATEST',
-            title: 'The version of the loaded kernel is different from the latest version',
-
+            title:
+              'The version of the loaded kernel is different from the latest version',
             detail: {
               diagnosis: [
                 {
-                  context: 'Latest kernel version available in updates: 3.10.0-1160.90.1.el7\n Loaded kernel version: 3.10.0-1160.88.1.el7',
+                  context:
+                    'Latest kernel version available in updates: 3.10.0-1160.90.1.el7\n Loaded kernel version: 3.10.0-1160.88.1.el7',
                 },
               ],
               remediations: [
                 {
                   type: 'hint',
                   context:
-                    "To proceed with the conversion, update the kernel version by executing the following steps:\n\n1. yum install kernel-3.10.0-1160.90.1.el7 -y\n2. reboot",
+                    'To proceed with the conversion, update the kernel version by executing the following steps:\n\n1. yum install kernel-3.10.0-1160.90.1.el7 -y\n2. reboot',
                 },
               ],
             },
-            summary: 'The version of the loaded kernel is different from the latest version in the enabled system repositories.',
+            summary:
+              'The version of the loaded kernel is different from the latest version in the enabled system repositories.',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
             severity: 'Error',
@@ -429,7 +416,8 @@ export const convert2rhel_task_jobs = [
             detail: {
               diagnosis: [
                 {
-                  context: 'In order to continue the conversion, secure boot must be disabled',
+                  context:
+                    'In order to continue the conversion, secure boot must be disabled',
                 },
               ],
               remediations: [
@@ -440,23 +428,40 @@ export const convert2rhel_task_jobs = [
                 },
               ],
             },
-            summary: 'The conversion with secure boot is currently not possible.',
+            summary:
+              'The conversion with secure boot is currently not possible.',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
             severity: 'Error',
             timeStamp: '2022-10-12T17:16:47.104093Z',
           },
           {
-            id: 'REPOSITORY_FILE_PACKAGES_REMOVED',
-            key: 'REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED',
+            id: 'PACKAGE_UP_TO_DATE_CHECK_FAIL',
+            key: 'PACKAGE_UPDATES::PACKAGE_UP_TO_DATE_CHECK_FAIL',
             tags: [],
-            actor: 'REMOVE_REPOSITORY_FILES_PACKAGES',
-            flags: [],
-            title: 'Repository file package removal',
-            summary: 'The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3',
+            actor: 'PACKAGE_UPDATES',
+            flags: ['inhibitor'],
+            title: 'Package up to date check fail',
+            detail: {
+              diagnosis: [
+                {
+                  context:
+                    'There was an error while checking whether the installed packages are up-to-date. Having an updated system is an important prerequisite for a successful conversion.',
+                },
+              ],
+              remediations: [
+                {
+                  type: 'hint',
+                  context:
+                    'Consider verifyng the system is up to date manually before proceeding with the conversion.',
+                },
+              ],
+            },
+            summary:
+              'The conversion with secure boot is currently not possible.',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
-            severity: 'Info',
+            severity: 'Overridable',
             timeStamp: '2022-10-12T17:16:47.104093Z',
           },
         ],
@@ -469,25 +474,46 @@ export const convert2rhel_task_jobs = [
   {
     executed_task: 2909,
     system: 'f1356a99-754d-4219-9g25-fccb2cc6e2f2',
-    status: 'Failure',
+    status: 'Success',
     results: {
-      message: 'There was an error during script execution, the checks could not be run',
+      message:
+        'No inhibtors found, conversion should run smoothly for this system.',
+      report_json: {
+        entries: [
+          {
+            id: 'REPOSITORY_FILE_PACKAGES_REMOVED',
+            key: 'REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED',
+            tags: [],
+            actor: 'REMOVE_REPOSITORY_FILES_PACKAGES',
+            flags: [],
+            title: 'Repository file package removal',
+            summary:
+              'The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'Info',
+            timeStamp: '2022-10-12T17:16:47.104093Z',
+          },
+          {
+            id: 'SECURE_BOOT_DETECTED',
+            key: 'DBUS_IS_RUNNING::SECURE_BOOT_DETECTED',
+            tags: [],
+            actor: 'DBUS_IS_RUNNING',
+            title: 'Dbus is running check skip',
+            summary:
+              'Skipping the check because we have been asked not to subscribe this system to RHSM',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'Warning',
+            timeStamp: '2022-10-12T17:16:44.065672Z',
+          },
+        ],
+      },
     },
     updated_on: '2022-08-08T18:19:50.898540Z',
-    display_name: 'centos7-test-device-1',
+    display_name: 'centos7-test-device-3',
   },
 ];
-
-
-export const convert2rhel_task_main_page = [
-    {
-      slug: "foo",
-      title: "Preconversion analysis utility",
-      description: "For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.",
-      publish_date: "2022-10-05T00:00:00Z"
-    },
-  ];
-
 
 export const running_task = {
   id: 217,

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
@@ -389,7 +389,7 @@ export const convert2rhel_task_jobs = [
               'Skipping the check because we have been asked not to subscribe this system to RHSM',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
-            severity: 'low',
+            severity: 'Warning',
             timeStamp: '2022-10-12T17:16:44.065672Z',
           },
           {
@@ -416,7 +416,7 @@ export const convert2rhel_task_jobs = [
             summary: 'The version of the loaded kernel is different from the latest version in the enabled system repositories.',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
-            severity: 'high',
+            severity: 'Error',
             timeStamp: '2022-10-12T17:16:44.255785Z',
           },
           {
@@ -443,7 +443,7 @@ export const convert2rhel_task_jobs = [
             summary: 'The conversion with secure boot is currently not possible.',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
-            severity: 'high',
+            severity: 'Error',
             timeStamp: '2022-10-12T17:16:47.104093Z',
           },
           {
@@ -456,7 +456,7 @@ export const convert2rhel_task_jobs = [
             summary: 'The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3',
             audience: 'sysadmin',
             hostname: 'dan-laptop',
-            severity: 'info',
+            severity: 'Info',
             timeStamp: '2022-10-12T17:16:47.104093Z',
           },
         ],

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
@@ -59,6 +59,23 @@ export const upgrade_leapp_task = {
   systems_count: 5,
 };
 
+
+export const convert2rhel_task_details = {
+  id: 2909,
+  alerts_count: 3,
+  task_slug: 'convert2rhel-preconversion',
+  task_title: 'Convert to RHEL Preanalysis',
+  task_description:
+      'For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.',
+  start_time: '2023-06-01T19:58:51.330433Z',
+  end_time: '2023-07-16T20:30:24.772008Z',
+  initiated_by: 'insights-qa',
+  status: 'Running',
+  system_count: 2,
+  systems_count: 2,
+};
+
+
 export const leapp_task_jobs = [
   {
     executed_task: 235,
@@ -339,6 +356,138 @@ export const leapp_task_jobs = [
     display_name: 'dl-test-device-5',
   },
 ];
+
+export const convert2rhel_task_jobs = [
+  {
+    executed_task: 2909,
+    system: 'f1356a99-754d-4219-9g25-fccb2cc6e2f2',
+    status: 'Success',
+    results: {
+      message: 'No inhibtors found, conversion will run smoothly for this system.',
+    },
+    updated_on: '2022-08-08T18:19:50.898540Z',
+    display_name: 'centos7-test-device-1',
+  },
+  {
+    executed_task: 2909,
+    system: 'f1356a99-754d-4219-9g25-fccb2cc53bee',
+    status: 'Success',
+    results: {
+
+      alert: true,
+      report: '',
+      message: 'Your system has 2 inhibitors out of 3 potential problems.',
+      report_json: {
+        entries: [
+          {
+            id: 'SECURE_BOOT_DETECTED',
+            key: 'DBUS_IS_RUNNING::SECURE_BOOT_DETECTED',
+            tags: [],
+            actor: 'DBUS_IS_RUNNING',
+            title: 'Dbus is running check skip',
+            summary:
+              'Skipping the check because we have been asked not to subscribe this system to RHSM',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'low',
+            timeStamp: '2022-10-12T17:16:44.065672Z',
+          },
+          {
+            id: 'INVALID_KERNEL_VERSION',
+            key: 'IS_LOADED_KERNEL_LATEST::INVALID_KERNEL_VERSION',
+            tags: [],
+            actor: 'IS_LOADED_KERNEL_LATEST',
+            title: 'The version of the loaded kernel is different from the latest version',
+
+            detail: {
+              diagnosis: [
+                {
+                  context: 'Latest kernel version available in updates: 3.10.0-1160.90.1.el7\n Loaded kernel version: 3.10.0-1160.88.1.el7',
+                },
+              ],
+              remediations: [
+                {
+                  type: 'hint',
+                  context:
+                    "To proceed with the conversion, update the kernel version by executing the following steps:\n\n1. yum install kernel-3.10.0-1160.90.1.el7 -y\n2. reboot",
+                },
+              ],
+            },
+            summary: 'The version of the loaded kernel is different from the latest version in the enabled system repositories.',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'high',
+            timeStamp: '2022-10-12T17:16:44.255785Z',
+          },
+          {
+            id: 'SECURE_BOOT_DETECTED',
+            key: 'EFI::SECURE_BOOT_DETECTED',
+            tags: [],
+            actor: 'EFI',
+            flags: ['inhibitor'],
+            title: 'Secure boot detected',
+            detail: {
+              diagnosis: [
+                {
+                  context: 'In order to continue the conversion, secure boot must be disabled',
+                },
+              ],
+              remediations: [
+                {
+                  type: 'hint',
+                  context:
+                    'To disable the secure boot, follow the instructions available in this article: https://access.redhat.com/solutions/6753681',
+                },
+              ],
+            },
+            summary: 'The conversion with secure boot is currently not possible.',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'high',
+            timeStamp: '2022-10-12T17:16:47.104093Z',
+          },
+          {
+            id: 'REPOSITORY_FILE_PACKAGES_REMOVED',
+            key: 'REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED',
+            tags: [],
+            actor: 'REMOVE_REPOSITORY_FILES_PACKAGES',
+            flags: [],
+            title: 'Repository file package removal',
+            summary: 'The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3',
+            audience: 'sysadmin',
+            hostname: 'dan-laptop',
+            severity: 'info',
+            timeStamp: '2022-10-12T17:16:47.104093Z',
+          },
+        ],
+        leapp_run_id: 'e7d38746-cfe4-4ec3-8ad5-4e6a16790cf4',
+      },
+    },
+    updated_on: '2022-08-08T18:19:50.898540Z',
+    display_name: 'centos7-test-device-2',
+  },
+  {
+    executed_task: 2909,
+    system: 'f1356a99-754d-4219-9g25-fccb2cc6e2f2',
+    status: 'Failure',
+    results: {
+      message: 'There was an error during script execution, the checks could not be run',
+    },
+    updated_on: '2022-08-08T18:19:50.898540Z',
+    display_name: 'centos7-test-device-1',
+  },
+];
+
+
+export const convert2rhel_task_main_page = [
+    {
+      slug: "foo",
+      title: "Preconversion analysis utility",
+      description: "For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.",
+      publish_date: "2022-10-05T00:00:00Z"
+    },
+  ];
+
 
 export const running_task = {
   id: 217,

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -1576,7 +1576,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         aria-label="Go to previous page"
                         class="pf-c-button pf-m-plain pf-m-disabled"
                         data-action="previous"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-19"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-18"
                         data-ouia-component-type="PF4/Button"
                         data-ouia-safe="true"
                         disabled=""
@@ -1605,7 +1605,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         aria-label="Go to next page"
                         class="pf-c-button pf-m-plain pf-m-disabled"
                         data-action="next"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-20"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-19"
                         data-ouia-component-type="PF4/Button"
                         data-ouia-safe="true"
                         disabled=""
@@ -2072,7 +2072,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#C9190B"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -2106,6 +2106,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
                               </div>
@@ -2122,6 +2123,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -2144,6 +2146,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 ca7a1a66906a7df3da890aa538562708d3ea6ecd
                               </div>
@@ -2248,7 +2251,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#C9190B"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -2282,6 +2285,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 Firewalld has enabled configuration option "AllowZoneDrifiting" which has been removed in RHEL-9. New behavior is as if "AllowZoneDrifiting" was set to "no".
                               </div>
@@ -2298,6 +2302,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -2330,6 +2335,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 5b1cf050e1a877b0358b6e8c612277c591d40c13
                               </div>
@@ -2434,7 +2440,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#C9190B"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -2468,6 +2474,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 VDO devices 'vda, vda1, vda2' require migration to LVM management.After performing the upgrade VDO devices can only be managed via LVM. Any VDO device not currently managed by LVM must be converted to LVM management before upgrading. The data on any VDO device not converted to LVM management will be inaccessible after upgrading.
                               </div>
@@ -2484,6 +2491,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -2506,6 +2514,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 f7c335398cc449f5d7baf4e73255d44c34ad2620
                               </div>
@@ -2610,7 +2619,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#F0AB00"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -2644,6 +2653,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
                               </div>
@@ -2660,6 +2670,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -2682,6 +2693,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
                               </div>
@@ -2786,7 +2798,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#2B9AF3"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -2820,6 +2832,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 SElinux relabeling will be scheduled as the status is permissive/enforcing.
                               </div>
@@ -2836,6 +2849,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                               </div>
@@ -3242,7 +3256,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#C9190B"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -3276,6 +3290,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
                               </div>
@@ -3292,6 +3307,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -3314,6 +3330,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 ca7a1a66906a7df3da890aa538562708d3ea6ecd
                               </div>
@@ -3418,7 +3435,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#F0AB00"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -3452,6 +3469,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
                               </div>
@@ -3468,6 +3486,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -3490,6 +3509,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
                               </div>
@@ -3594,7 +3614,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#F0AB00"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -3628,6 +3648,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 After the upgrade has completed the release of the subscription-manager will be set to 9.0. This will ensure that you will receive and keep the version you choose to upgrade to.
                               </div>
@@ -3644,6 +3665,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 <div>
                                   <span
@@ -3666,6 +3688,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 747a4ca25303eda17d1891bb85eeb226be14f252
                               </div>
@@ -3770,7 +3793,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    fill="currentColor"
+                                    fill="#2B9AF3"
                                     height="1em"
                                     role="img"
                                     style="vertical-align: -0.125em;"
@@ -3804,6 +3827,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 SElinux relabeling will be scheduled as the status is permissive/enforcing.
                               </div>
@@ -3820,6 +3844,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 class="pf-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
                                 l="6"
                                 m="7"
+                                style="white-space: pre-line;"
                               >
                                 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                               </div>
@@ -3844,40 +3869,9 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
               data-ouia-safe="true"
             >
               <td
-                class="pf-c-table__toggle"
+                class=""
                 data-key="0"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-expanded="false"
-                  aria-label="Details"
-                  aria-labelledby="simple-node7 expandable-toggle7"
-                  class="pf-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-18"
-                  data-ouia-component-type="PF4/Button"
-                  data-ouia-safe="true"
-                  id="expandable-toggle7"
-                  type="button"
-                >
-                  <div
-                    class="pf-c-table__toggle-icon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style="vertical-align: -0.125em;"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                      />
-                    </svg>
-                  </div>
-                </button>
-              </td>
+              />
               <td
                 class="pf-m-width-30"
                 data-key="1"
@@ -3940,84 +3934,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                   >
                     Your system has 1 inhibitor out of 4 potential problems
                   </div>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class="pf-c-table__expandable-row"
-              data-ouia-component-id="OUIA-Generated-TableRow-39"
-              data-ouia-component-type="PF4/TableRow"
-              data-ouia-safe="true"
-              hidden=""
-            >
-              <td
-                class=""
-                colspan="4"
-                data-key="0"
-                id="expanded-content8"
-              >
-                <div>
-                  <div
-                    class="pf-c-code-block"
-                    style="--pf-c-code-block__header--BorderBottomColor: [object Object]; background-color: rgb(255, 255, 255);"
-                  >
-                    <div
-                      class="pf-c-code-block__header"
-                    >
-                      <div
-                        class="pf-c-code-block__actions"
-                      />
-                    </div>
-                    <div
-                      class="pf-c-code-block__content"
-                    >
-                      <pre
-                        class="pf-c-code-block__pre"
-                      >
-                        <code
-                          class="pf-c-code-block__code"
-                        >
-                          Risk Factor: high
-Title: Leapp could not identify where GRUB core is located
-Summary: We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
-Remediation: [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
-Key: ca7a1a66906a7df3da890aa538562708d3ea6ecd
-----------------------------------------
-Risk Factor: low
-Title: SElinux will be set to permissive mode
-Summary: SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
-Remediation: [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
-Key: 39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
-----------------------------------------
-Risk Factor: low
-Title: The subscription-manager release is going to be set after the upgrade
-Summary: After the upgrade has completed the release of the subscription-manager will be set to 9.0. This will ensure that you will receive and keep the version you choose to upgrade to.
-Remediation: [hint] If you wish to receive updates for the latest released version of the target system, run \`subscription-manager release --unset\` after the upgrade.
-Key: 747a4ca25303eda17d1891bb85eeb226be14f252
-----------------------------------------
-Risk Factor: info
-Title: SElinux relabeling will be scheduled
-Summary: SElinux relabeling will be scheduled as the status is permissive/enforcing.
-Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
-----------------------------------------
-
-                        </code>
-                      </pre>
-                    </div>
-                  </div>
-                  <table
-                    class="pf-c-table pf-m-grid-md pf-m-compact"
-                    data-ouia-component-id="OUIA-Generated-Table-7"
-                    data-ouia-component-type="PF4/Table"
-                    data-ouia-safe="true"
-                    role="grid"
-                    style="margin-bottom: 30px; --pf-c-table__expandable-row--after--border-width--base: 0;"
-                  >
-                    <tbody
-                      class=""
-                      role="rowgroup"
-                    />
-                  </table>
                 </div>
               </td>
             </tr>
@@ -4101,7 +4017,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                   aria-label="Go to first page"
                   class="pf-c-button pf-m-plain pf-m-disabled"
                   data-action="first"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-21"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-20"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
                   disabled=""
@@ -4130,7 +4046,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                   aria-label="Go to previous page"
                   class="pf-c-button pf-m-plain pf-m-disabled"
                   data-action="previous"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-22"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-21"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
                   disabled=""
@@ -4177,7 +4093,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                   aria-label="Go to next page"
                   class="pf-c-button pf-m-plain pf-m-disabled"
                   data-action="next"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-23"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-22"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
                   disabled=""
@@ -4206,7 +4122,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                   aria-label="Go to last page"
                   class="pf-c-button pf-m-plain pf-m-disabled"
                   data-action="last"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-24"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-23"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe="true"
                   disabled=""

--- a/src/SmartComponents/completedTaskDetailsHelpers.js
+++ b/src/SmartComponents/completedTaskDetailsHelpers.js
@@ -76,7 +76,7 @@ export const fetchTaskJobs = async (taskDetails, setError) => {
 
 export const hasDetails = (completedTaskJob) => {
   return completedTaskJob.status === 'Success' &&
-    completedTaskJob.results.report
+    completedTaskJob.results.report_json?.entries?.length
     ? true
     : false;
 };


### PR DESCRIPTION
This PR mainly makes some components more generic so different types of tasks can display on the same component. We've done this by creating constants that define how each unique task defines its statuses and other data, and then we map the executed task to the constant via the task_slug and pull in the constant.