### PR TITLE
temporarily hide preconversion in stable envs

### DIFF
--- a/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
+++ b/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
@@ -14,8 +14,11 @@ import {
   TASKS_API_ROOT,
   TASKS_ERROR,
 } from '../../constants';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 const AvailableTasksTable = ({ availableTasks, error, openTaskModal }) => {
+  const chrome = useChrome();
+
   return (
     <div aria-label="available-tasks-table">
       {error ? (
@@ -33,41 +36,48 @@ const AvailableTasksTable = ({ availableTasks, error, openTaskModal }) => {
         />
       ) : (
         availableTasks?.map((task) => {
-          return (
-            <div aria-label={task.title} key={task.title}>
-              <CardBuilder>
-                <CardBuilderContent content={task.title} type="title" />
-                <CardBuilderContent
-                  className="card-task-description"
-                  content={task.description}
-                  type="body"
-                />
-                <CardBuilderContent
-                  content={
-                    <Flex direction={{ default: 'column' }}>
-                      <FlexItem>
-                        <a
-                          href={`${TASKS_API_ROOT}${AVAILABLE_TASKS_ROOT}/${task.slug}/playbook`}
-                        >
-                          Download preview of playbook
-                        </a>
-                      </FlexItem>
-                      <FlexItem>
-                        <RunTaskButton
-                          slug={task.slug}
-                          isFirst
-                          variant="primary"
-                          openTaskModal={openTaskModal}
-                        />
-                      </FlexItem>
-                    </Flex>
-                  }
-                  type="footer"
-                />
-              </CardBuilder>
-              <br />
-            </div>
-          );
+          if (
+            chrome.isBeta() ||
+            (!chrome.isBeta() &&
+              task.slug !== 'convert-to-rhel-preanalysis-stage' &&
+              task.slug !== 'convert-to-rhel-preanalysis')
+          ) {
+            return (
+              <div aria-label={task.title} key={task.title}>
+                <CardBuilder>
+                  <CardBuilderContent content={task.title} type="title" />
+                  <CardBuilderContent
+                    className="card-task-description"
+                    content={task.description}
+                    type="body"
+                  />
+                  <CardBuilderContent
+                    content={
+                      <Flex direction={{ default: 'column' }}>
+                        <FlexItem>
+                          <a
+                            href={`${TASKS_API_ROOT}${AVAILABLE_TASKS_ROOT}/${task.slug}/playbook`}
+                          >
+                            Download preview of playbook
+                          </a>
+                        </FlexItem>
+                        <FlexItem>
+                          <RunTaskButton
+                            slug={task.slug}
+                            isFirst
+                            variant="primary"
+                            openTaskModal={openTaskModal}
+                          />
+                        </FlexItem>
+                      </Flex>
+                    }
+                    type="footer"
+                  />
+                </CardBuilder>
+                <br />
+              </div>
+            );
+          }
         })
       )}
     </div>


### PR DESCRIPTION
With this PR, we are temporarily hiding the new preconversion task in the Available Tasks tab when in stage-stable and prod-stable. It should still be visible in preview environments.