### PR TITLE
fix: update run date/time column

### DIFF
--- a/src/SmartComponents/ActivityTable/ActivityTable.js
+++ b/src/SmartComponents/ActivityTable/ActivityTable.js
@@ -99,10 +99,8 @@ const ActivityTable = () => {
   );
 
   const setTasks = async (result) => {
-    result?.map((task) =>
-      task.status === 'Completed'
-        ? (task.run_date_time = renderRunDateTime(task.end_time))
-        : (task.run_date_time = task.status)
+    result?.map(
+      (task) => (task.run_date_time = renderRunDateTime(task.start_time))
     );
 
     await setActivities(result);

--- a/src/SmartComponents/ActivityTable/Columns.js
+++ b/src/SmartComponents/ActivityTable/Columns.js
@@ -70,7 +70,7 @@ export const RunDateTimeColumn = {
   props: {
     width: 20,
   },
-  sortByProp: 'end_time',
+  sortByProp: 'start_time',
   renderExport: (task) => task.run_date_time,
   renderFunc: (_, _empty, result) => result.run_date_time,
 };

--- a/src/SmartComponents/ActivityTable/__tests__/__snapshots__/ActivityTable.tests.js.snap
+++ b/src/SmartComponents/ActivityTable/__tests__/__snapshots__/ActivityTable.tests.js.snap
@@ -593,7 +593,7 @@ exports[`ActivityTable should export 1`] = `
             data-key="3"
             data-label="Run date/time"
           >
-            Running
+            21 Apr 2022, 10:10 UTC
           </td>
           <td
             class="pf-c-table__action"
@@ -684,7 +684,7 @@ exports[`ActivityTable should export 1`] = `
             data-key="3"
             data-label="Run date/time"
           >
-            20 Apr 2022, 11:10 UTC
+            20 Apr 2022, 10:10 UTC
           </td>
           <td
             class="pf-c-table__action"

--- a/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/columns.fixtures.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/columns.fixtures.js
@@ -19,6 +19,6 @@ export default [
     props: {
       width: 20,
     },
-    sortByProp: 'end_time',
+    sortByProp: 'start_time',
   },
 ];

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useRowsBuilder.tests.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useRowsBuilder.tests.js.snap
@@ -15,7 +15,7 @@ Object {
                 "title": 10,
               },
               Object {
-                "title": "2022-04-20T11:10:00",
+                "title": "2022-04-20T10:10:00",
               },
             ],
             "itemId": undefined,
@@ -29,7 +29,7 @@ Object {
                 "title": 5,
               },
               Object {
-                "title": "null",
+                "title": "2022-04-21T10:10:00",
               },
             ],
             "itemId": undefined,
@@ -43,7 +43,7 @@ Object {
                 "title": 3,
               },
               Object {
-                "title": "2022-04-28T11:10:00",
+                "title": "2022-04-25T10:10:00",
               },
             ],
             "itemId": undefined,
@@ -67,7 +67,7 @@ Object {
               "title": 10,
             },
             Object {
-              "title": "2022-04-20T11:10:00",
+              "title": "2022-04-20T10:10:00",
             },
           ],
           "itemId": undefined,
@@ -81,7 +81,7 @@ Object {
               "title": 5,
             },
             Object {
-              "title": "null",
+              "title": "2022-04-21T10:10:00",
             },
           ],
           "itemId": undefined,
@@ -95,7 +95,7 @@ Object {
               "title": 3,
             },
             Object {
-              "title": "2022-04-28T11:10:00",
+              "title": "2022-04-25T10:10:00",
             },
           ],
           "itemId": undefined,

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableSort.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableSort.test.js.snap
@@ -32,7 +32,7 @@ Object {
             "props": Object {
               "width": 20,
             },
-            "sortByProp": "end_time",
+            "sortByProp": "start_time",
             "title": "Run date/time",
             "transforms": Array [
               [Function],
@@ -76,7 +76,7 @@ Object {
           "props": Object {
             "width": 20,
           },
-          "sortByProp": "end_time",
+          "sortByProp": "start_time",
           "title": "Run date/time",
           "transforms": Array [
             [Function],

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableTools.tests.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableTools.tests.js.snap
@@ -31,7 +31,7 @@ Object {
             "props": Object {
               "width": 20,
             },
-            "sortByProp": "end_time",
+            "sortByProp": "start_time",
             "title": "Run date/time",
             "transforms": Array [
               [Function],
@@ -49,7 +49,7 @@ Object {
                 "title": 10,
               },
               Object {
-                "title": "2022-04-20T11:10:00",
+                "title": "2022-04-20T10:10:00",
               },
             ],
             "itemId": undefined,
@@ -63,7 +63,7 @@ Object {
                 "title": 5,
               },
               Object {
-                "title": "null",
+                "title": "2022-04-21T10:10:00",
               },
             ],
             "itemId": undefined,
@@ -77,7 +77,7 @@ Object {
                 "title": 3,
               },
               Object {
-                "title": "2022-04-28T11:10:00",
+                "title": "2022-04-25T10:10:00",
               },
             ],
             "itemId": undefined,
@@ -126,7 +126,7 @@ Object {
             "props": Object {
               "width": 20,
             },
-            "sortByProp": "end_time",
+            "sortByProp": "start_time",
             "title": "Run date/time",
             "transforms": Array [
               [Function],
@@ -144,7 +144,7 @@ Object {
                 "title": 10,
               },
               Object {
-                "title": "2022-04-20T11:10:00",
+                "title": "2022-04-20T10:10:00",
               },
             ],
             "itemId": undefined,
@@ -158,7 +158,7 @@ Object {
                 "title": 5,
               },
               Object {
-                "title": "null",
+                "title": "2022-04-21T10:10:00",
               },
             ],
             "itemId": undefined,
@@ -172,7 +172,7 @@ Object {
                 "title": 3,
               },
               Object {
-                "title": "2022-04-28T11:10:00",
+                "title": "2022-04-25T10:10:00",
               },
             ],
             "itemId": undefined,
@@ -222,7 +222,7 @@ Object {
           "props": Object {
             "width": 20,
           },
-          "sortByProp": "end_time",
+          "sortByProp": "start_time",
           "title": "Run date/time",
           "transforms": Array [
             [Function],
@@ -240,7 +240,7 @@ Object {
               "title": 10,
             },
             Object {
-              "title": "2022-04-20T11:10:00",
+              "title": "2022-04-20T10:10:00",
             },
           ],
           "itemId": undefined,
@@ -254,7 +254,7 @@ Object {
               "title": 5,
             },
             Object {
-              "title": "null",
+              "title": "2022-04-21T10:10:00",
             },
           ],
           "itemId": undefined,
@@ -268,7 +268,7 @@ Object {
               "title": 3,
             },
             Object {
-              "title": "2022-04-28T11:10:00",
+              "title": "2022-04-25T10:10:00",
             },
           ],
           "itemId": undefined,


### PR DESCRIPTION
This PR updates the "Run date/time" column on the Activity table to display the start_time instead of the end_time. This also removes the "Running" status from the same column. Now, we'll only look to the status column for statuses.