### PR TITLE
fix(HMS-2644): catch new remediation field structure

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -40,7 +40,9 @@ const EntryDetails = ({ entry, taskConstantMapper }) => {
             </span>
           ) : null}
           <span style={{ fontFamily: 'overpass-mono' }}>
-            [{remediation.type}] {remediation.context}
+            {remediation.type
+              ? `[${remediation.type}] ${remediation.context}`
+              : `${remediation.context}`}
           </span>
         </div>
       );
@@ -76,7 +78,7 @@ const EntryDetails = ({ entry, taskConstantMapper }) => {
         {detail?.diagnosis?.context
           ? createGrid('Diagnosis', renderDiagnosisDetails)
           : null}
-        {detail?.remediations
+        {detail?.remediations && detail?.remediations[0]?.context !== ''
           ? createGrid('Remediation', renderRemediationsDetails)
           : null}
         {createGrid('Key', key)}


### PR DESCRIPTION
When a pre-upgrade analysis task has a job that doesn't return a remediation, then it leaves the field off completely. We currently handle that correctly. But the new pre-conversion analysis tasks have jobs that, when a remediation isn't provided, still provides the remediation key value pair, but it is empty. This is why the commit checks for `detail?.remediations[0]?.context !== ''`. Pre-conversion tasks return:

```
detail: {
  remediations: [
    context: '',
  ],
},
```

Whereas pre-upgrade tasks return the following when no `detail.remediations` when there is no remediation.

This PR handles both scenarios. Let me know if you need ids to test both types of tasks.