### PR TITLE
feat(RHINENG-1454): Add ability to name tasks

### DIFF
--- a/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
+++ b/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
@@ -2,44 +2,26 @@ import React from 'react';
 import { Button } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import { executeTask } from '../../../api';
-import { dispatchNotification } from '../../Utilities/Dispatcher';
-import { EXECUTE_TASK_NOTIFICATION } from '../../constants';
-import { isError } from '../../SmartComponents/completedTaskDetailsHelpers';
 
 const ExecuteTaskButton = ({
   classname,
   ids,
-  setIsRunTaskAgain,
-  setModalOpened,
+  setExecuteTaskResult,
   slug,
-  title,
+  taskName,
   variant,
 }) => {
   const buildApiBody = () => {
     return {
       task: slug,
       hosts: ids,
+      name: taskName,
     };
   };
 
   const submitTask = async () => {
-    setModalOpened(false);
-
     let result = await executeTask(buildApiBody());
-    if (isError(result)) {
-      dispatchNotification({
-        variant: 'danger',
-        title: 'Error',
-        description: result.message,
-        dismissable: true,
-        autoDismiss: false,
-      });
-    } else {
-      if (setIsRunTaskAgain) {
-        setIsRunTaskAgain(true);
-      }
-      EXECUTE_TASK_NOTIFICATION(title, ids, result.data.id);
-    }
+    setExecuteTaskResult(result);
   };
 
   return (
@@ -58,10 +40,9 @@ const ExecuteTaskButton = ({
 ExecuteTaskButton.propTypes = {
   classname: propTypes.string,
   ids: propTypes.array,
-  setIsRunTaskAgain: propTypes.func,
-  setModalOpened: propTypes.func,
+  setExecuteTaskResult: propTypes.func,
   slug: propTypes.string,
-  title: propTypes.oneOfType([propTypes.string, propTypes.node]),
+  taskName: propTypes.string,
   variant: propTypes.string,
 };
 

--- a/src/PresentationalComponents/ExecuteTaskButton/__tests__/ExecuteTaskButton.tests.js
+++ b/src/PresentationalComponents/ExecuteTaskButton/__tests__/ExecuteTaskButton.tests.js
@@ -7,11 +7,7 @@ import { init } from '../../../store';
 
 import ExecuteTaskButton from '../ExecuteTaskButton';
 import { executeTask } from '../../../../api';
-import * as dispatcher from '../../../Utilities/Dispatcher';
-import {
-  successResponse,
-  errorResponse,
-} from '../../../SmartComponents/__tests__/__fixtures__/completedTaskDetailsHelpers.fixtures';
+import { successResponse } from '../../../SmartComponents/__tests__/__fixtures__/completedTaskDetailsHelpers.fixtures';
 
 jest.mock('../../../../api');
 
@@ -23,10 +19,9 @@ describe('ExecuteTaskButton', () => {
     props = {
       classname: 'some-class-name',
       ids: ['abcd-1234'],
-      setIsRunTaskAgain: jest.fn(),
-      setModalOpened: jest.fn(),
+      setExecuteTaskResult: jest.fn(),
       slug: 'taska',
-      title: 'TaskA',
+      taskName: 'Task A',
       variant: 'primary',
     };
   });
@@ -38,7 +33,6 @@ describe('ExecuteTaskButton', () => {
   });
 
   it('should execute on click', async () => {
-    props.setIsRunTaskAgain = undefined;
     executeTask.mockImplementation(async () => {
       return {
         successResponse,
@@ -46,9 +40,6 @@ describe('ExecuteTaskButton', () => {
       };
     });
 
-    const notification = jest
-      .spyOn(dispatcher, 'dispatchNotification')
-      .mockImplementation();
     render(
       <MemoryRouter keyLength={0}>
         <Provider store={store}>
@@ -60,54 +51,6 @@ describe('ExecuteTaskButton', () => {
     await waitFor(() =>
       userEvent.click(screen.getByLabelText('taska-submit-task-button'))
     );
-    expect(notification).toHaveBeenCalled();
-  });
-
-  it('should execute on click with run task again', async () => {
-    executeTask.mockImplementation(async () => {
-      return {
-        successResponse,
-        data: { id: '1' },
-      };
-    });
-
-    const notification = jest
-      .spyOn(dispatcher, 'dispatchNotification')
-      .mockImplementation();
-    render(
-      <MemoryRouter keyLength={0}>
-        <Provider store={store}>
-          <ExecuteTaskButton {...props} />
-        </Provider>
-      </MemoryRouter>
-    );
-
-    await waitFor(() =>
-      userEvent.click(screen.getByLabelText('taska-submit-task-button'))
-    );
-    expect(notification).toHaveBeenCalled();
-    expect(props.setIsRunTaskAgain).toHaveBeenCalledWith(true);
-  });
-
-  it('should execute error on click', async () => {
-    executeTask.mockImplementation(async () => {
-      return errorResponse;
-    });
-
-    const notification = jest
-      .spyOn(dispatcher, 'dispatchNotification')
-      .mockImplementation();
-    render(
-      <MemoryRouter keyLength={0}>
-        <Provider store={store}>
-          <ExecuteTaskButton {...props} />
-        </Provider>
-      </MemoryRouter>
-    );
-
-    await waitFor(() =>
-      userEvent.click(screen.getByLabelText('taska-submit-task-button'))
-    );
-    expect(notification).toHaveBeenCalled();
+    expect(props.setExecuteTaskResult).toHaveBeenCalled();
   });
 });

--- a/src/SmartComponents/ActivityTable/Columns.js
+++ b/src/SmartComponents/ActivityTable/Columns.js
@@ -4,15 +4,15 @@ import { renderColumnComponent } from '../../Utilities/helpers';
 import { CheckCircleIcon, InProgressIcon } from '@patternfly/react-icons';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 
-const TaskNameCell = ({ id, task_title }, index) => (
-  <InsightsLink key={`task-title-${index}`} to={`/executed/${id}`}>
-    {task_title}
+const TaskNameCell = ({ id, name }, index) => (
+  <InsightsLink key={`task-name-${index}`} to={`/executed/${id}`}>
+    {name}
   </InsightsLink>
 );
 
 TaskNameCell.propTypes = {
   id: propTypes.number,
-  task_title: propTypes.any,
+  name: propTypes.any,
   index: propTypes.number,
 };
 
@@ -41,8 +41,8 @@ export const TaskColumn = {
   props: {
     width: 25,
   },
-  sortByProp: 'task_title',
-  renderExport: (task) => task.task_title,
+  sortByProp: 'name',
+  renderExport: (task) => task.name,
   renderFunc: renderColumnComponent(TaskNameCell),
 };
 

--- a/src/SmartComponents/ActivityTable/__tests__/ActivityTable.tests.js
+++ b/src/SmartComponents/ActivityTable/__tests__/ActivityTable.tests.js
@@ -153,8 +153,8 @@ describe('ActivityTable', () => {
       userEvent.click(screen.getAllByText('Completed')[0]);
     });
     await waitFor(() => {
-      expect(screen.getByText('taskA')).toBeInTheDocument();
-      expect(screen.queryByText('taskB')).not.toBeInTheDocument();
+      expect(screen.getByText('Task A')).toBeInTheDocument();
+      expect(screen.queryByText('Task B')).not.toBeInTheDocument();
     });
   });
 
@@ -187,8 +187,8 @@ describe('ActivityTable', () => {
       userEvent.click(screen.getAllByText('Running')[0]);
     });
     await waitFor(() => {
-      expect(screen.getByText('taskB')).toBeInTheDocument();
-      expect(screen.queryByText('taskA')).not.toBeInTheDocument();
+      expect(screen.getByText('Task B')).toBeInTheDocument();
+      expect(screen.queryByText('Task A')).not.toBeInTheDocument();
     });
   });
 

--- a/src/SmartComponents/ActivityTable/__tests__/__snapshots__/ActivityTable.tests.js.snap
+++ b/src/SmartComponents/ActivityTable/__tests__/__snapshots__/ActivityTable.tests.js.snap
@@ -554,7 +554,7 @@ exports[`ActivityTable should export 1`] = `
             <a
               href="/insights/tasks/executed/2"
             >
-              taskB
+              Task B
             </a>
           </td>
           <td
@@ -645,7 +645,7 @@ exports[`ActivityTable should export 1`] = `
             <a
               href="/insights/tasks/executed/1"
             >
-              taskA
+              Task A
             </a>
           </td>
           <td

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -89,7 +89,7 @@ const CompletedTaskDetails = () => {
   useEffect(() => {
     completedTaskDetails &&
       chrome.updateDocumentTitle(
-        `${completedTaskDetails.task_title} - Tasks | Red Hat Insights`
+        `${completedTaskDetails.name} - Tasks | Red Hat Insights`
       );
   }, [chrome, completedTaskDetails]);
 
@@ -131,7 +131,7 @@ const CompletedTaskDetails = () => {
         selectedSystems={selectedSystems}
         setModalOpened={setRunTaskModalOpened}
         slug={completedTaskDetails.task_slug}
-        title={completedTaskDetails.task_title}
+        title={completedTaskDetails.name}
       />
       <DeleteCancelTaskModal
         id={completedTaskDetails.id}
@@ -141,7 +141,7 @@ const CompletedTaskDetails = () => {
         setModalOpened={setIsDeleteCancelModalOpened}
         startTime={completedTaskDetails.start_time}
         status={completedTaskDetails.status}
-        title={completedTaskDetails.task_title}
+        title={completedTaskDetails.name}
       />
       {error ? (
         <EmptyStateDisplay
@@ -157,7 +157,7 @@ const CompletedTaskDetails = () => {
             <Breadcrumb ouiaId="completed-tasks-details-breadcrumb">
               <BreadcrumbLinkItem to="/executed">Tasks</BreadcrumbLinkItem>
               <BreadcrumbItem isActive>
-                {completedTaskDetails.task_title}
+                {completedTaskDetails.name}
               </BreadcrumbItem>
             </Breadcrumb>
             <Flex direction={{ default: 'column', md: 'row' }}>
@@ -166,7 +166,7 @@ const CompletedTaskDetails = () => {
                 flex={{ default: 'flex_1' }}
               >
                 <FlexItem>
-                  <PageHeaderTitle title={completedTaskDetails.task_title} />
+                  <PageHeaderTitle title={completedTaskDetails.name} />
                 </FlexItem>
                 <FlexItem>
                   <ReactMarkdown>

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
@@ -1,5 +1,6 @@
 export const log4j_task = {
   id: 42,
+  name: 'log4j task',
   task_title: 'Log4J Detection',
   task_slug: 'log4j',
   task_description:
@@ -47,6 +48,7 @@ export const log4j_task_jobs = [
 
 export const upgrade_leapp_task = {
   id: 43,
+  name: 'leapp task',
   task_slug: 'leapp-preupgrade',
   task_title: 'Upgrade RHEL version with LEAP tool',
   task_description:
@@ -61,6 +63,7 @@ export const upgrade_leapp_task = {
 
 export const convert2rhel_task_details = {
   id: 2909,
+  name: 'convert-to-rhel-preanalysis task',
   alerts_count: 3,
   task_slug: 'convert-to-rhel-preanalysis',
   task_title: 'Convert to RHEL Preanalysis',
@@ -517,6 +520,7 @@ export const convert2rhel_task_jobs = [
 
 export const running_task = {
   id: 217,
+  name: 'running task',
   task_title: 'Running task',
   task_slug: 'running_task',
   description:

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -47,7 +47,7 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                 />
               </svg>
             </span>
-            Log4J Detection
+            log4j task
           </li>
         </ol>
       </nav>
@@ -67,7 +67,7 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
               data-ouia-safe="true"
               widget-type="InsightsPageHeaderTitle"
             >
-              Log4J Detection
+              log4j task
             </h1>
           </div>
           <div
@@ -1147,7 +1147,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                 />
               </svg>
             </span>
-            Upgrade RHEL version with LEAP tool
+            leapp task
           </li>
         </ol>
       </nav>
@@ -1167,7 +1167,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
               data-ouia-safe="true"
               widget-type="InsightsPageHeaderTitle"
             >
-              Upgrade RHEL version with LEAP tool
+              leapp task
             </h1>
           </div>
           <div

--- a/src/Utilities/hooks/useTableTools/Components/__tests__/TasksTable.fixtures.js
+++ b/src/Utilities/hooks/useTableTools/Components/__tests__/TasksTable.fixtures.js
@@ -2,6 +2,7 @@ export const activityTableItems = {
   meta: { count: 2 },
   data: [
     {
+      name: 'Task A',
       task_title: 'taskA',
       task_slug: 'taska',
       id: 1,
@@ -13,6 +14,7 @@ export const activityTableItems = {
       systems_count: 10,
     },
     {
+      name: 'Task B',
       task_title: 'taskB',
       task_slug: 'taskb',
       id: 2,
@@ -39,6 +41,7 @@ export const availableTasksTableItems = {
   },
   data: [
     {
+      name: 'Task A',
       title: 'taskA',
       slug: 'taska',
       description:
@@ -47,6 +50,7 @@ export const availableTasksTableItems = {
       severity: 'critical',
     },
     {
+      name: 'Task B',
       title: 'taskB',
       slug: 'taskb',
       description:

--- a/src/Utilities/hooks/useTableTools/Components/__tests__/__snapshots__/TasksTables.tests.js.snap
+++ b/src/Utilities/hooks/useTableTools/Components/__tests__/__snapshots__/TasksTables.tests.js.snap
@@ -404,7 +404,7 @@ exports[`TasksTables should render correctly 1`] = `
           <a
             href="/insights/tasks/executed/1"
           >
-            taskA
+            Task A
           </a>
         </td>
         <td
@@ -460,7 +460,7 @@ exports[`TasksTables should render correctly 1`] = `
           <a
             href="/insights/tasks/executed/2"
           >
-            taskB
+            Task B
           </a>
         </td>
         <td

--- a/src/constants.js
+++ b/src/constants.js
@@ -229,7 +229,7 @@ export const LOADING_CONTENT = [
 ];
 
 export const TASK_LOADING_CONTENT = {
-  task_title: <Skeleton size={SkeletonSize.sm} />,
+  name: <Skeleton size={SkeletonSize.sm} />,
   task_description: <Skeleton size={SkeletonSize.md} />,
 };
 
@@ -270,31 +270,31 @@ export const LOADING_JOBS_TABLE = [
 
 export const LOADING_ACTIVITIES_TABLE = [
   {
-    task_title: <Skeleton size={SkeletonSize.md} />,
+    name: <Skeleton size={SkeletonSize.md} />,
     systems_count: <Skeleton size={SkeletonSize.md} />,
     status: <Skeleton size={SkeletonSize.md} />,
     run_date_time: <Skeleton size={SkeletonSize.md} />,
   },
   {
-    task_title: <Skeleton size={SkeletonSize.md} />,
+    name: <Skeleton size={SkeletonSize.md} />,
     systems_count: <Skeleton size={SkeletonSize.md} />,
     status: <Skeleton size={SkeletonSize.md} />,
     run_date_time: <Skeleton size={SkeletonSize.md} />,
   },
   {
-    task_title: <Skeleton size={SkeletonSize.md} />,
+    name: <Skeleton size={SkeletonSize.md} />,
     systems_count: <Skeleton size={SkeletonSize.md} />,
     status: <Skeleton size={SkeletonSize.md} />,
     run_date_time: <Skeleton size={SkeletonSize.md} />,
   },
   {
-    task_title: <Skeleton size={SkeletonSize.md} />,
+    name: <Skeleton size={SkeletonSize.md} />,
     systems_count: <Skeleton size={SkeletonSize.md} />,
     status: <Skeleton size={SkeletonSize.md} />,
     run_date_time: <Skeleton size={SkeletonSize.md} />,
   },
   {
-    task_title: <Skeleton size={SkeletonSize.md} />,
+    name: <Skeleton size={SkeletonSize.md} />,
     systems_count: <Skeleton size={SkeletonSize.md} />,
     status: <Skeleton size={SkeletonSize.md} />,
     run_date_time: <Skeleton size={SkeletonSize.md} />,


### PR DESCRIPTION
This PR adds the ability to give your tasks a unique name. You can name tasks the same as another task. If an error occurs in the creation of the executed task, the run task modal will stay open and an error will be displayed.

To test, open an available task and notice that the task_slug populates in the text input box. You can change the name of the task to whatever you want, select your systems, and run the task. The notification should allow you to navigate to the new task.

You should also see the new task name populated in the Activity table as well as the executed task details. And, if you select Run task again, you should see the modal populate with the same task name.