### PR TITLE
fix: properly filter by os version

### DIFF
--- a/src/SmartComponents/SystemTable/helpers.js
+++ b/src/SmartComponents/SystemTable/helpers.js
@@ -10,15 +10,16 @@ const buildSortString = (orderBy, orderDirection) => {
 };
 
 const buildFilterString = (filters) => {
+  let osFiltersString = '';
   let displayNameFilter = filters.hostnameOrId
     ? `&display_name=${filters.hostnameOrId}`
     : '';
 
-  let osFilter = filters.osFilter?.length
-    ? '&os_version=' + filters.osFilter.join(',')
-    : '';
+  filters.osFilter?.forEach(({ osName, value }) => {
+    osFiltersString += `&os_name=${osName}&os_version=${value}`;
+  });
 
-  return `${displayNameFilter}${osFilter}`;
+  return `${displayNameFilter}${osFiltersString}`;
 };
 
 const buildTagsFilterString = (tags, filters) => {
@@ -37,6 +38,7 @@ const buildTagsFilterString = (tags, filters) => {
       (value) => (tagFiltersString += `${tag.category}/${value.name}`)
     );
   });
+
   return `${tagsFilterString}${globalTagsFilterString}${tagFiltersString}`;
 };
 


### PR DESCRIPTION
Currently in stage-beta, if you add os filters, the system fetch will break because it's not properly adding the versions to the request string. This PR properly creates the fetch request.

It will only work in stage-beta at this point. It is currently not fetching correctly because the backend needs a change. if you filter by centos version 7.9 and rhel version 8.8, it will try to fetch centos versions 7.9 and 8.8 and rhel versions 7.9 and 8.8.