### PR TITLE
fix(RHINENG-2529): show centos versions in os filter

### DIFF
--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -153,6 +153,7 @@ const SystemTable = ({ bulkSelectIds, selectedIds, selectIds }) => {
         isStickyHeader: true,
         onSelect: items.length ? selectIds : null,
       }}
+      showCentosVersions={true}
     />
   );
 };


### PR DESCRIPTION
With this PR, CentOS Linux versions should show up in the os filter dropdown on the inventory table. Go to Available tasks tab and click Run task on one of the available tasks. The systems table will populate there. In stage-preview, you shouldn't see the CentOS Linux versions, but this PR exposes them.