### PR TITLE
fix(RHINENG-2490): bulk select all filtered systems

### DIFF
--- a/src/SmartComponents/RunTaskModal/RunTaskModal.js
+++ b/src/SmartComponents/RunTaskModal/RunTaskModal.js
@@ -42,6 +42,7 @@ const RunTaskModal = ({
   const [taskName, setTaskName] = useState();
   const [executeTaskResult, setExecuteTaskResult] = useState();
   const [createTaskError, setCreateTaskError] = useState({});
+  const [filterSortString, setFilterSortString] = useState('');
 
   useEffect(() => {
     if (isOpen) {
@@ -109,7 +110,7 @@ const RunTaskModal = ({
       }
 
       case 'all': {
-        let results = await fetchSystems(`?limit=${options.total}&offset=0`);
+        let results = await fetchSystems(filterSortString);
         setSelectedIds(results.data.map(({ id }) => id));
         break;
       }
@@ -225,6 +226,7 @@ const RunTaskModal = ({
             bulkSelectIds={bulkSelectIds}
             selectedIds={selectedIds}
             selectIds={selectIds}
+            setFilterSortString={setFilterSortString}
           />
         </React.Fragment>
       )}

--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -12,7 +12,12 @@ import { useDispatch } from 'react-redux';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { generateFilter } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 
-const SystemTable = ({ bulkSelectIds, selectedIds, selectIds }) => {
+const SystemTable = ({
+  bulkSelectIds,
+  selectedIds,
+  selectIds,
+  setFilterSortString,
+}) => {
   const [items, setItems] = useState([]);
   const [total, setTotal] = useState(0);
   const inventory = useRef(null);
@@ -52,6 +57,7 @@ const SystemTable = ({ bulkSelectIds, selectedIds, selectIds }) => {
 
   const getEntities = useGetEntities(onComplete, {
     selectedIds,
+    setFilterSortString,
   });
 
   const mergedColumns = (defaultColumns) =>
@@ -162,6 +168,7 @@ SystemTable.propTypes = {
   bulkSelectIds: propTypes.func,
   selectedIds: propTypes.array,
   selectIds: propTypes.func,
+  setFilterSortString: propTypes.func,
 };
 
 export default SystemTable;

--- a/src/SmartComponents/SystemTable/hooks.js
+++ b/src/SmartComponents/SystemTable/hooks.js
@@ -1,7 +1,10 @@
 import { fetchSystems } from '../../../api';
 import { buildFilterSortString } from './helpers';
 
-export const useGetEntities = (onComplete, { selectedIds }) => {
+export const useGetEntities = (
+  onComplete,
+  { selectedIds, setFilterSortString }
+) => {
   return async (_items, config) => {
     const {
       page,
@@ -29,6 +32,12 @@ export const useGetEntities = (onComplete, { selectedIds }) => {
       data,
       meta: { count },
     } = fetchedEntities || {};
+
+    const bulkFilterSortString = filterSortString.replace(
+      /(limit=)[^&]+/,
+      '$1' + count
+    );
+    setFilterSortString(bulkFilterSortString);
 
     onComplete && onComplete(fetchedEntities);
 


### PR DESCRIPTION
When you're selecting systems to run a task on, if you filter the systems and then try to select all, it doesn't properly select all of the filtered systems. It selects the correct amount, but only based on a fetch of all systems and not the filtered systems.