### PR TITLE
fix(RHINENG-2581): update os filter request to api

### DIFF
--- a/src/SmartComponents/SystemTable/helpers.js
+++ b/src/SmartComponents/SystemTable/helpers.js
@@ -16,7 +16,7 @@ const buildFilterString = (filters) => {
     : '';
 
   filters.osFilter?.forEach(({ osName, value }) => {
-    osFiltersString += `&os_name=${osName}&os_version=${value}`;
+    osFiltersString += `&operating_system=${osName}|${value}`;
   });
 
   return `${displayNameFilter}${osFiltersString}`;


### PR DESCRIPTION
The current os request to tasks/system api sends the os name and version separately. When a centos and rhel version are added to the request, it fetches the versions for both os names. So if you request `os_name=RHEL&os_version=7.9&os_name=CentOS Linux&os_version=8.3`, you will systems that match RHEL 7.9, RHEL 8.3, CentOS Linux 7.9, and CentOS Linux 8.3.

A new MR on the backend updates the request so you request the os name and version together; like, `&operating_system=RHEL|7.9&operating_system=CentOS Linux|8.3`.