### PR TITLE
fix(RHINENG-2644): Add dictionary for leapp-upgrade

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
+++ b/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
@@ -113,8 +113,72 @@ const leapppreupgradeSeverityMap = {
   },
 };
 
+const leappupgradeSeverityMap = {
+  high: {
+    text: 'High risk',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2000,
+  },
+  medium: {
+    text: 'Medium risk',
+    icon: <ExclamationTriangleIcon color="#F0AB00" />,
+    titleColor: '#795000',
+    severityColor: 'orange',
+    severityLevel: 1500,
+  },
+  low: {
+    text: 'Low risk',
+    icon: <ExclamationTriangleIcon color="#F0AB00" />,
+    titleColor: '#795000',
+    severityColor: 'orange',
+    severityLevel: 1000,
+  },
+  info: {
+    text: 'Info',
+    icon: <InfoCircleIcon color="#2B9AF3" />,
+    titleColor: '#002952',
+    severityColor: 'blue',
+    severityLevel: 500,
+  },
+};
+
+const leappupgradestageSeverityMap = {
+  high: {
+    text: 'High risk',
+    icon: <ExclamationCircleIcon color="#C9190B" />,
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2000,
+  },
+  medium: {
+    text: 'Medium risk',
+    icon: <ExclamationTriangleIcon color="#F0AB00" />,
+    titleColor: '#795000',
+    severityColor: 'orange',
+    severityLevel: 1500,
+  },
+  low: {
+    text: 'Low risk',
+    icon: <ExclamationTriangleIcon color="#F0AB00" />,
+    titleColor: '#795000',
+    severityColor: 'orange',
+    severityLevel: 1000,
+  },
+  info: {
+    text: 'Info',
+    icon: <InfoCircleIcon color="#2B9AF3" />,
+    titleColor: '#002952',
+    severityColor: 'blue',
+    severityLevel: 500,
+  },
+};
+
 export default {
   converttorhelpreanalysisSeverityMap,
   converttorhelpreanalysisstageSeverityMap,
   leapppreupgradeSeverityMap,
+  leappupgradeSeverityMap,
+  leappupgradestageSeverityMap,
 };


### PR DESCRIPTION
There is a new task called leapp-upgrade that is like leapp-preupgrade. Certain leapp-upgrades task details will currently fail because there isn't a dictionary to map the severities to the visual items in the jobs table. This PR adds a dictionary.

I'm not sure if I can run this task on a system yet in order to return data I would need to test that this fix works. I'm hoping to push this to prod where I know an existing task fails and test it there. This PR won't break prod if it gets pushed up and doesn't fix the issue.