### PR TITLE
fix(RHELC-1186): diagnosis doesn't show for pre-conversion

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -35,3 +35,7 @@
   font-size: '14px';
   font-weight: 500;
 }
+
+.remediations-font-family {
+  font-family: 'overpass-mono', sans-serif;
+}

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/EntryDetails.js
@@ -21,28 +21,18 @@ const EntryDetails = ({ entry, taskConstantMapper }) => {
     );
   };
 
-  const renderDiagnosisDetails = () => {
-    return (
-      <div>
-        <span>{detail.diagnosis.context}</span>
-      </div>
-    );
-  };
-
-  const renderRemediationsDetails = () => {
-    return detail.remediations.map((remediation, index) => {
-      let remediationKey = `remediation-${index}`;
+  const renderResolutionDetails = (content, type, classname) => {
+    return content.map((item, index) => {
+      let key = `${type}-${index}`;
       return (
-        <div key={remediationKey}>
+        <div key={key}>
           {index > 0 ? (
             <span>
               <br />
             </span>
           ) : null}
-          <span style={{ fontFamily: 'overpass-mono' }}>
-            {remediation.type
-              ? `[${remediation.type}] ${remediation.context}`
-              : `${remediation.context}`}
+          <span className={classname}>
+            {item.type ? `[${item.type}] ${item.context}` : `${item.context}`}
           </span>
         </div>
       );
@@ -75,11 +65,21 @@ const EntryDetails = ({ entry, taskConstantMapper }) => {
     return (
       <React.Fragment>
         {createGrid('Summary', summary)}
-        {detail?.diagnosis?.context
-          ? createGrid('Diagnosis', renderDiagnosisDetails)
+        {detail?.diagnosis && detail?.diagnosis?.[0]?.context !== ''
+          ? createGrid(
+              'Diagnosis',
+              renderResolutionDetails(detail.diagnosis, 'diagnosis')
+            )
           : null}
-        {detail?.remediations && detail?.remediations[0]?.context !== ''
-          ? createGrid('Remediation', renderRemediationsDetails)
+        {detail?.remediations && detail?.remediations?.[0]?.context !== ''
+          ? createGrid(
+              'Remediation',
+              renderResolutionDetails(
+                detail.remediations,
+                'remediations',
+                'remediations-font-family'
+              )
+            )
           : null}
         {createGrid('Key', key)}
       </React.Fragment>

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -2317,7 +2317,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                               >
                                 <div>
                                   <span
-                                    style="font-family: overpass-mono;"
+                                    class="remediations-font-family"
                                   >
                                     [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
                                   </span>
@@ -2496,7 +2496,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                               >
                                 <div>
                                   <span
-                                    style="font-family: overpass-mono;"
+                                    class="remediations-font-family"
                                   >
                                     [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
                                   </span>
@@ -2675,7 +2675,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                               >
                                 <div>
                                   <span
-                                    style="font-family: overpass-mono;"
+                                    class="remediations-font-family"
                                   >
                                     [hint] If you wish to receive updates for the latest released version of the target system, run \`subscription-manager release --unset\` after the upgrade.
                                   </span>
@@ -3232,7 +3232,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                               >
                                 <div>
                                   <span
-                                    style="font-family: overpass-mono;"
+                                    class="remediations-font-family"
                                   >
                                     [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
                                   </span>
@@ -3411,7 +3411,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                               >
                                 <div>
                                   <span
-                                    style="font-family: overpass-mono;"
+                                    class="remediations-font-family"
                                   >
                                     [hint] Set AllowZoneDrifting=no in /etc/firewalld/firewalld.conf
                                   </span>
@@ -3421,7 +3421,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     <br />
                                   </span>
                                   <span
-                                    style="font-family: overpass-mono;"
+                                    class="remediations-font-family"
                                   >
                                     [command] sed -i "s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/" /etc/firewalld/firewalld.conf
                                   </span>
@@ -3600,7 +3600,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                               >
                                 <div>
                                   <span
-                                    style="font-family: overpass-mono;"
+                                    class="remediations-font-family"
                                   >
                                     [hint] Consult the VDO to LVM conversion process documentation for how to perform the conversion.
                                   </span>
@@ -3779,7 +3779,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                               >
                                 <div>
                                   <span
-                                    style="font-family: overpass-mono;"
+                                    class="remediations-font-family"
                                   >
                                     [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
                                   </span>


### PR DESCRIPTION
We were incorrectly checking the `detail.diagnosis` value as an object when it was, in fact, an array. This PR combines some code for simplicity and properly checks the value and displays it.

To test, in insights account, check `executed_task/5330`. You should be able to expand some of the job details and see that the `diagnosis` field doesn't populate in the details. When running this PR, you should see it.

Please also check that `executed_task/5331` also works correctly by continuing to show `remediations` field.