### PR TITLE
chore(HMS-2110): Add alert to backup for pre-conversions

### DIFF
--- a/src/SmartComponents/RunTaskModal/RunTaskModal.js
+++ b/src/SmartComponents/RunTaskModal/RunTaskModal.js
@@ -26,6 +26,7 @@ import ReactMarkdown from 'react-markdown';
 import { dispatchNotification } from '../../Utilities/Dispatcher';
 import { EXECUTE_TASK_NOTIFICATION } from '../../constants';
 import { isError } from '../completedTaskDetailsHelpers';
+import warningConstants from '../warningConstants';
 
 const RunTaskModal = ({
   description,
@@ -43,6 +44,10 @@ const RunTaskModal = ({
   const [executeTaskResult, setExecuteTaskResult] = useState();
   const [createTaskError, setCreateTaskError] = useState({});
   const [filterSortString, setFilterSortString] = useState('');
+
+  const warningConstantMapper = `${slug
+    ?.toUpperCase()
+    .replace(/-/g, '_')}_WARNING`;
 
   useEffect(() => {
     if (isOpen) {
@@ -221,6 +226,7 @@ const RunTaskModal = ({
           <div style={{ paddingBottom: '8px' }}>
             <b>Systems to run tasks on</b>
           </div>
+          {warningConstants[warningConstantMapper]}
           <Alert variant="info" isInline title={INFO_ALERT_SYSTEMS} />
           <SystemTable
             bulkSelectIds={bulkSelectIds}

--- a/src/SmartComponents/warningConstants.js
+++ b/src/SmartComponents/warningConstants.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Alert } from '@patternfly/react-core/dist/js/components/Alert';
+
+const CONVERT_TO_RHEL_PREANALYSIS_WARNING = (
+  <Alert
+    style={{ marginBottom: '8px' }}
+    isInline
+    variant="warning"
+    title="System backup is recommended."
+  >
+    <p>
+      The pre-conversion analysis task modifies the systems during the analysis
+      and then rolls back these changes when the analysis is complete. In rare
+      cases, this rollback can fail. It is highly recommended that you create a
+      system backup and verify that you can restore your system from the backup
+      before running this task.
+    </p>
+  </Alert>
+);
+
+export default {
+  CONVERT_TO_RHEL_PREANALYSIS_WARNING,
+};


### PR DESCRIPTION
For pre-conversions, we need to include a warning message about backing up systems. I've made this flexible so different tasks can have different alerts. I suspect conversions will need a similar warning.

To test, go to tasks in stage-preview, go to `Available` tab and click the Run task button for multiple tasks. You should only see the warning alert for pre-conversion task. You should also test this functionality by going to the `Activity` tab, and clicking the kebab, and `Run this task again` on multiple tasks. Also when you open specific tasks from the Activity table, there is a `Run this task again` button in the top right. This functionality should also be here.