### PR TITLE
fix(RHINENG-3105): loading rows not showing on activity delete

### DIFF
--- a/src/Utilities/hooks/useTableTools/__tests__/useRowsBuilder.tests.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/useRowsBuilder.tests.js
@@ -5,11 +5,28 @@ import useRowsBuilder from '../useRowsBuilder';
 
 describe('useRowsBuilder', () => {
   it('returns a rows configuration', () => {
+    const paginator = jest.fn((items) => items);
+
     const { result } = renderHook(() =>
       useRowsBuilder(items, columns, {
         rowTransformer: [undefined],
+        isTableLoading: false,
+        paginator: paginator,
       })
     );
+    expect(paginator).toHaveBeenCalled();
     expect(result).toMatchSnapshot();
+  });
+
+  it('doesnt paginate when the table is loading', () => {
+    const paginator = jest.fn();
+    renderHook(() =>
+      useRowsBuilder(items, columns, {
+        rowTransformer: [undefined],
+        isTableLoading: true,
+        paginator: paginator,
+      })
+    );
+    expect(paginator).not.toHaveBeenCalled();
   });
 });

--- a/src/Utilities/hooks/useTableTools/useRowsBuilder.js
+++ b/src/Utilities/hooks/useTableTools/useRowsBuilder.js
@@ -35,9 +35,10 @@ const useRowsBuilder = (items, columns, options = {}) => {
     ? options.sorter(filteredItems)
     : filteredItems;
 
-  const paginatedItems = options?.paginator
-    ? options?.paginator(filteredItems)
-    : sortedItems;
+  const paginatedItems =
+    options?.paginator && !options?.isTableLoading
+      ? options?.paginator(filteredItems)
+      : sortedItems;
 
   let parentIndex = -1;
   let row;

--- a/src/Utilities/hooks/useTableTools/useTableTools.js
+++ b/src/Utilities/hooks/useTableTools/useTableTools.js
@@ -65,6 +65,7 @@ const useTableTools = (
     paginator,
     filter,
     sorter,
+    isTableLoading,
   });
 
   const toolbarProps = {


### PR DESCRIPTION
**Description of Problem**
There's a small bug in Tasks on the Activity table. When you're on any page other than 1 and you delete an activity, the table shows a No results empty state instead of loading rows.

**How reproducible**
Always

**Steps to Reproduce**
- Go to Tasks
- Click Activity Tab
- Go to page 2+
- Delete an activity via the kebab

**Actual Behavior**
Table shows a "No results" empty state.

**Expected Behavior**
Should show loading rows

**Additional info**
This happens because the table component receives an array of 5 loading row components. Then it tries to paginate that data, and the `page` is currently set to a page over page 1, so if you're looking at 10 per page and you're on page 2, the 5 items sent in get paginated out.

This fix will skip pagination if the table is in a loading state.