### PR TITLE
chore(HMS-3012): Temporarily hide column

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/Columns.js
+++ b/src/SmartComponents/CompletedTaskDetails/Columns.js
@@ -64,5 +64,6 @@ export const MessageColumn = {
 };
 
 export const exportableColumns = [SystemColumn, StatusColumn, MessageColumn];
+export const conversionColumns = [SystemColumn, MessageColumn];
 
 export default [SystemColumn, StatusColumn, MessageColumn];

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -17,7 +17,7 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import columns, { exportableColumns } from './Columns';
+import columns, { conversionColumns, exportableColumns } from './Columns';
 import { statusFilters, systemFilter } from './Filters';
 import {
   COMPLETED_INFO_PANEL,
@@ -140,6 +140,25 @@ const CompletedTaskDetails = () => {
     [completedTaskJobs]
   );
 
+  const isConversionTask = () => {
+    if (
+      completedTaskDetails.task_slug === 'convert-to-rhel-conversion-stage' ||
+      completedTaskDetails.task_slug === 'convert-to-rhel-conversion'
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  const buildFilterConfig = () => {
+    if (isConversionTask()) {
+      return { filterConfig: [...systemFilter] };
+    } else {
+      return { filterConfig: [...systemFilter, ...statusFilters] };
+    }
+  };
+
   return (
     <div>
       <RunTaskModal
@@ -230,16 +249,16 @@ const CompletedTaskDetails = () => {
                 <TasksTables
                   label={`${completedTaskDetails.id}-completed-jobs`}
                   ouiaId={`${completedTaskDetails.id}-completed-jobs-table`}
-                  columns={columns}
+                  columns={isConversionTask() ? conversionColumns : columns}
                   items={completedTaskJobs}
-                  filters={{
-                    filterConfig: [...systemFilter, ...statusFilters],
-                  }}
+                  filters={buildFilterConfig()}
                   options={{
                     ...TASKS_TABLE_DEFAULTS,
                     exportable: {
                       ...TASKS_TABLE_DEFAULTS.exportable,
-                      columns: exportableColumns,
+                      columns: isConversionTask()
+                        ? conversionColumns
+                        : exportableColumns,
                     },
                     detailsComponent: completedTaskJobs.some((job) =>
                       hasDetails(job)


### PR DESCRIPTION
We need to hide the status column for convert to rhel tasks until we nail down a redesign for the column. It's currently confusing with the "Success" status when there are inhibitors.

To test:

1. Go to Activity tab and find a `Convert2RHEL Conversion(Stage)` task
2. Click it
3. See that the status column is not visible, and that you can't filter on status
4. Go to Activity tab and find any other task
5. Click it
6. See that the status column is visible, and that you CAN filter on status.