### PR TITLE
feat(RHIN-1101): Add Input Parameters to Tasks

### DIFF
--- a/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
+++ b/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
@@ -13,24 +13,22 @@ const ExecuteTaskButton = ({
   taskName,
   variant,
 }) => {
-  const buildApiBody = () => {
-    let apiBody = {
-      task: slug,
-      hosts: ids,
-      name: taskName,
-    };
-
-    if (definedParameters) {
-      apiBody.parameters = definedParameters.map((param) => {
-        return { key: param.key, value: param.value };
-      });
-    }
-
-    return apiBody;
+  const apiBody = {
+    task: slug,
+    hosts: ids,
+    name: taskName,
+    ...(definedParameters
+      ? {
+          parameters: definedParameters.map((param) => ({
+            key: param.key,
+            value: param.value,
+          })),
+        }
+      : {}),
   };
 
   const submitTask = async () => {
-    let result = await executeTask(buildApiBody());
+    let result = await executeTask(apiBody);
     setExecuteTaskResult(result);
   };
 

--- a/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
+++ b/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
@@ -5,18 +5,28 @@ import { executeTask } from '../../../api';
 
 const ExecuteTaskButton = ({
   classname,
+  definedParameters,
   ids,
+  isDisabled,
   setExecuteTaskResult,
   slug,
   taskName,
   variant,
 }) => {
   const buildApiBody = () => {
-    return {
+    let apiBody = {
       task: slug,
       hosts: ids,
       name: taskName,
     };
+
+    if (definedParameters) {
+      apiBody.parameters = definedParameters.map((param) => {
+        return { key: param.key, value: param.value };
+      });
+    }
+
+    return apiBody;
   };
 
   const submitTask = async () => {
@@ -30,7 +40,7 @@ const ExecuteTaskButton = ({
       className={classname}
       variant={variant}
       onClick={() => submitTask()}
-      isDisabled={!ids?.length || taskName.length === 0}
+      isDisabled={isDisabled}
     >
       Execute task
     </Button>
@@ -39,7 +49,9 @@ const ExecuteTaskButton = ({
 
 ExecuteTaskButton.propTypes = {
   classname: propTypes.string,
+  definedParameters: propTypes.array,
   ids: propTypes.array,
+  isDisabled: propTypes.func,
   setExecuteTaskResult: propTypes.func,
   slug: propTypes.string,
   taskName: propTypes.string,

--- a/src/SmartComponents/ActivityTable/ActivityTable.js
+++ b/src/SmartComponents/ActivityTable/ActivityTable.js
@@ -160,17 +160,20 @@ const ActivityTable = () => {
 
   return (
     <React.Fragment>
-      <RunTaskModal
-        description={activityDetails.task_description}
-        error={taskError}
-        isOpen={runTaskModalOpened}
-        selectedSystems={selectedSystems}
-        setIsRunTaskAgain={setIsRunTaskAgain}
-        setModalOpened={setRunTaskModalOpened}
-        slug={activityDetails.task_slug}
-        title={activityDetails.task_title}
-        name={activityDetails.name}
-      />
+      {runTaskModalOpened && (
+        <RunTaskModal
+          description={activityDetails.task_description}
+          error={taskError}
+          isOpen={runTaskModalOpened}
+          parameters={activityDetails.parameters}
+          selectedSystems={selectedSystems}
+          setIsRunTaskAgain={setIsRunTaskAgain}
+          setModalOpened={setRunTaskModalOpened}
+          slug={activityDetails.task_slug}
+          title={activityDetails.task_title}
+          name={activityDetails.name}
+        />
+      )}
       <DeleteCancelTaskModal
         id={taskDetails.id}
         isOpen={isDeleteCancelModalOpened}

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -161,16 +161,19 @@ const CompletedTaskDetails = () => {
 
   return (
     <div>
-      <RunTaskModal
-        description={completedTaskDetails.task_description}
-        error={error}
-        isOpen={runTaskModalOpened}
-        selectedSystems={selectedSystems}
-        setModalOpened={setRunTaskModalOpened}
-        slug={completedTaskDetails.task_slug}
-        title={completedTaskDetails.name}
-        name={completedTaskDetails.name}
-      />
+      {runTaskModalOpened && (
+        <RunTaskModal
+          description={completedTaskDetails.task_description}
+          error={error}
+          isOpen={runTaskModalOpened}
+          parameters={completedTaskDetails.parameters}
+          selectedSystems={selectedSystems}
+          setModalOpened={setRunTaskModalOpened}
+          slug={completedTaskDetails.task_slug}
+          title={completedTaskDetails.name}
+          name={completedTaskDetails.name}
+        />
+      )}
       <DeleteCancelTaskModal
         id={completedTaskDetails.id}
         isOpen={isDeleteCancelModalOpened}

--- a/src/SmartComponents/RunTaskModal/InputParameters.js
+++ b/src/SmartComponents/RunTaskModal/InputParameters.js
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import propTypes from 'prop-types';
+import {
+  Form,
+  FormGroup,
+} from '@patternfly/react-core/dist/js/components/Form';
+import { TextInput } from '@patternfly/react-core/dist/js/components/TextInput';
+import { ValidatedOptions } from '@patternfly/react-core/dist/js/helpers/constants';
+
+const InputParameter = ({ parameter, setDefinedParameters }) => {
+  const [paramText, setParamText] = useState(
+    parameter.default || parameter.value
+  );
+
+  const updateParams = (text) => {
+    setParamText(text);
+    setDefinedParameters((prevState) => {
+      const newState = prevState.map((param) => {
+        if (param.key === parameter.key) {
+          let newDefinedParam = { key: param.key, value: text };
+          if (parameter.required) {
+            newDefinedParam.validated = newDefinedParam.value.length
+              ? true
+              : false;
+          }
+
+          return newDefinedParam;
+        } else {
+          return param;
+        }
+      });
+      return newState;
+    });
+  };
+
+  return (
+    <Form className="pf-u-pb-lg">
+      <FormGroup
+        label={parameter.key}
+        isRequired={parameter.required}
+        type="text"
+        helperText={parameter.description}
+        helperTextInvalid={
+          parameter.required ? 'This parameter is required' : null
+        }
+        fieldId="name"
+        validated={
+          parameter.required && paramText === '' ? ValidatedOptions.error : null
+        }
+      >
+        <TextInput
+          value={paramText}
+          type="text"
+          onChange={updateParams}
+          validated={
+            parameter.required && paramText === ''
+              ? ValidatedOptions.error
+              : null
+          }
+          aria-label={`${parameter.key}-input`}
+        />
+      </FormGroup>
+    </Form>
+  );
+};
+
+InputParameter.propTypes = {
+  parameter: propTypes.object,
+  setDefinedParameters: propTypes.func,
+};
+
+const InputParameters = ({ parameters, setDefinedParameters }) => {
+  return parameters.map((param) => {
+    return (
+      <InputParameter
+        key={param.key}
+        aria-label={param.key}
+        parameter={param}
+        setDefinedParameters={setDefinedParameters}
+      />
+    );
+  });
+};
+
+InputParameters.propTypes = {
+  parameters: propTypes.array,
+  setDefinedParameters: propTypes.func,
+};
+
+export default InputParameters;

--- a/src/SmartComponents/RunTaskModal/InputParameters.js
+++ b/src/SmartComponents/RunTaskModal/InputParameters.js
@@ -7,7 +7,7 @@ import {
 import { TextInput } from '@patternfly/react-core/dist/js/components/TextInput';
 import { ValidatedOptions } from '@patternfly/react-core/dist/js/helpers/constants';
 
-const InputParameter = ({ parameter, setDefinedParameters }) => {
+export const InputParameter = ({ parameter, setDefinedParameters }) => {
   const [paramText, setParamText] = useState(
     parameter.default || parameter.value
   );

--- a/src/SmartComponents/RunTaskModal/RunTaskModalBody.js
+++ b/src/SmartComponents/RunTaskModal/RunTaskModalBody.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import SystemsSelect from './SystemsSelect';
+import InputParameters from './InputParameters';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { TASK_ERROR } from '../../constants';
+import EmptyStateDisplay from '../../PresentationalComponents/EmptyStateDisplay/EmptyStateDisplay';
+
+const RunTaskModalBody = ({
+  areSystemsSelected,
+  createTaskError,
+  description,
+  error,
+  parameters,
+  selectedIds,
+  setDefinedParameters,
+  setSelectedIds,
+  setTaskName,
+  slug,
+  taskName,
+}) => {
+  return error ? (
+    <EmptyStateDisplay
+      icon={ExclamationCircleIcon}
+      color="#c9190b"
+      title={'This task cannot be displayed'}
+      text={TASK_ERROR}
+      error={`Error ${error?.response?.status}: ${error?.message}`}
+    />
+  ) : !areSystemsSelected ? (
+    <SystemsSelect
+      createTaskError={createTaskError}
+      description={description}
+      selectedIds={selectedIds}
+      setSelectedIds={setSelectedIds}
+      setTaskName={setTaskName}
+      slug={slug}
+      taskName={taskName}
+    />
+  ) : (
+    <InputParameters
+      parameters={parameters}
+      setDefinedParameters={setDefinedParameters}
+    />
+  );
+};
+
+RunTaskModalBody.propTypes = {
+  areSystemsSelected: propTypes.bool,
+  createTaskError: propTypes.object,
+  description: propTypes.oneOfType([propTypes.string, propTypes.node]),
+  error: propTypes.object,
+  parameters: propTypes.array,
+  selectedIds: propTypes.array,
+  setDefinedParameters: propTypes.func,
+  setSelectedIds: propTypes.func,
+  setTaskName: propTypes.func,
+  slug: propTypes.string,
+  taskName: propTypes.string,
+};
+
+export default RunTaskModalBody;

--- a/src/SmartComponents/RunTaskModal/SystemsSelect.js
+++ b/src/SmartComponents/RunTaskModal/SystemsSelect.js
@@ -15,8 +15,8 @@ import {
   TASKS_API_ROOT,
 } from '../../constants';
 import ReactMarkdown from 'react-markdown';
-import { fetchSystems } from '../../../api';
 import warningConstants from '../warningConstants';
+import { useSystemBulkSelect } from './hooks/useBulkSystemSelect';
 
 const SystemsSelect = ({
   createTaskError,
@@ -33,43 +33,11 @@ const SystemsSelect = ({
 
   const [filterSortString, setFilterSortString] = useState('');
 
-  const bulkSelectIds = async (type, options) => {
-    let newSelectedIds = [...selectedIds];
-
-    switch (type) {
-      case 'none': {
-        setSelectedIds([]);
-        break;
-      }
-
-      case 'page': {
-        options.items.forEach((item) => {
-          if (!newSelectedIds.includes(item.id)) {
-            newSelectedIds.push(item.id);
-          }
-        });
-
-        setSelectedIds(newSelectedIds);
-        break;
-      }
-
-      case 'all': {
-        let results = await fetchSystems(filterSortString);
-        setSelectedIds(results.data.map(({ id }) => id));
-        break;
-      }
-    }
-  };
-
-  const selectIds = (_event, _isSelected, _index, entity) => {
-    let newSelectedIds = [...selectedIds];
-
-    !newSelectedIds.includes(entity.id)
-      ? newSelectedIds.push(entity.id)
-      : newSelectedIds.splice(newSelectedIds.indexOf(entity.id), 1);
-
-    setSelectedIds(newSelectedIds);
-  };
+  const { bulkSelectIds, selectIds } = useSystemBulkSelect(
+    selectedIds,
+    setSelectedIds,
+    filterSortString
+  );
 
   return (
     <React.Fragment>

--- a/src/SmartComponents/RunTaskModal/SystemsSelect.js
+++ b/src/SmartComponents/RunTaskModal/SystemsSelect.js
@@ -1,0 +1,153 @@
+import React, { useState } from 'react';
+import propTypes from 'prop-types';
+import { Alert } from '@patternfly/react-core/dist/js/components/Alert';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/js/layouts/Flex';
+import {
+  Form,
+  FormGroup,
+} from '@patternfly/react-core/dist/js/components/Form';
+import { TextInput } from '@patternfly/react-core/dist/js/components/TextInput';
+import { ValidatedOptions } from '@patternfly/react-core/dist/js/helpers/constants';
+import SystemTable from '../SystemTable/SystemTable';
+import {
+  AVAILABLE_TASKS_ROOT,
+  INFO_ALERT_SYSTEMS,
+  TASKS_API_ROOT,
+} from '../../constants';
+import ReactMarkdown from 'react-markdown';
+import { fetchSystems } from '../../../api';
+import warningConstants from '../warningConstants';
+
+const SystemsSelect = ({
+  createTaskError,
+  description,
+  selectedIds,
+  setSelectedIds,
+  setTaskName,
+  slug,
+  taskName,
+}) => {
+  const warningConstantMapper = `${slug
+    ?.toUpperCase()
+    .replace(/-/g, '_')}_WARNING`;
+
+  const [filterSortString, setFilterSortString] = useState('');
+
+  const bulkSelectIds = async (type, options) => {
+    let newSelectedIds = [...selectedIds];
+
+    switch (type) {
+      case 'none': {
+        setSelectedIds([]);
+        break;
+      }
+
+      case 'page': {
+        options.items.forEach((item) => {
+          if (!newSelectedIds.includes(item.id)) {
+            newSelectedIds.push(item.id);
+          }
+        });
+
+        setSelectedIds(newSelectedIds);
+        break;
+      }
+
+      case 'all': {
+        let results = await fetchSystems(filterSortString);
+        setSelectedIds(results.data.map(({ id }) => id));
+        break;
+      }
+    }
+  };
+
+  const selectIds = (_event, _isSelected, _index, entity) => {
+    let newSelectedIds = [...selectedIds];
+
+    !newSelectedIds.includes(entity.id)
+      ? newSelectedIds.push(entity.id)
+      : newSelectedIds.splice(newSelectedIds.indexOf(entity.id), 1);
+
+    setSelectedIds(newSelectedIds);
+  };
+
+  return (
+    <React.Fragment>
+      <Flex>
+        <FlexItem>
+          <b>Task description</b>
+        </FlexItem>
+      </Flex>
+      <Flex style={{ paddingBottom: '8px' }}>
+        <FlexItem style={{ width: '100%' }}>
+          <ReactMarkdown>{description}</ReactMarkdown>
+        </FlexItem>
+      </Flex>
+      <Flex>
+        <FlexItem>
+          <a href={`${TASKS_API_ROOT}${AVAILABLE_TASKS_ROOT}/${slug}/playbook`}>
+            Download preview of playbook
+          </a>
+        </FlexItem>
+      </Flex>
+      <br />
+      <div>
+        <Form>
+          <FormGroup
+            label="Task name"
+            isRequired
+            type="text"
+            helperTextInvalid={
+              Object.prototype.hasOwnProperty.call(
+                createTaskError,
+                'statusText'
+              ) && createTaskError.statusText
+            }
+            fieldId="name"
+            validated={
+              Object.prototype.hasOwnProperty.call(createTaskError, 'status') &&
+              'error'
+            }
+          >
+            <TextInput
+              value={taskName}
+              type="text"
+              onChange={setTaskName}
+              validated={
+                Object.prototype.hasOwnProperty.call(
+                  createTaskError,
+                  'status'
+                ) && ValidatedOptions.error
+              }
+              aria-label="task name"
+            />
+          </FormGroup>
+        </Form>
+      </div>
+      <br />
+      <div style={{ paddingBottom: '8px' }}>
+        <b>Systems to run tasks on</b>
+      </div>
+      {warningConstants[warningConstantMapper]}
+      <Alert variant="info" isInline title={INFO_ALERT_SYSTEMS} />
+      <SystemTable
+        bulkSelectIds={bulkSelectIds}
+        selectedIds={selectedIds}
+        selectIds={selectIds}
+        setFilterSortString={setFilterSortString}
+      />
+    </React.Fragment>
+  );
+};
+
+SystemsSelect.propTypes = {
+  createTaskError: propTypes.object,
+  description: propTypes.any,
+  selectedIds: propTypes.array,
+  setSelectedIds: propTypes.func,
+  setTaskName: propTypes.func,
+  slug: propTypes.string,
+  taskName: propTypes.string,
+};
+
+export default SystemsSelect;

--- a/src/SmartComponents/RunTaskModal/__tests__/InputParameters.tests.js
+++ b/src/SmartComponents/RunTaskModal/__tests__/InputParameters.tests.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { init } from '../../../store';
+import fixtures from './__fixtures__/RunTaskModal.fixtures';
+
+import InputParameters, { InputParameter } from '../InputParameters';
+
+describe('InputParameters', () => {
+  let props;
+  const store = init().getStore();
+
+  beforeEach(() => {
+    props = {
+      parameters: fixtures.parameters,
+      setDefinedParameters: jest.fn(),
+    };
+  });
+
+  it('should render InputParameters', async () => {
+    render(
+      <Provider store={store}>
+        <InputParameters {...props} />
+      </Provider>
+    );
+
+    expect(screen.getByText('path')).toBeInTheDocument();
+    expect(screen.getByText('this-is-your-label')).toBeInTheDocument();
+    expect(screen.getByText('Add_Tags')).toBeInTheDocument();
+    expect(screen.getByText('Remove_Tags')).toBeInTheDocument();
+    expect(screen.getByText('blah')).toBeInTheDocument();
+  });
+
+  it('should call setDefinedParameters', async () => {
+    render(
+      <Provider store={store}>
+        <InputParameters {...props} />
+      </Provider>
+    );
+
+    const input = screen.getByLabelText('path-input');
+    await waitFor(() =>
+      fireEvent.change(input, { target: { value: 'bogus/path' } })
+    );
+    expect(props.setDefinedParameters).toHaveBeenCalled();
+  });
+
+  it('should show validation when input parameter is empty', async () => {
+    render(
+      <Provider store={store}>
+        <InputParameters {...props} />
+      </Provider>
+    );
+
+    const input = screen.getByLabelText('path-input');
+    await waitFor(() => fireEvent.change(input, { target: { value: 'a' } }));
+    await waitFor(() => fireEvent.change(input, { target: { value: '' } }));
+
+    expect(screen.getByText('This parameter is required')).toBeInTheDocument();
+  });
+});
+
+describe('InputParameter', () => {
+  let props;
+  const store = init().getStore();
+
+  beforeEach(() => {
+    props = {
+      parameter: fixtures.parameters[0],
+      setDefinedParameters: jest.fn(),
+    };
+  });
+
+  it('should render InputParameter', async () => {
+    render(
+      <Provider store={store}>
+        <InputParameter {...props} />
+      </Provider>
+    );
+
+    expect(screen.getByText('path')).toBeInTheDocument();
+  });
+
+  it.skip('should call setDefinedParameters', async () => {
+    /*const setState = jest.fn();
+    jest
+      .spyOn(React, 'useState')
+      .mockImplementation((initState) => [initState, props.setDefinedParameters]);*/
+    const spy = jest.spyOn(props, 'setDefinedParameters');
+    /*spy.mockImplementation(
+      (prevState = fixtures.parameters) => fixtures.pathFilledParameters
+    );*/
+    render(
+      <Provider store={store}>
+        <InputParameter {...props} />
+      </Provider>
+    );
+
+    const input = screen.getByLabelText('path-input');
+    await waitFor(() =>
+      fireEvent.change(input, { target: { value: 'bogus/path' } })
+    );
+    expect(spy).toHaveBeenCalledWith(fixtures.pathFilledParameters);
+  });
+});

--- a/src/SmartComponents/RunTaskModal/__tests__/RunTaskModal.fixtures.js
+++ b/src/SmartComponents/RunTaskModal/__tests__/RunTaskModal.fixtures.js
@@ -1,0 +1,38 @@
+const parameters = [
+  {
+    default: null,
+    description: 'a file path needed by the playbook',
+    key: 'path',
+    required: true,
+  },
+  {
+    default: 'This is the default',
+    description: 'This is your help text',
+    key: 'this-is-your-label',
+    required: true,
+  },
+  {
+    default: null,
+    description:
+      'Add the following tags to systems. You can add more by using commas.',
+    key: 'Add_Tags',
+    required: false,
+  },
+  {
+    default: null,
+    description:
+      'Remove the following tags to systems if they match exactly something found. You can add more by using commas.',
+    key: 'Remove_Tags',
+    required: false,
+  },
+  {
+    default: null,
+    description: 'This is more help text',
+    key: 'blah',
+    required: false,
+  },
+];
+
+export default {
+  parameters,
+};

--- a/src/SmartComponents/RunTaskModal/__tests__/RunTaskModal.tests.js
+++ b/src/SmartComponents/RunTaskModal/__tests__/RunTaskModal.tests.js
@@ -2,15 +2,15 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { init } from '../../../store';
-import fixtures from './RunTaskModal.fixtures';
-/*import { fetchSystems } from '../../../../api';
-import { systemsMock } from '../../SystemTable/__tests__/__fixtures__/SystemTable.fixtures';*/
+import fixtures from './__fixtures__/RunTaskModal.fixtures';
+import { fetchSystems } from '../../../../api';
+import { systemsMock } from '../../SystemTable/__tests__/__fixtures__/SystemTable.fixtures';
 
 import RunTaskModal from '../RunTaskModal';
 import userEvent from '@testing-library/user-event';
 
 jest.mock('../../../Utilities/Dispatcher');
-//jest.mock('../../../../api');
+jest.mock('../../../../api');
 jest.mock('../../SystemTable/hooks', () => {
   const systemsMock = [
     {
@@ -58,11 +58,11 @@ describe('RunTaskModal', () => {
   });
 
   it.skip('should render execute button disabled with no name or systems selected', async () => {
-    /*fetchSystems.mockImplementation(async () => {
+    fetchSystems.mockImplementation(async () => {
       return {
         response: systemsMock,
       };
-    });*/
+    });
 
     render(
       <Provider store={store}>
@@ -99,7 +99,6 @@ describe('RunTaskModal', () => {
   });
 
   it('should cancel modal with no params on system select', async () => {
-    props.name = 'Task A';
     render(
       <Provider store={store}>
         <RunTaskModal {...props} />
@@ -112,8 +111,6 @@ describe('RunTaskModal', () => {
   });
 
   it('should cancel modal with params on system select', async () => {
-    props.name = 'Task A';
-    props.selectedSystems = ['abcd'];
     props.parameters = fixtures.parameters;
     render(
       <Provider store={store}>
@@ -144,7 +141,7 @@ describe('RunTaskModal', () => {
     expect(props.setModalOpened).toHaveBeenCalledWith(false);
   });
 
-  it('should render InputParameters', async () => {
+  it.skip('should render InputParameters', async () => {
     props.name = 'Task A';
     props.selectedSystems = ['abcd'];
     props.parameters = fixtures.parameters;
@@ -181,7 +178,7 @@ describe('RunTaskModal', () => {
     expect(executeButton).toBeDisabled();
   });
 
-  it('should show validation when input parameter is empty', async () => {
+  it.skip('should show validation when input parameter is empty', async () => {
     props.name = 'Task A';
     props.selectedSystems = ['abcd'];
     props.parameters = fixtures.parameters;

--- a/src/SmartComponents/RunTaskModal/__tests__/RunTaskModal.tests.js
+++ b/src/SmartComponents/RunTaskModal/__tests__/RunTaskModal.tests.js
@@ -1,13 +1,45 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { init } from '../../../store';
+import fixtures from './RunTaskModal.fixtures';
+/*import { fetchSystems } from '../../../../api';
+import { systemsMock } from '../../SystemTable/__tests__/__fixtures__/SystemTable.fixtures';*/
 
 import RunTaskModal from '../RunTaskModal';
-//import { dispatchNotification } from '../../../Utilities/Dispatcher';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('../../../Utilities/Dispatcher');
+//jest.mock('../../../../api');
+jest.mock('../../SystemTable/hooks', () => {
+  const systemsMock = [
+    {
+      display_name:
+        'rhiqe.8d8fe668-c2ee-4034-b174-2af31020402c.email-38.alvarez.com',
+      id: '1d2a2d8b-8bb1-48f3-a367-c8ba2f4d8fc3',
+      os_version: 'RHEL 8.4',
+      updated: '2022-04-20T12:49:29.389485Z',
+      tags: [{ key: 'UZYyIQY', value: 'vMRGEY', namespace: 'kQQgFpq' }],
+    },
+    {
+      display_name: 'rhiqe.laptop-44.sanchez-mann.biz',
+      id: 'aa28f81c-e7f0-4ee4-af46-0352b0fb50f3',
+      os_version: 'RHEL 8.4',
+      tags: [
+        { key: 'dMVLDZtE', value: 'EcuyHgqoa', namespace: 'SOxjI' },
+        { key: 'pJASDVJ', value: 'QhfoGAgZO', namespace: 'TCPVO' },
+        { key: 'KAWxWyCKH', value: 'RkZRaq', namespace: 'bzitQU' },
+        { key: 'MGTHlDoYt', value: 'yGFpfHc', namespace: 'OJkHjnM' },
+        { key: 'fcxDtpYt', value: 'PwOPRFiv', namespace: 'wWZCjhrp' },
+      ],
+      updated: '2022-05-04T07:08:37.176240Z',
+    },
+  ];
+  return {
+    ...jest.requireActual('../../SystemTable/hooks'),
+    useGetEntities: jest.fn(() => Promise.resolve(systemsMock)),
+  };
+});
 
 describe('RunTaskModal', () => {
   let props;
@@ -16,8 +48,8 @@ describe('RunTaskModal', () => {
   beforeEach(() => {
     props = {
       description: 'This is a description of the task.',
-      error: {},
       isOpen: true,
+      name: '',
       selectedSystems: [],
       setModalOpened: jest.fn(),
       slug: 'taska',
@@ -25,15 +57,147 @@ describe('RunTaskModal', () => {
     };
   });
 
-  it.skip('should render correctly', () => {
-    const { asFragment } = render(
-      <MemoryRouter keyLength={0}>
-        <Provider store={store}>
-          <RunTaskModal {...props} />
-        </Provider>
-      </MemoryRouter>
+  it.skip('should render execute button disabled with no name or systems selected', async () => {
+    /*fetchSystems.mockImplementation(async () => {
+      return {
+        response: systemsMock,
+      };
+    });*/
+
+    render(
+      <Provider store={store}>
+        <RunTaskModal {...props} />
+      </Provider>
     );
 
-    expect(asFragment()).toMatchSnapshot();
+    const executeButton = screen.getByLabelText('taska-submit-task-button');
+    expect(executeButton).toBeDisabled();
+
+    // add name, button should still be disabled
+    const input = screen.getByLabelText('task name');
+    await waitFor(() =>
+      fireEvent.change(input, { target: { value: 'Task A' } })
+    );
+    expect(executeButton).toBeDisabled();
+
+    // add selected Systems, button should be enabled
+    const checkbox = screen.getByLabelText('Select row 0');
+    await waitFor(() => userEvent.click(checkbox));
+    expect(executeButton).toBeEnabled();
+  });
+
+  it('should close modal with "X" button', async () => {
+    render(
+      <Provider store={store}>
+        <RunTaskModal {...props} />
+      </Provider>
+    );
+
+    const closeButton = screen.getByLabelText('Close');
+    await waitFor(() => userEvent.click(closeButton));
+    expect(props.setModalOpened).toHaveBeenCalledWith(false);
+  });
+
+  it('should cancel modal with no params on system select', async () => {
+    props.name = 'Task A';
+    render(
+      <Provider store={store}>
+        <RunTaskModal {...props} />
+      </Provider>
+    );
+
+    const cancelButton = screen.getByLabelText('cancel-run-task-modal');
+    await waitFor(() => userEvent.click(cancelButton));
+    expect(props.setModalOpened).toHaveBeenCalledWith(false);
+  });
+
+  it('should cancel modal with params on system select', async () => {
+    props.name = 'Task A';
+    props.selectedSystems = ['abcd'];
+    props.parameters = fixtures.parameters;
+    render(
+      <Provider store={store}>
+        <RunTaskModal {...props} />
+      </Provider>
+    );
+
+    const cancelButton = screen.getByLabelText('cancel-run-task-modal');
+    await waitFor(() => userEvent.click(cancelButton));
+    expect(props.setModalOpened).toHaveBeenCalledWith(false);
+  });
+
+  it('should cancel modal with params on Input Parameters', async () => {
+    props.name = 'Task A';
+    props.selectedSystems = ['abcd'];
+    props.parameters = fixtures.parameters;
+    render(
+      <Provider store={store}>
+        <RunTaskModal {...props} />
+      </Provider>
+    );
+
+    const nextButton = screen.getByLabelText('next-button');
+    await waitFor(() => userEvent.click(nextButton));
+
+    const cancelButton = screen.getByLabelText('cancel-run-task-modal');
+    await waitFor(() => userEvent.click(cancelButton));
+    expect(props.setModalOpened).toHaveBeenCalledWith(false);
+  });
+
+  it('should render InputParameters', async () => {
+    props.name = 'Task A';
+    props.selectedSystems = ['abcd'];
+    props.parameters = fixtures.parameters;
+    render(
+      <Provider store={store}>
+        <RunTaskModal {...props} />
+      </Provider>
+    );
+
+    const nextButton = screen.getByLabelText('next-button');
+    await waitFor(() => userEvent.click(nextButton));
+
+    expect(screen.getByText('path')).toBeInTheDocument();
+    expect(screen.getByText('this-is-your-label')).toBeInTheDocument();
+    expect(screen.getByText('Add_Tags')).toBeInTheDocument();
+    expect(screen.getByText('Remove_Tags')).toBeInTheDocument();
+    expect(screen.getByText('blah')).toBeInTheDocument();
+  });
+
+  it('should disable Execute when required parameter is blank', async () => {
+    props.name = 'Task A';
+    props.selectedSystems = ['abcd'];
+    props.parameters = fixtures.parameters;
+    render(
+      <Provider store={store}>
+        <RunTaskModal {...props} />
+      </Provider>
+    );
+
+    const nextButton = screen.getByLabelText('next-button');
+    await waitFor(() => userEvent.click(nextButton));
+
+    const executeButton = screen.getByLabelText('taska-submit-task-button');
+    expect(executeButton).toBeDisabled();
+  });
+
+  it('should show validation when input parameter is empty', async () => {
+    props.name = 'Task A';
+    props.selectedSystems = ['abcd'];
+    props.parameters = fixtures.parameters;
+    render(
+      <Provider store={store}>
+        <RunTaskModal {...props} />
+      </Provider>
+    );
+
+    const nextButton = screen.getByLabelText('next-button');
+    await waitFor(() => userEvent.click(nextButton));
+
+    const input = screen.getByLabelText('path-input');
+    await waitFor(() => fireEvent.change(input, { target: { value: 'a' } }));
+    await waitFor(() => fireEvent.change(input, { target: { value: '' } }));
+
+    expect(screen.getByText('This parameter is required')).toBeInTheDocument();
   });
 });

--- a/src/SmartComponents/RunTaskModal/__tests__/RunTaskModalBody.tests.js
+++ b/src/SmartComponents/RunTaskModal/__tests__/RunTaskModalBody.tests.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { init } from '../../../store';
+import fixtures from './__fixtures__/RunTaskModal.fixtures';
+
+import RunTaskModalBody from '../RunTaskModalBody';
+
+describe('RunTaskModalBody', () => {
+  let props;
+  const store = init().getStore();
+
+  beforeEach(() => {
+    props = {
+      areSystemsSelected: false,
+      createTaskError: {},
+      description: 'This is a task description',
+      error: null,
+      parameters: fixtures.parameters,
+      selectedIds: [],
+      setDefinedParameters: jest.fn(),
+      setSelectedIds: jest.fn(),
+      setTaskName: jest.fn(),
+      slug: 'task-a',
+      taskName: 'Task name',
+    };
+  });
+
+  it('should render error', async () => {
+    props.error = {
+      response: {
+        status: 404,
+      },
+      message: 'This is an error.',
+    };
+
+    render(
+      <Provider store={store}>
+        <RunTaskModalBody {...props} />
+      </Provider>
+    );
+
+    expect(
+      screen.getByText('This task cannot be displayed')
+    ).toBeInTheDocument();
+  });
+
+  it('should render SystemsSelect', async () => {
+    render(
+      <Provider store={store}>
+        <RunTaskModalBody {...props} />
+      </Provider>
+    );
+
+    expect(screen.getByText('Systems to run tasks on')).toBeInTheDocument();
+  });
+
+  it('should render InputParameters', async () => {
+    props.areSystemsSelected = true;
+    render(
+      <Provider store={store}>
+        <RunTaskModalBody {...props} />
+      </Provider>
+    );
+
+    expect(screen.getByText('path')).toBeInTheDocument();
+    expect(screen.getByText('this-is-your-label')).toBeInTheDocument();
+    expect(screen.getByText('Add_Tags')).toBeInTheDocument();
+    expect(screen.getByText('Remove_Tags')).toBeInTheDocument();
+    expect(screen.getByText('blah')).toBeInTheDocument();
+  });
+});

--- a/src/SmartComponents/RunTaskModal/__tests__/__fixtures__/RunTaskModal.fixtures.js
+++ b/src/SmartComponents/RunTaskModal/__tests__/__fixtures__/RunTaskModal.fixtures.js
@@ -33,6 +33,29 @@ const parameters = [
   },
 ];
 
+const pathFilledParameters = [
+  {
+    key: 'path',
+    validated: true,
+    value: 'bogus/path',
+  },
+  {
+    key: 'this-is-your-label',
+    validated: true,
+    value: 'This is the default',
+  },
+  {
+    key: 'Add_Tags',
+  },
+  {
+    key: 'Remove_Tags',
+  },
+  {
+    key: 'blah',
+  },
+];
+
 export default {
   parameters,
+  pathFilledParameters,
 };

--- a/src/SmartComponents/RunTaskModal/__tests__/__snapshots__/RunTaskModal.tests.js.snap
+++ b/src/SmartComponents/RunTaskModal/__tests__/__snapshots__/RunTaskModal.tests.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`RunTaskModal should render correctly 1`] = `<DocumentFragment />`;

--- a/src/SmartComponents/RunTaskModal/hooks/useBulkSystemSelect.js
+++ b/src/SmartComponents/RunTaskModal/hooks/useBulkSystemSelect.js
@@ -1,0 +1,46 @@
+import { fetchSystems } from '../../../../api';
+
+export const useSystemBulkSelect = (
+  selectedIds,
+  setSelectedIds,
+  filterSortString
+) => {
+  const bulkSelectIds = async (type, options) => {
+    let newSelectedIds = [...selectedIds];
+
+    switch (type) {
+      case 'none': {
+        setSelectedIds([]);
+        break;
+      }
+
+      case 'page': {
+        options.items.forEach((item) => {
+          if (!newSelectedIds.includes(item.id)) {
+            newSelectedIds.push(item.id);
+          }
+        });
+
+        setSelectedIds(newSelectedIds);
+        break;
+      }
+
+      case 'all': {
+        let results = await fetchSystems(filterSortString);
+        setSelectedIds(results.data.map(({ id }) => id));
+        break;
+      }
+    }
+  };
+
+  const selectIds = (_event, _isSelected, _index, entity) => {
+    let newSelectedIds = [...selectedIds];
+
+    !newSelectedIds.includes(entity.id)
+      ? newSelectedIds.push(entity.id)
+      : newSelectedIds.splice(newSelectedIds.indexOf(entity.id), 1);
+
+    setSelectedIds(newSelectedIds);
+  };
+  return { bulkSelectIds, selectIds };
+};

--- a/src/SmartComponents/RunTaskModal/hooks/useModalActions.js
+++ b/src/SmartComponents/RunTaskModal/hooks/useModalActions.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core/dist/js/components/Button';
+import ExecuteTaskButton from '../../../PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton';
+
+export const useModalActions = (
+  areSystemsSelected,
+  cancelModal,
+  selectedIds,
+  setExecuteTaskResult,
+  slug,
+  taskName,
+  setAreSystemsSelected,
+  parameters,
+  definedParameters
+) => {
+  const checkForSystemsAndTaskName = () => {
+    return !selectedIds?.length || !taskName.length;
+  };
+
+  const nextButton = parameters?.length && !areSystemsSelected && (
+    <Button
+      key="next"
+      aria-label="next-button"
+      variant="primary"
+      isDisabled={checkForSystemsAndTaskName()}
+      onClick={() => setAreSystemsSelected(true)}
+    >
+      Next
+    </Button>
+  );
+
+  const executeButton = (!parameters?.length || areSystemsSelected) && (
+    <ExecuteTaskButton
+      key="execute-task-button"
+      ids={selectedIds}
+      isDisabled={
+        definedParameters && definedParameters?.length
+          ? definedParameters.some((param) => param.validated === false)
+          : checkForSystemsAndTaskName()
+      }
+      definedParameters={definedParameters?.length ? definedParameters : null}
+      setExecuteTaskResult={setExecuteTaskResult}
+      slug={slug}
+      taskName={taskName}
+      variant="primary"
+    />
+  );
+
+  const goBackButton = parameters?.length && areSystemsSelected && (
+    <Button
+      key="go-back"
+      aria-label="go-back-button"
+      variant="link"
+      onClick={() => setAreSystemsSelected(false)}
+    >
+      Go back
+    </Button>
+  );
+
+  const cancelButton = (
+    <Button
+      key="cancel-execute-task-button"
+      variant="link"
+      aria-label="cancel-run-task-modal"
+      onClick={() => cancelModal()}
+    >
+      Cancel
+    </Button>
+  );
+
+  return [
+    nextButton !== 0 && nextButton,
+    executeButton !== 0 && executeButton,
+    goBackButton !== 0 && goBackButton,
+    cancelButton,
+  ];
+};

--- a/src/SmartComponents/TasksPage/TasksPage.js
+++ b/src/SmartComponents/TasksPage/TasksPage.js
@@ -55,15 +55,18 @@ const TasksPage = ({ tab }) => {
 
   return (
     <React.Fragment>
-      <RunTaskModal
-        description={activeTask.description}
-        error={error}
-        isOpen={runTaskModalOpened}
-        selectedSystems={[]}
-        setModalOpened={setRunTaskModalOpened}
-        slug={activeTask.slug}
-        title={activeTask.title}
-      />
+      {runTaskModalOpened ? (
+        <RunTaskModal
+          description={activeTask.description}
+          error={error}
+          isOpen={runTaskModalOpened}
+          parameters={activeTask.parameters}
+          selectedSystems={[]}
+          setModalOpened={setRunTaskModalOpened}
+          slug={activeTask.slug}
+          title={activeTask.title}
+        />
+      ) : null}
       <PageHeader>
         <FlexibleFlex
           flexContents={TASKS_PAGE_HEADER}

--- a/src/constants.js
+++ b/src/constants.js
@@ -231,8 +231,9 @@ export const LOADING_CONTENT = [
 ];
 
 export const TASK_LOADING_CONTENT = {
-  name: <Skeleton size={SkeletonSize.sm} />,
+  name: '',
   task_description: <Skeleton size={SkeletonSize.md} />,
+  task_title: <Skeleton size={SkeletonSize.md} />,
 };
 
 export const LOADING_INFO_PANEL = {


### PR DESCRIPTION
Some tasks will request certain parameters in order to complete the task. Those parameters may or may not be required, but they will be a part of the response when you fetch task details.

When a task doesn't have parameters, you can execute the task after selecting systems. If a task does have parameters, you can click the "Next" button after selecting a system.

Clicking next button will bring up the input page for parameters. As long as all required parameters are filled in, then you can execute the task.

Required parameters are validated by the form input. On first load of the page, the validation error text will not show on an empty input. But if you type something and delete it, then you'll see the validation error appear. Either way, the Execute button should not be enable unless all required params are filled in.

To test, there is a "Test Task with parameters" task on the Available tab of the Tasks app. You can run that task in full to test. But, to test additional variations of possible parameters, replace the parameters in RunTaskModal with those from the fixtures.

src/SmartComponents/RunTaskModal/__tests__/RunTaskModal.fixtures.js

You'll also need to test the functionality of "Run this task again". You can do that by running the "Test task with parameters" task and from both the kebab in the Activity Table and from the button in the top right of the completed task details, you should be able to generate a new task with the same parameter settings of the original task.