### PR TITLE
bug(RHIN-1128): Disable execution with whitespace

### DIFF
--- a/src/SmartComponents/RunTaskModal/InputParameters.js
+++ b/src/SmartComponents/RunTaskModal/InputParameters.js
@@ -19,7 +19,7 @@ export const InputParameter = ({ parameter, setDefinedParameters }) => {
         if (param.key === parameter.key) {
           let newDefinedParam = { key: param.key, value: text };
           if (parameter.required) {
-            newDefinedParam.validated = newDefinedParam.value.length
+            newDefinedParam.validated = newDefinedParam.value.trim().length
               ? true
               : false;
           }


### PR DESCRIPTION
To test:
- Go to tasks
- On available tab, select Test Task with Parameters
- Select a random system
- In the `path` field, start typing spaces with the spacebar

This should render the `Execute Task` button as disabled until characters are added.