### PR TITLE
feat(RHINENG-6101): Add parameter details to CompletedTaskDetails

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -49,6 +49,7 @@ import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome'
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 import ReactMarkdown from 'react-markdown';
 import { useInterval } from '../../Utilities/hooks/useTableTools/useInterval';
+import ParameterDetails from './ParameterDetails';
 
 const CompletedTaskDetails = () => {
   const { id } = useParams();
@@ -219,6 +220,9 @@ const CompletedTaskDetails = () => {
                     {completedTaskDetails.task_description}
                   </ReactMarkdown>
                 </FlexItem>
+                <ParameterDetails
+                  parameters={completedTaskDetails.parameters}
+                />
               </Flex>
               <FlexibleFlex
                 data={completedTaskDetails}

--- a/src/SmartComponents/CompletedTaskDetails/ParameterDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/ParameterDetails.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import {
+  Flex,
+  FlexItem,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+
+const ParameterDetails = ({ parameters }) => {
+  return (
+    parameters && (
+      <Flex>
+        <FlexItem>
+          <TextContent>
+            <Text component={TextVariants.h4}>Parameter details</Text>
+            {parameters.map((parameter) => (
+              <Text
+                key={`parameter-${parameter.key}`}
+                component={TextVariants.p}
+                className="pf-u-mb-sm"
+              >
+                {parameter.key}: <b>{parameter.value}</b>
+              </Text>
+            ))}
+          </TextContent>
+        </FlexItem>
+      </Flex>
+    )
+  );
+};
+
+ParameterDetails.propTypes = {
+  parameters: propTypes.array,
+};
+
+export default ParameterDetails;

--- a/src/SmartComponents/CompletedTaskDetails/ParameterDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/ParameterDetails.js
@@ -9,8 +9,10 @@ import {
 } from '@patternfly/react-core';
 
 const ParameterDetails = ({ parameters }) => {
+  const parametersExist = parameters?.length ? true : false;
+
   return (
-    parameters && (
+    parametersExist && (
       <Flex>
         <FlexItem>
           <TextContent>


### PR DESCRIPTION
This is a companion PR to this PR: https://github.com/RedHatInsights/tasks-frontend/pull/126

If you follow the guide to run a task with parameters, then you can use this PR to check that the parameters are shown in the completed task details page. Otherwise, you can simply find a completed task that already exists and use that.

To test:
- Go to `/insights/tasks`
- Click the 'Activity' tab
- In the search bar, type 'parameter'. This should show some existing tasks that have run with parameters
- Click the task to open the completed task details page
- Check under the description of the task to see the 'Parameter details' section

Do this same thing with a non-parameter task and make sure that 'Parameter details' do NOT appear.