### PR TITLE
fix(RHINENG-7678): Include task name in Task name filter

### DIFF
--- a/src/SmartComponents/ActivityTable/Filters.js
+++ b/src/SmartComponents/ActivityTable/Filters.js
@@ -5,8 +5,10 @@ export const nameFilter = [
     type: conditionalFilterType.text,
     label: 'Task',
     filter: (tasks, value) =>
-      tasks.filter((task) =>
-        task.task_title.toLowerCase().includes(value.toLowerCase())
+      tasks.filter(
+        (task) =>
+          task.task_title.toLowerCase().includes(value.toLowerCase()) ||
+          task.name.toLowerCase().includes(value.toLowerCase())
       ),
   },
 ];


### PR DESCRIPTION
The user can create their own name for a task rather than use the default task_title field.  This PR modifies the Task name filter to also consider the name field as well as the task_title field when filtering the text.