### PR TITLE
fix(RHINENG-7678): Task name filters on task name only

### DIFF
--- a/src/SmartComponents/ActivityTable/Filters.js
+++ b/src/SmartComponents/ActivityTable/Filters.js
@@ -5,10 +5,8 @@ export const nameFilter = [
     type: conditionalFilterType.text,
     label: 'Task',
     filter: (tasks, value) =>
-      tasks.filter(
-        (task) =>
-          task.task_title.toLowerCase().includes(value.toLowerCase()) ||
-          task.name.toLowerCase().includes(value.toLowerCase())
+      tasks.filter((task) =>
+        task.name.toLowerCase().includes(value.toLowerCase())
       ),
   },
 ];


### PR DESCRIPTION
Ooops.  I missed testing this in my last commit.

Before fix:
![Screenshot from 2024-01-22 20-31-42](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/74f9d927-e163-404f-beec-f95f84a4462d)

After fix:
![Screenshot from 2024-01-22 20-35-20](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/5e09bf40-d8e4-4c9d-ba09-2ffd64b8656e)
