### PR TITLE
fix(RHINENG-7680): Sort system OS column with new API 'os' sort param

### DIFF
--- a/src/SmartComponents/SystemTable/helpers.js
+++ b/src/SmartComponents/SystemTable/helpers.js
@@ -4,7 +4,10 @@ const buildSortString = (orderBy, orderDirection) => {
   if (orderDirection === 'DESC') {
     direction = '-';
   }
-  let order = orderBy === 'updated' ? 'last_seen' : orderBy;
+  let order =
+    (orderBy === 'updated' && 'last_seen') ||
+    (orderBy === 'os_version' && 'os') ||
+    orderBy;
 
   return `${sortString}${direction}${order}`;
 };


### PR DESCRIPTION
- Allows sorting by both name and version together

Before PR, sorting is done using OS version only, so CentOS and RHEL hosts are intermixed:
![Screenshot from 2024-01-23 17-17-25](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/627a304a-78de-4e85-a2a0-d8e843d0a214)


After PR, the sorting is done using both OS name and version (via the new Tasks API sort parameter 'os'):
![Screenshot from 2024-01-23 17-17-05](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/49b85151-ed6d-4266-bada-24b5f6de1288)
![Screenshot from 2024-01-23 17-16-53](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/e701cfdf-5160-4a8b-a4bd-2f61f660f5fb)
