### PR TITLE
feat: distinguish leapp inhibitors from other high risk issues by extending severity mapping

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
+++ b/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
@@ -180,6 +180,14 @@ const converttorhelpreanalysisstageSeverityMap = {
 };
 
 const leapppreupgradeSeverityMap = {
+  inhibitor: {
+    text: 'Inhibitor',
+    icon: <ExclamationCircleIcon />,
+    iconSeverityColor: 'danger',
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2500,
+  },
   high: {
     text: 'High risk',
     icon: <ExclamationCircleIcon />,
@@ -215,6 +223,14 @@ const leapppreupgradeSeverityMap = {
 };
 
 const leappupgradeSeverityMap = {
+  inhibitor: {
+    text: 'Inhibitor',
+    icon: <ExclamationCircleIcon />,
+    iconSeverityColor: 'danger',
+    titleColor: '#A30000',
+    severityColor: 'red',
+    severityLevel: 2500,
+  },
   high: {
     text: 'High risk',
     icon: <ExclamationCircleIcon />,


### PR DESCRIPTION
Related to OAMG-10608 and OAMG-10609

Goal of this change is to extend severity maps so we can adjust tasks to distinguish high risk issues and inhibitors, e.g. image below shows that system has one inhibitor, but all red records have high severity in report which makes UI look same. (this is caused by leapp report structure and tasks will be changed to use new inhibitor severity - the changes can be seen [in this upstream PR](https://github.com/oamg/leapp-insights-tasks/pull/12))

![image](https://github.com/RedHatInsights/tasks-frontend/assets/19702477/c39ca16c-1312-4a58-868b-4da32e14ad52)


