### PR TITLE
fix(RHINENG-8085): Workaround for only 10 available tasks listed

### DIFF
--- a/api.js
+++ b/api.js
@@ -44,8 +44,8 @@ const deleteTask = async (path) => {
   return returnErrOrData(response);
 };
 
-export const fetchAvailableTasks = () => {
-  return getTasks(AVAILABLE_TASKS_ROOT);
+export const fetchAvailableTasks = (path = '') => {
+  return getTasks(AVAILABLE_TASKS_ROOT.concat(path));
 };
 
 export const fetchAvailableTask = (slug) => {

--- a/src/SmartComponents/AvailableTasks/AvailableTasks.js
+++ b/src/SmartComponents/AvailableTasks/AvailableTasks.js
@@ -65,7 +65,8 @@ const AvailableTasks = ({ openTaskModal }) => {
   useEffect(() => {
     const fetchData = async () => {
       setIsLoading(true);
-      const result = await fetchAvailableTasks();
+      const taskLimit = '?limit=50&offset=0'; // temp workaround for tasks list > 10, eg in stage
+      const result = await fetchAvailableTasks(taskLimit);
 
       setTasks(result);
     };


### PR DESCRIPTION
Before PR - only 10 available tasks listed:
![Screenshot from 2024-02-07 14-41-05](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/48df2fa2-13f9-41fa-90a4-e037eec42bb2)

After PR - all available tasks listed (11):
![Screenshot from 2024-02-07 14-58-50](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/48200b04-7d3c-4a05-8f20-02f8c1d542e2)
