### PR TITLE
Fix documentation link 404s in About Tasks popover

### DIFF
--- a/src/PresentationalComponents/TasksPopover/TasksPageHeaderPopover.js
+++ b/src/PresentationalComponents/TasksPopover/TasksPageHeaderPopover.js
@@ -5,11 +5,11 @@ import {
   OutlinedQuestionCircleIcon,
 } from '@patternfly/react-icons';
 import {
-  ACCESS_REDHAT_DOT_COM,
+  INSIGHTS_DOCUMENTATION,
+  DOC_VERSION,
   HOST_COMMUNICATION_DOC_PATH,
   RHC_DOC,
   SATELLITE_DOC,
-  YEAR,
 } from '../../constants';
 
 export const TasksPagePopoverHeader = () => {
@@ -49,7 +49,9 @@ export const TasksPagePopoverFooter = () => {
   return (
     <div>
       <a
-        href={`${ACCESS_REDHAT_DOT_COM}${YEAR}${HOST_COMMUNICATION_DOC_PATH}${RHC_DOC}`}
+        href={`${INSIGHTS_DOCUMENTATION}${DOC_VERSION}${HOST_COMMUNICATION_DOC_PATH}${RHC_DOC}`}
+        target="_blank"
+        rel="noopener noreferrer"
       >
         <span>
           Using rhc with systems{' '}
@@ -60,7 +62,9 @@ export const TasksPagePopoverFooter = () => {
       </a>
       <br />
       <a
-        href={`${ACCESS_REDHAT_DOT_COM}${YEAR}${HOST_COMMUNICATION_DOC_PATH}${SATELLITE_DOC}`}
+        href={`${INSIGHTS_DOCUMENTATION}${DOC_VERSION}${HOST_COMMUNICATION_DOC_PATH}${SATELLITE_DOC}`}
+        target="_blank"
+        rel="noopener noreferrer"
       >
         <span>
           Configure Cloud Connector and Satellite{' '}

--- a/src/constants.js
+++ b/src/constants.js
@@ -21,14 +21,13 @@ import RunTaskButton from './PresentationalComponents/RunTaskButton/RunTaskButto
 /**
  * String constants
  */
-const today = new Date();
 export const TASKS_API_ROOT = '/api/tasks/v1';
 export const AVAILABLE_TASKS_ROOT = '/task';
 export const EXECUTED_TASK_ROOT = '/executed_task';
 export const SYSTEMS_ROOT = '/system';
-export const ACCESS_REDHAT_DOT_COM =
+export const INSIGHTS_DOCUMENTATION =
   'https://access.redhat.com/documentation/en-us/red_hat_insights/';
-export const YEAR = `${today.getFullYear()}/html/`;
+export const DOC_VERSION = '1-latest/html/';
 export const HOST_COMMUNICATION_DOC_PATH =
   'red_hat_insights_remediations_guide/host-communication-with-insights_red-hat-insights-remediation-guide';
 export const RHC_DOC =


### PR DESCRIPTION
The popover links are broken (again).  This PR fixes the links (again).  It opens the documentation in a new browser tab/window which I think is a better user experience than opening them in the same tab/window.

![Screenshot from 2024-02-15 14-31-09](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/d1e1ef58-f465-40ad-858d-ecc08f374e43)
