### PR TITLE
feat(RHINENG-8320): Add groups column & filter to SystemTable

### DIFF
--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -136,6 +136,7 @@ const SystemTable = ({
         name: false,
         tags: false,
         operatingSystem: false,
+        hostGroupFilter: false,
       }}
       columns={mergedColumns}
       ref={inventory}

--- a/src/SmartComponents/SystemTable/constants.js
+++ b/src/SmartComponents/SystemTable/constants.js
@@ -19,6 +19,7 @@ export const systemColumns = (isBeta) => [
       return createEligibilityTooltip(eligibility);
     },
   },
+  'groups',
   'tags',
   {
     key: 'os_version',

--- a/src/SmartComponents/SystemTable/helpers.js
+++ b/src/SmartComponents/SystemTable/helpers.js
@@ -16,6 +16,7 @@ const buildSortString = (orderBy, orderDirection) => {
 
 const buildFilterString = (filters) => {
   let osFiltersString = '';
+  let groupsFilterString = '';
   let displayNameFilter = filters.hostnameOrId
     ? `&display_name=${filters.hostnameOrId}`
     : '';
@@ -24,7 +25,11 @@ const buildFilterString = (filters) => {
     osFiltersString += `&operating_system=${osName}|${value}`;
   });
 
-  return `${displayNameFilter}${osFiltersString}`;
+  filters.hostGroupFilter?.forEach((group) => {
+    groupsFilterString += `&groups=${group}`;
+  });
+
+  return `${displayNameFilter}${osFiltersString}${groupsFilterString}`;
 };
 
 const buildTagsFilterString = (tags, filters) => {


### PR DESCRIPTION
After the PR the group column is visible and sortable and displays hosts without groups in the standard format:
![Screenshot from 2024-02-20 12-31-14](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/94267797-6919-48be-8d1d-2220062f975e)


Also the group filtering works as expected:
![Screenshot from 2024-02-20 12-31-45](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/3842964e-b982-4dfd-9c2f-7773b6fe2153)
