### PR TITLE
Remove SystemTable bulk select all if number of systems > 1000

### DIFF
--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -125,6 +125,34 @@ const SystemTable = ({
     },
   };
 
+  const buildBulkSelectItems = () => {
+    let bulkSelectItems = [
+      {
+        title: `Select none (0)`,
+        onClick: () => {
+          bulkSelectIds('none');
+        },
+      },
+      {
+        title: `Select page (${items?.length || 0})`,
+        onClick: () => {
+          bulkSelectIds('page', { items: items });
+        },
+      },
+    ];
+    // The Tasks API responds with a max of 1000 systems even if the account has more than 1000 systems
+    // and the request params contain something like '/systems?limit=20000&offset=0'.
+    // So don't show the "Select all" option if total > 1000 because we can't select them all anyway
+    total <= 1000 &&
+      bulkSelectItems.push({
+        title: `Select all (${total || 0})`,
+        onClick: () => {
+          bulkSelectIds('all', { total: total });
+        },
+      });
+    return bulkSelectItems;
+  };
+
   return (
     <InventoryTable
       isFullView
@@ -170,26 +198,7 @@ const SystemTable = ({
         id: 'systems-bulk-select',
         isDisabled: !total,
         count: selectedIds.length,
-        items: [
-          {
-            title: `Select none (0)`,
-            onClick: () => {
-              bulkSelectIds('none');
-            },
-          },
-          {
-            title: `Select page (${items?.length || 0})`,
-            onClick: () => {
-              bulkSelectIds('page', { items: items });
-            },
-          },
-          {
-            title: `Select all (${total || 0})`,
-            onClick: () => {
-              bulkSelectIds('all', { total: total });
-            },
-          },
-        ],
+        items: buildBulkSelectItems(),
         onSelect: () => {
           if (selectedIds.length) {
             bulkSelectIds('none');


### PR DESCRIPTION
The Tasks API responds with a max of 1000 systems even if the account has more than 1000 systems and the request params contain something like '/systems?limit=20000&offset=0'.  So don't show the "Select all" option if total > 1000 because we can't select them all anyway.

This screenshot shows that even though there are 23047 systems and the request is for https://console.redhat.com/api/tasks/v1/task/leapp-preupgrade/systems?limit=23047&offset=0&sort=-last_seen&all_systems=true ... only 1000 systems are returned by the API when we request *ALL* systems:

![Screenshot from 2024-02-21 14-20-47](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/99ad1de7-a39c-474e-aa94-33e14a3a776d)



So if there are more than 1000 systems, remove the 'Select all' option from the bulk select:

![Screenshot from 2024-02-21 15-12-48](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/0f614e42-082e-4971-8b58-03d633ad7f0b)
![Screenshot from 2024-02-21 15-12-57](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/b178f7e3-415e-420b-801a-88fa5c8ca92e)

