### PR TITLE
fix(RHINENG-8404): Bulk select all systems in batches in SystemTable

### DIFF
--- a/src/SmartComponents/RunTaskModal/hooks/useBulkSystemSelect.js
+++ b/src/SmartComponents/RunTaskModal/hooks/useBulkSystemSelect.js
@@ -9,7 +9,7 @@ export const useSystemBulkSelect = (
   const bulkSelectIds = async (type, options) => {
     let newSelectedIds = [...selectedIds];
     // only bulkSelect items that have no requirements
-    const isEligible = (item) => !item.requirements.length;
+    const isEligible = (item) => item?.requirements?.length === 0;
 
     switch (type) {
       case 'none': {
@@ -29,8 +29,27 @@ export const useSystemBulkSelect = (
       }
 
       case 'all': {
-        const allSystems = await fetchSystems(filterSortString, slug);
-        const eligibleIds = allSystems.data
+        // The Tasks API paginator responds with a maximum of 1000 systems, even if the account has more
+        // than 1000 systems and the request params contain something like '/systems?limit=20000&offset=0'.
+        // So we retrieve systems in batches of 1000, regardless of the number of systems
+        // TBH though, this doesn't scale very well if selecting many thousands systems (eg 5000+)
+        const batchSize = 1000;
+        const pages = Math.ceil(options.total / batchSize) || 1;
+        let allSystems = await options.resolve(
+          [...new Array(pages)].map(
+            (_, pageIdx) => () =>
+              fetchSystems(
+                filterSortString
+                  .replace(/limit=\d+/, `limit=${batchSize}`)
+                  .replace(/offset=\d+/, `offset=${batchSize * pageIdx}`),
+                slug
+              )
+          )
+        );
+        // extract all the 'data' arrays and merge them into a single array
+        const eligibleIds = allSystems
+          .map((batch) => batch.data)
+          .flat()
           .filter((item) => isEligible(item))
           .map((item) => item.id);
         setSelectedIds(eligibleIds);

--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -18,6 +18,7 @@ import { useDispatch } from 'react-redux';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { generateFilter } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
+import usePromiseQueue from '../../Utilities/hooks/usePromiseQueue';
 
 const SystemTable = ({
   bulkSelectIds,
@@ -33,6 +34,7 @@ const SystemTable = ({
   const { getRegistry } = useContext(RegistryContext);
   const dispatch = useDispatch();
   const chrome = useChrome();
+  const { resolve } = usePromiseQueue();
 
   const tagsFilter = useSelector(
     ({ globalFilterState }) => globalFilterState?.tagsFilter
@@ -187,7 +189,7 @@ const SystemTable = ({
           {
             title: `Select all (${total || 0})`,
             onClick: () => {
-              bulkSelectIds('all', { total: total });
+              bulkSelectIds('all', { total: total, resolve: resolve });
             },
           },
         ],


### PR DESCRIPTION
The Tasks API paginator responds with a maximum of 1000 systems, even if the account has more  than 1000 systems and the request params contain something like '/systems?limit=20000&offset=0'.  The BulkSelect all component needs to retrieve systems in batches of 1000 so all systems can be selected, not just the systems in the first 1000.

Before the PR only systems within the first 1000 may be selected in the bulkSelect, so there are only 5 matching systems:
![Screenshot from 2024-02-22 17-29-40](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/779c0a34-171b-4cbb-91f5-2a8d7336c251)
![Screenshot from 2024-02-22 17-31-17](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/38f49db0-8c37-4984-9199-189425d00f01)


After the PR all 3125 systems may be selected within the bulkSelect, so there are 12 matching systems which is the correct number:
![Screenshot from 2024-02-22 17-29-05](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/4c3f25a7-d6ef-4bd1-8dae-8563a3c2d974)
![Screenshot from 2024-02-22 17-30-34](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/f6b387c1-9604-4755-8faf-ef47e00a2089)

