### PR TITLE
fix(RHINENG-7695): Change download playbook to script

### DIFF
--- a/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
+++ b/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
@@ -9,6 +9,7 @@ import EmptyStateDisplay from '../../PresentationalComponents/EmptyStateDisplay/
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import {
   AVAILABLE_TASKS_ROOT,
+  CONVERSION_SLUG,
   EMPTY_TASKS_MESSAGE,
   EMPTY_TASKS_TITLE,
   TASKS_API_ROOT,
@@ -17,6 +18,10 @@ import {
 import ReactMarkdown from 'react-markdown';
 
 const AvailableTasksTable = ({ availableTasks, error, openTaskModal }) => {
+  const scriptOrPlaybook = (slug) => {
+    return slug.includes(CONVERSION_SLUG) ? 'script' : 'playbook';
+  };
+
   return (
     <div aria-label="available-tasks-table">
       {error ? (
@@ -49,7 +54,7 @@ const AvailableTasksTable = ({ availableTasks, error, openTaskModal }) => {
                         <a
                           href={`${TASKS_API_ROOT}${AVAILABLE_TASKS_ROOT}/${task.slug}/playbook`}
                         >
-                          Download preview of playbook
+                          {`Download preview of ${scriptOrPlaybook(task.slug)}`}
                         </a>
                       </FlexItem>
                     </Flex>

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -24,6 +24,7 @@ import {
   COMPLETED_INFO_PANEL_FLEX_PROPS,
   COMPLETED_INFO_BUTTONS,
   COMPLETED_INFO_BUTTONS_FLEX_PROPS,
+  CONVERSION_SLUG,
   LOADING_INFO_PANEL,
   LOADING_JOBS_TABLE,
   TASK_ERROR,
@@ -143,8 +144,9 @@ const CompletedTaskDetails = () => {
 
   const isConversionTask = () => {
     if (
-      completedTaskDetails.task_slug === 'convert-to-rhel-conversion-stage' ||
-      completedTaskDetails.task_slug === 'convert-to-rhel-conversion'
+      completedTaskDetails.task_slug ===
+        `${CONVERSION_SLUG}-conversion-stage` ||
+      completedTaskDetails.task_slug === `${CONVERSION_SLUG}-conversion`
     ) {
       return true;
     } else {

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__fixtures__/completedTasksDetails.fixtures.js
@@ -1,3 +1,5 @@
+import { CONVERSION_SLUG } from '../../../../constants';
+
 export const log4j_task = {
   id: 42,
   name: 'log4j task',
@@ -63,9 +65,9 @@ export const upgrade_leapp_task = {
 
 export const convert2rhel_task_details = {
   id: 2909,
-  name: 'convert-to-rhel-preanalysis task',
+  name: `${CONVERSION_SLUG}-preanalysis task`,
   alerts_count: 3,
-  task_slug: 'convert-to-rhel-preanalysis',
+  task_slug: `${CONVERSION_SLUG}-preanalysis`,
   task_title: 'Convert to RHEL Preanalysis',
   task_description:
     'For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.',

--- a/src/constants.js
+++ b/src/constants.js
@@ -68,6 +68,7 @@ export const JOB_TIMED_OUT_MESSAGE =
   'Task failed to complete due to timing out. Retry this task at a later time.';
 
 export const JOB_RUNNING_MESSAGE = 'No result yet';
+export const CONVERSION_SLUG = 'convert-to-rhel';
 
 /**
  * Flex constants


### PR DESCRIPTION
"Looking at the pre-conversion for convert2RHEL, the link should say I can download the script.. not download the playbook."

This PR compares the task slug and when it's a conversion task, it will show the "Download preview..." link on the Available tasks page to "script" instead of "playbook". All other tasks will remain as "Download preview of playbook".