### PR TITLE
feat(RHINENG-2263): Add log viewer to task details

### DIFF
--- a/api.js
+++ b/api.js
@@ -4,6 +4,7 @@ import {
   AVAILABLE_TASKS_ROOT,
   EXECUTED_TASK_ROOT,
   SYSTEMS_ROOT,
+  JOB_ROOT,
 } from './src/constants';
 
 const returnErrOrData = (response) => {
@@ -87,4 +88,8 @@ export const deleteExecutedTask = (id) => {
 
 export const cancelExecutedTask = (id) => {
   return postTask(EXECUTED_TASK_ROOT.concat(`/${id}/cancel`));
+};
+
+export const getLogs = (id) => {
+  return getTasks(JOB_ROOT.concat(`/${id}/stdout`))
 };

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -11,12 +11,11 @@ const { config: webpackConfig, plugins } = config({
   appUrl: process.env.BETA
     ? ['/beta/insights/preview', '/preview/insights/tasks']
     : ['/insights/tasks'],
-  /*env: process.env.CHROME_ENV
+  env: process.env.CHROME_ENV
     ? process.env.CHROME_ENV
     : process.env.BETA
     ? 'stage-beta'
-    : 'stage-stable', // pick chrome env ['stage-beta', 'stage-stable', 'prod-beta', 'prod-stable'],*/
-  env: 'prod-stable',
+    : 'stage-stable', // pick chrome env ['stage-beta', 'stage-stable', 'prod-beta', 'prod-stable'],
   deployment: process.env.BETA ? 'beta/apps' : 'apps',
 });
 

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -11,11 +11,12 @@ const { config: webpackConfig, plugins } = config({
   appUrl: process.env.BETA
     ? ['/beta/insights/preview', '/preview/insights/tasks']
     : ['/insights/tasks'],
-  env: process.env.CHROME_ENV
+  /*env: process.env.CHROME_ENV
     ? process.env.CHROME_ENV
     : process.env.BETA
     ? 'stage-beta'
-    : 'stage-stable', // pick chrome env ['stage-beta', 'stage-stable', 'prod-beta', 'prod-stable'],
+    : 'stage-stable', // pick chrome env ['stage-beta', 'stage-stable', 'prod-beta', 'prod-stable'],*/
+  env: 'prod-stable',
   deployment: process.env.BETA ? 'beta/apps' : 'apps',
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@patternfly/react-core": "^5.0.0",
         "@patternfly/react-icons": "5.0.0",
+        "@patternfly/react-log-viewer": "^5.1.0",
         "@patternfly/react-table": "^5.0.0",
         "@patternfly/react-tokens": "^5.0.0",
         "@redhat-cloud-services/frontend-components": "^4.2.0",
@@ -2779,6 +2780,21 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.0.0.tgz",
       "integrity": "sha512-GG5Y/UYl0h346MyDU9U650Csaq4Mxk8S6U8XC7ERk/xIrRr2RF67O2uY7zKBDMTNLYdBvPzgc2s3OMV1+d2/mg==",
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@patternfly/react-log-viewer": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-log-viewer/-/react-log-viewer-5.1.0.tgz",
+      "integrity": "sha512-76Sm8lKwXbXmjIwYwsUjk8H4jy7aDslDw7DK8MDzIaKdE8BLDA4EJ636Qv1zo5JFPbBKRpVeDrrMqqqfvPt5rg==",
+      "dependencies": {
+        "@patternfly/react-core": "^5.0.0",
+        "@patternfly/react-icons": "^5.0.0",
+        "@patternfly/react-styles": "^5.0.0",
+        "memoize-one": "^5.1.0"
+      },
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
@@ -13165,6 +13181,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "node_modules/memory-fs": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
@@ -21039,6 +21060,17 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.0.0.tgz",
       "integrity": "sha512-GG5Y/UYl0h346MyDU9U650Csaq4Mxk8S6U8XC7ERk/xIrRr2RF67O2uY7zKBDMTNLYdBvPzgc2s3OMV1+d2/mg==",
       "requires": {}
+    },
+    "@patternfly/react-log-viewer": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-log-viewer/-/react-log-viewer-5.1.0.tgz",
+      "integrity": "sha512-76Sm8lKwXbXmjIwYwsUjk8H4jy7aDslDw7DK8MDzIaKdE8BLDA4EJ636Qv1zo5JFPbBKRpVeDrrMqqqfvPt5rg==",
+      "requires": {
+        "@patternfly/react-core": "^5.0.0",
+        "@patternfly/react-icons": "^5.0.0",
+        "@patternfly/react-styles": "^5.0.0",
+        "memoize-one": "^5.1.0"
+      }
     },
     "@patternfly/react-styles": {
       "version": "5.1.2",
@@ -29063,6 +29095,11 @@
       "requires": {
         "fs-monkey": "^1.0.3"
       }
+    },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "memory-fs": {
       "version": "0.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
         "axios": "^0.27.0",
         "classnames": "^2.3.1",
+        "jest-canvas-mock": "^2.5.2",
         "moment": "2.29.4",
         "p-all": "^4.0.0",
         "react": "^18.0.0",
@@ -6510,6 +6511,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg=="
+    },
     "node_modules/cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -10675,6 +10681,15 @@
         }
       }
     },
+    "node_modules/jest-canvas-mock": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz",
+      "integrity": "sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==",
+      "dependencies": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "node_modules/jest-changed-files": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.5.1.tgz",
@@ -13932,6 +13947,19 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dependencies": {
+        "color-name": "^1.1.4"
+      }
+    },
+    "node_modules/moo-color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -24019,6 +24047,11 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg=="
+    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -27150,6 +27183,15 @@
         "jest-cli": "^27.5.1"
       }
     },
+    "jest-canvas-mock": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz",
+      "integrity": "sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==",
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "jest-changed-files": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.5.1.tgz",
@@ -29556,6 +29598,21 @@
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
+    "moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "requires": {
+        "color-name": "^1.1.4"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
     },
     "mri": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
       "<rootDir>/.+fixtures.+"
     ],
     "setupFilesAfterEnv": [
-      "<rootDir>/config/setupTests.js"
+      "<rootDir>/config/setupTests.js",
+      "jest-canvas-mock"
     ],
     "roots": [
       "<rootDir>/src/"
@@ -59,14 +60,15 @@
   "dependencies": {
     "@patternfly/react-core": "^5.0.0",
     "@patternfly/react-icons": "5.0.0",
+    "@patternfly/react-log-viewer": "^5.1.0",
     "@patternfly/react-table": "^5.0.0",
     "@patternfly/react-tokens": "^5.0.0",
-    "@patternfly/react-log-viewer": "^5.1.0",
     "@redhat-cloud-services/frontend-components": "^4.2.0",
     "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
     "axios": "^0.27.0",
     "classnames": "^2.3.1",
+    "jest-canvas-mock": "^2.5.2",
     "moment": "2.29.4",
     "p-all": "^4.0.0",
     "react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@patternfly/react-icons": "5.0.0",
     "@patternfly/react-table": "^5.0.0",
     "@patternfly/react-tokens": "^5.0.0",
+    "@patternfly/react-log-viewer": "^5.1.0",
     "@redhat-cloud-services/frontend-components": "^4.2.0",
     "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",

--- a/src/App.scss
+++ b/src/App.scss
@@ -35,3 +35,7 @@
 .remediations-font-family {
   font-family: 'overpass-mono', sans-serif;
 }
+
+.my-app-modified-drawer-width .pf-v5-c-drawer__panel {
+  --pf-v5-c-drawer__panel--md--FlexBasis: 50%;
+}

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -50,6 +50,7 @@ import useInsightsNavigate from '@redhat-cloud-services/frontend-components-util
 import ReactMarkdown from 'react-markdown';
 import { useInterval } from '../../Utilities/hooks/useTableTools/useInterval';
 import ParameterDetails from './ParameterDetails';
+import JobLogDrawer from './JobResultsDetails/JobLogDrawer';
 
 const CompletedTaskDetails = () => {
   const { id } = useParams();
@@ -67,6 +68,9 @@ const CompletedTaskDetails = () => {
   const [isCancel, setIsCancel] = useState(false);
   const [lastUpdated, setLastUpdated] = useState();
   const [isRunning, setIsRunning] = useState(false);
+  const [isLogDrawerExpanded, setIsLogDrawerExpanded] = useState(false);
+  const [jobId, setJobId] = useState();
+  const [jobName, setJobName] = useState();
   const chrome = useChrome();
   const { hasAccess, isLoading } = usePermissions('inventory', [
     'inventory:hosts:*',
@@ -133,6 +137,9 @@ const CompletedTaskDetails = () => {
       function Row(props) {
         return (
           <JobResultsDetails
+            setIsLogDrawerExpanded={setIsLogDrawerExpanded}
+            setJobName={setJobName}
+            setJobId={setJobId}
             taskSlug={completedTaskDetails.task_slug}
             {...props}
           />
@@ -195,7 +202,12 @@ const CompletedTaskDetails = () => {
           error={`Error ${error?.response?.status}: ${error?.message}`}
         />
       ) : (
-        <React.Fragment>
+        <JobLogDrawer
+          isLogDrawerExpanded={isLogDrawerExpanded}
+          jobName={jobName}
+          jobId={jobId}
+          setIsLogDrawerExpanded={setIsLogDrawerExpanded}
+        >
           <PageHeader>
             <Breadcrumb ouiaId="completed-tasks-details-breadcrumb">
               <BreadcrumbLinkItem to="/executed">Tasks</BreadcrumbLinkItem>
@@ -293,7 +305,7 @@ const CompletedTaskDetails = () => {
               )}
             </Card>
           </section>
-        </React.Fragment>
+        </JobLogDrawer>
       )}
     </div>
   );

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -12,6 +12,7 @@ import {
   Card,
   Flex,
   FlexItem,
+  Page,
   Text,
   TextContent,
   TextVariants,
@@ -168,7 +169,18 @@ const CompletedTaskDetails = () => {
   };
 
   return (
-    <div>
+    <Page
+      notificationDrawer={
+        <JobLogDrawer
+          isLogDrawerExpanded={isLogDrawerExpanded}
+          jobName={jobName}
+          jobId={jobId}
+          setIsLogDrawerExpanded={setIsLogDrawerExpanded}
+        />
+      }
+      isNotificationDrawerExpanded={isLogDrawerExpanded}
+      className="my-app-modified-drawer-width"
+    >
       {runTaskModalOpened && (
         <RunTaskModal
           description={completedTaskDetails.task_description}
@@ -202,12 +214,7 @@ const CompletedTaskDetails = () => {
           error={`Error ${error?.response?.status}: ${error?.message}`}
         />
       ) : (
-        <JobLogDrawer
-          isLogDrawerExpanded={isLogDrawerExpanded}
-          jobName={jobName}
-          jobId={jobId}
-          setIsLogDrawerExpanded={setIsLogDrawerExpanded}
-        >
+        <React.Fragment>
           <PageHeader>
             <Breadcrumb ouiaId="completed-tasks-details-breadcrumb">
               <BreadcrumbLinkItem to="/executed">Tasks</BreadcrumbLinkItem>
@@ -305,9 +312,9 @@ const CompletedTaskDetails = () => {
               )}
             </Card>
           </section>
-        </JobLogDrawer>
+        </React.Fragment>
       )}
-    </div>
+    </Page>
   );
 };
 

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobLogDrawer.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobLogDrawer.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useRef, useState } from 'react';
+import propTypes from 'prop-types';
+import {
+  Drawer,
+  DrawerPanelContent,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerPanelBody,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import { getLogs } from '../../../../api';
+import LogDrawerDetails from './LogDrawerDetails';
+
+const JobLogDrawer = ({
+  children,
+  isLogDrawerExpanded,
+  jobName,
+  jobId,
+  setIsLogDrawerExpanded,
+}) => {
+  const [stdout, setStdOut] = useState();
+  useEffect(() => {
+    const fetchlogs = async () => {
+      setStdOut(await getLogs(jobId));
+    };
+
+    if (isLogDrawerExpanded) {
+      fetchlogs();
+    }
+  }, [isLogDrawerExpanded]);
+
+  const drawerRef = useRef();
+  const onExpand = () => {
+    drawerRef.current && drawerRef.current.focus();
+  };
+
+  const onCloseClick = () => {
+    setIsLogDrawerExpanded(false);
+  };
+
+  const panelContent = (
+    <DrawerPanelContent
+      isResizable
+      id="end-resize-panel"
+      defaultSize="1000px"
+      minSize="500px"
+    >
+      <DrawerHead>
+        <TextContent>
+          <Text component={TextVariants.h1}>
+            <span tabIndex={isLogDrawerExpanded ? 0 : -1} ref={drawerRef}>
+              {`Log for: ${jobName || 'System deleted'}`}
+            </span>
+          </Text>
+        </TextContent>
+        <DrawerActions>
+          <DrawerCloseButton onClick={onCloseClick} />
+        </DrawerActions>
+      </DrawerHead>
+      <DrawerPanelBody>
+        <LogDrawerDetails logs={stdout} jobName={jobName} />
+      </DrawerPanelBody>
+    </DrawerPanelContent>
+  );
+
+  return (
+    <Drawer isExpanded={isLogDrawerExpanded} onExpand={onExpand} position="end">
+      <DrawerContent panelContent={panelContent}>
+        <DrawerContentBody>{children}</DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+JobLogDrawer.propTypes = {
+  children: propTypes.node,
+  isLogDrawerExpanded: propTypes.bool,
+  jobName: propTypes.string,
+  jobId: propTypes.string,
+  setIsLogDrawerExpanded: propTypes.func,
+};
+
+export default JobLogDrawer;

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobLogDrawer.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobLogDrawer.js
@@ -44,12 +44,7 @@ const JobLogDrawer = ({
   };
 
   const panelContent = (
-    <DrawerPanelContent
-      isResizable
-      id="end-resize-panel"
-      defaultSize="1000px"
-      minSize="500px"
-    >
+    <DrawerPanelContent id="log-drawer" defaultSize="100%">
       <DrawerHead>
         <TextContent>
           <Text component={TextVariants.h1}>
@@ -69,7 +64,7 @@ const JobLogDrawer = ({
   );
 
   return (
-    <Drawer isExpanded={isLogDrawerExpanded} onExpand={onExpand} position="end">
+    <Drawer isExpanded={isLogDrawerExpanded} onExpand={onExpand}>
       <DrawerContent panelContent={panelContent}>
         <DrawerContentBody>{children}</DrawerContentBody>
       </DrawerContent>
@@ -81,7 +76,7 @@ JobLogDrawer.propTypes = {
   children: propTypes.node,
   isLogDrawerExpanded: propTypes.bool,
   jobName: propTypes.string,
-  jobId: propTypes.string,
+  jobId: propTypes.number,
   setIsLogDrawerExpanded: propTypes.func,
 };
 

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobResultsDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobResultsDetails.js
@@ -1,22 +1,35 @@
 import React from 'react';
 import propTypes from 'prop-types';
+import { Button } from '@patternfly/react-core';
 import { Table, Tbody } from '@patternfly/react-table';
 import { buildResultsRows } from './jobResultsDetailsHelpers';
 import ExpandedIssues from './ExpandedIssues';
 
-const JobResultsDetails = ({ taskSlug, item }) => {
+const JobResultsDetails = ({
+  taskSlug,
+  item,
+  setIsLogDrawerExpanded,
+  setJobName,
+  setJobId,
+}) => {
   const isReportJson = item.results.report_json?.entries ? true : false;
 
   const rowPairs = isReportJson
     ? buildResultsRows(item.results.report_json.entries, isReportJson, taskSlug)
     : buildResultsRows([item.results.report], isReportJson, taskSlug);
 
+  const handleViewLogs = (id, jobName) => {
+    setIsLogDrawerExpanded(true);
+    setJobId(id);
+    setJobName(jobName);
+  };
+
   return (
     <div>
       <Table
         variant="compact"
         style={{
-          marginBottom: '30px',
+          marginBottom: '16px',
           '--pf-v5-c-table__expandable-row--after--border-width--base': '0',
         }}
       >
@@ -24,12 +37,25 @@ const JobResultsDetails = ({ taskSlug, item }) => {
           <ExpandedIssues rowPairs={rowPairs} isReportJson={isReportJson} />
         </Tbody>
       </Table>
+      {item.has_stdout && (
+        <Button
+          style={{ paddingLeft: '32px', paddingBottom: '16px' }}
+          variant="link"
+          isInline
+          onClick={() => handleViewLogs(item.id, item.display_name)}
+        >
+          View logs
+        </Button>
+      )}
     </div>
   );
 };
 
 JobResultsDetails.propTypes = {
   item: propTypes.object,
+  setIsLogDrawerExpanded: propTypes.func,
+  setJobId: propTypes.func,
+  setJobName: propTypes.func,
   taskSlug: propTypes.string,
 };
 

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/LogDrawerDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/LogDrawerDetails.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { LogViewer, LogViewerSearch } from '@patternfly/react-log-viewer';
+import {
+  Icon,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+  Button,
+} from '@patternfly/react-core';
+import { ExportIcon } from '@patternfly/react-icons';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm';
+
+const LogDrawerDetails = ({ jobName, logs }) => {
+  function downloadFile(
+    data,
+    filename = `${new Date().toISOString()}`,
+    format = 'txt'
+  ) {
+    const blob = new Blob([data], { type: 'text/plain;charset=utf-8' });
+    const link = document.createElement('a');
+    link.setAttribute('href', URL.createObjectURL(blob));
+    link.setAttribute('download', `${filename}.${format}`);
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
+
+  function openInNewTab(data) {
+    const blob = new Blob([data], { type: 'text/plain;charset=utf-8' });
+    window.open(URL.createObjectURL(blob), '_blank');
+  }
+
+  const onDownloadLogClick = () => {
+    downloadFile(logs, `${jobName}-${new Date().toISOString()}`);
+  };
+
+  return (
+    <LogViewer
+      data={logs}
+      toolbar={
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarItem>
+              <LogViewerSearch
+                style={{ minWidth: '300px' }}
+                placeholder="Search"
+              />
+            </ToolbarItem>
+            <ToolbarItem style={{ marginRight: '0px' }}>
+              <Button variant="plain" onClick={onDownloadLogClick}>
+                <Icon>
+                  <ExportIcon />
+                </Icon>
+              </Button>
+            </ToolbarItem>
+            <ToolbarItem>
+              <Button
+                variant="link"
+                onClick={() =>
+                  openInNewTab(logs, `${jobName}-${new Date().toISOString()}`)
+                }
+              >
+                Open log in new tab{' '}
+                {
+                  <Icon>
+                    <ExternalLinkAltIcon />
+                  </Icon>
+                }
+              </Button>
+            </ToolbarItem>
+          </ToolbarContent>
+        </Toolbar>
+      }
+    />
+  );
+};
+
+LogDrawerDetails.propTypes = {
+  jobName: propTypes.string,
+  logs: propTypes.string,
+};
+
+export default LogDrawerDetails;

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/LogDrawerDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/LogDrawerDetails.js
@@ -49,7 +49,11 @@ const LogDrawerDetails = ({ jobName, logs }) => {
               />
             </ToolbarItem>
             <ToolbarItem style={{ marginRight: '0px' }}>
-              <Button variant="plain" onClick={onDownloadLogClick}>
+              <Button
+                data-testid="download-button"
+                variant="plain"
+                onClick={onDownloadLogClick}
+              >
                 <Icon>
                   <ExportIcon />
                 </Icon>

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/__tests__/JobLogDrawer.tests.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/__tests__/JobLogDrawer.tests.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, fireEvent, act, screen } from '@testing-library/react';
+import JobLogDrawer from '../JobLogDrawer';
+import { getLogs } from '../../../../../api';
+
+jest.mock('../../../../../api');
+
+describe('JobLogDrawer', () => {
+  it('renders without crashing', () => {
+    render(<JobLogDrawer />);
+  });
+
+  it('fetches logs when drawer is expanded', async () => {
+    getLogs.mockResolvedValue('Mocked logs');
+
+    render(
+      <JobLogDrawer
+        isLogDrawerExpanded={true}
+        jobId={1}
+        jobName="system1"
+        setIsLogDrawerExpanded={() => jest.fn()}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button'));
+    });
+
+    expect(getLogs).toHaveBeenCalledWith(1);
+  });
+
+  it('does not fetch logs when drawer is not expanded', () => {
+    render(<JobLogDrawer isLogDrawerExpanded={false} jobId={1} />);
+
+    expect(getLogs).not.toHaveBeenCalled();
+  });
+
+  it('closes the drawer when close button is clicked', () => {
+    const mockSetIsLogDrawerExpanded = jest.fn();
+
+    const { getByRole } = render(
+      <JobLogDrawer
+        isLogDrawerExpanded={true}
+        setIsLogDrawerExpanded={mockSetIsLogDrawerExpanded}
+      />
+    );
+
+    fireEvent.click(getByRole('button'));
+
+    expect(mockSetIsLogDrawerExpanded).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/__tests__/JobLogDrawer.tests.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/__tests__/JobLogDrawer.tests.js
@@ -1,11 +1,15 @@
 import React from 'react';
-import { render, fireEvent, act, screen } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import JobLogDrawer from '../JobLogDrawer';
 import { getLogs } from '../../../../../api';
 
 jest.mock('../../../../../api');
 
 describe('JobLogDrawer', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders without crashing', () => {
     render(<JobLogDrawer />);
   });
@@ -22,10 +26,6 @@ describe('JobLogDrawer', () => {
       />
     );
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button'));
-    });
-
     expect(getLogs).toHaveBeenCalledWith(1);
   });
 
@@ -38,14 +38,14 @@ describe('JobLogDrawer', () => {
   it('closes the drawer when close button is clicked', () => {
     const mockSetIsLogDrawerExpanded = jest.fn();
 
-    const { getByRole } = render(
+    render(
       <JobLogDrawer
         isLogDrawerExpanded={true}
         setIsLogDrawerExpanded={mockSetIsLogDrawerExpanded}
       />
     );
 
-    fireEvent.click(getByRole('button'));
+    fireEvent.click(screen.getByLabelText('Close drawer panel'));
 
     expect(mockSetIsLogDrawerExpanded).toHaveBeenCalledWith(false);
   });

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/__tests__/LogDrawerDetails.test.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/__tests__/LogDrawerDetails.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import LogDrawerDetails from '../LogDrawerDetails';
+
+describe('LogDrawerDetails', () => {
+  const jobName = 'Test Job';
+  const logs = 'Sample log data';
+
+  test('renders log viewer with correct props', () => {
+    render(<LogDrawerDetails jobName={jobName} logs={logs} />);
+
+    // Assert that the LogViewer component is rendered with the correct props
+    expect(screen.getByTestId('log-viewer')).toHaveAttribute('data', logs);
+  });
+
+  test('calls downloadFile function when download button is clicked', () => {
+    render(<LogDrawerDetails jobName={jobName} logs={logs} />);
+
+    // Mock the downloadFile function
+    const mockDownloadFile = jest.fn();
+    jest.spyOn(global, 'URL').mockReturnValueOnce({
+      createObjectURL: jest.fn(),
+    });
+    global.URL.createObjectURL = jest.fn();
+
+    // Click the download button
+    fireEvent.click(screen.getByTestId('download-button'));
+
+    // Assert that the downloadFile function is called with the correct arguments
+    expect(mockDownloadFile).toHaveBeenCalledWith(logs, expect.any(String));
+
+    // Restore the mock
+    global.URL.createObjectURL.mockRestore();
+  });
+
+  test('opens log in new tab when open button is clicked', () => {
+    render(<LogDrawerDetails jobName={jobName} logs={logs} />);
+
+    // Mock the openInNewTab function
+    const mockOpenInNewTab = jest.fn();
+    jest.spyOn(global, 'URL').mockReturnValueOnce({
+      createObjectURL: jest.fn(),
+    });
+    global.URL.createObjectURL = jest.fn();
+
+    // Click the open button
+    fireEvent.click(screen.getByTestId('open-button'));
+
+    // Assert that the openInNewTab function is called with the correct arguments
+    expect(mockOpenInNewTab).toHaveBeenCalledWith(logs);
+
+    // Restore the mock
+    global.URL.createObjectURL.mockRestore();
+  });
+});

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/__tests__/LogDrawerDetails.test.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/__tests__/LogDrawerDetails.test.js
@@ -10,14 +10,12 @@ describe('LogDrawerDetails', () => {
     render(<LogDrawerDetails jobName={jobName} logs={logs} />);
 
     // Assert that the LogViewer component is rendered with the correct props
-    expect(screen.getByTestId('log-viewer')).toHaveAttribute('data', logs);
+    expect(screen.getByText('Sample log data')).toBeVisible();
   });
 
   test('calls downloadFile function when download button is clicked', () => {
     render(<LogDrawerDetails jobName={jobName} logs={logs} />);
 
-    // Mock the downloadFile function
-    const mockDownloadFile = jest.fn();
     jest.spyOn(global, 'URL').mockReturnValueOnce({
       createObjectURL: jest.fn(),
     });
@@ -27,7 +25,7 @@ describe('LogDrawerDetails', () => {
     fireEvent.click(screen.getByTestId('download-button'));
 
     // Assert that the downloadFile function is called with the correct arguments
-    expect(mockDownloadFile).toHaveBeenCalledWith(logs, expect.any(String));
+    expect(global.URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
 
     // Restore the mock
     global.URL.createObjectURL.mockRestore();
@@ -36,18 +34,20 @@ describe('LogDrawerDetails', () => {
   test('opens log in new tab when open button is clicked', () => {
     render(<LogDrawerDetails jobName={jobName} logs={logs} />);
 
-    // Mock the openInNewTab function
-    const mockOpenInNewTab = jest.fn();
     jest.spyOn(global, 'URL').mockReturnValueOnce({
       createObjectURL: jest.fn(),
     });
     global.URL.createObjectURL = jest.fn();
 
-    // Click the open button
-    fireEvent.click(screen.getByTestId('open-button'));
+    // Click the open log in new tab button
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /open log in new tab/i,
+      })
+    );
 
     // Assert that the openInNewTab function is called with the correct arguments
-    expect(mockOpenInNewTab).toHaveBeenCalledWith(logs);
+    expect(global.URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
 
     // Restore the mock
     global.URL.createObjectURL.mockRestore();

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -2,403 +2,147 @@
 
 exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`] = `
 <DocumentFragment>
-  <div>
+  <div
+    class="pf-v5-c-page my-app-modified-drawer-width"
+  >
     <div
-      class="pf-v5-c-drawer"
+      class="pf-v5-c-page__drawer"
     >
       <div
-        class="pf-v5-c-drawer__main"
+        class="pf-v5-c-drawer"
       >
         <div
-          class="pf-v5-c-drawer__content"
+          class="pf-v5-c-drawer__main"
         >
           <div
-            class="pf-v5-c-drawer__body"
+            class="pf-v5-c-drawer__content"
           >
-            <section
-              class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
-              widget-type="InsightsPageHeader"
+            <div
+              class="pf-v5-c-drawer__body"
             >
-              <nav
-                aria-label="Breadcrumb"
-                class="pf-v5-c-breadcrumb"
-                data-ouia-component-id="completed-tasks-details-breadcrumb"
-                data-ouia-component-type="PF5/Breadcrumb"
-                data-ouia-safe="true"
+              <main
+                class="pf-v5-c-page__main"
+                tabindex="-1"
               >
-                <ol
-                  class="pf-v5-c-breadcrumb__list"
-                  role="list"
+                <section
+                  class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+                  widget-type="InsightsPageHeader"
                 >
-                  <li
-                    class="pf-v5-c-breadcrumb__item"
+                  <nav
+                    aria-label="Breadcrumb"
+                    class="pf-v5-c-breadcrumb"
+                    data-ouia-component-id="completed-tasks-details-breadcrumb"
+                    data-ouia-component-type="PF5/Breadcrumb"
+                    data-ouia-safe="true"
                   >
-                    <a
-                      class="pf-v5-c-breadcrumb__link"
-                      href="/insights/tasks/executed"
+                    <ol
+                      class="pf-v5-c-breadcrumb__list"
+                      role="list"
                     >
-                      Tasks
-                    </a>
-                  </li>
-                  <li
-                    class="pf-v5-c-breadcrumb__item"
-                  >
-                    <span
-                      class="pf-v5-c-breadcrumb__item-divider"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
+                      <li
+                        class="pf-v5-c-breadcrumb__item"
                       >
-                        <path
-                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                        />
-                      </svg>
-                    </span>
-                    convert-to-rhel-preanalysis task
-                  </li>
-                </ol>
-              </nav>
-              <div
-                class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
-              >
-                <div
-                  class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
-                >
-                  <div
-                    class=""
-                  >
-                    <h1
-                      class="pf-v5-c-title pf-m-2xl"
-                      data-ouia-component-id="OUIA-Generated-Title-2"
-                      data-ouia-component-type="PF5/Title"
-                      data-ouia-safe="true"
-                      widget-type="InsightsPageHeaderTitle"
-                    >
-                      convert-to-rhel-preanalysis task
-                    </h1>
-                    <div
-                      class="pf-v5-c-content"
-                    >
-                      <small
-                        class=""
-                        data-ouia-component-id="OUIA-Generated-Text-3"
-                        data-ouia-component-type="PF5/Text"
-                        data-ouia-safe="true"
-                        data-pf-content="true"
+                        <a
+                          class="pf-v5-c-breadcrumb__link"
+                          href="/insights/tasks/executed"
+                        >
+                          Tasks
+                        </a>
+                      </li>
+                      <li
+                        class="pf-v5-c-breadcrumb__item"
                       >
-                        Convert to RHEL Preanalysis
-                      </small>
-                    </div>
-                  </div>
+                        <span
+                          class="pf-v5-c-breadcrumb__item-divider"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </span>
+                        convert-to-rhel-preanalysis task
+                      </li>
+                    </ol>
+                  </nav>
                   <div
-                    class=""
-                  >
-                    <p>
-                      For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="pf-v5-l-flex"
-                >
-                  <div
-                    class=""
-                  >
-                    <button
-                      aria-disabled="false"
-                      aria-label="convert-to-rhel-preanalysis-run-task-button"
-                      class="pf-v5-c-button pf-m-secondary"
-                      data-ouia-component-id="OUIA-Generated-Button-secondary-2"
-                      data-ouia-component-type="PF5/Button"
-                      data-ouia-safe="true"
-                      type="button"
-                    >
-                      Run task again
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="pf-v5-l-flex"
-                >
-                  <div
-                    class=""
-                  >
-                    <button
-                      aria-expanded="false"
-                      aria-label="Task details menu toggle"
-                      class="pf-v5-c-menu-toggle pf-m-plain"
-                      id="executed-task-kebab"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 192 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </section>
-            <section
-              class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
-            >
-              <div
-                class="pf-v5-c-card"
-                data-ouia-component-id="OUIA-Generated-Card-3"
-                data-ouia-component-type="PF5/Card"
-                data-ouia-safe="true"
-                id=""
-              >
-                <div
-                  class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
-                >
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
+                    class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
                   >
                     <div
-                      class=""
-                    >
-                      <b>
-                        Systems
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      3
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Run start
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      01 Jun 2023, 19:58 UTC
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Run end
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      -
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Initiated by
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      insights-qa
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Systems with alerts
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      -
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <br />
-              <div
-                class="pf-v5-c-card"
-                data-ouia-component-id="OUIA-Generated-Card-4"
-                data-ouia-component-type="PF5/Card"
-                data-ouia-safe="true"
-                id=""
-              >
-                <div
-                  class="pf-v5-c-toolbar  ins-c-primary-toolbar"
-                  data-ouia-component-id="PrimaryToolbar"
-                  data-ouia-component-type="PF5/Toolbar"
-                  data-ouia-safe="true"
-                  id="ins-primary-data-toolbar"
-                >
-                  <div
-                    class="pf-v5-c-toolbar__content"
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__content-section"
+                      class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
                     >
                       <div
-                        class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+                        class=""
                       >
-                        <div
-                          class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                        <h1
+                          class="pf-v5-c-title pf-m-2xl"
+                          data-ouia-component-id="OUIA-Generated-Title-2"
+                          data-ouia-component-type="PF5/Title"
+                          data-ouia-safe="true"
+                          widget-type="InsightsPageHeaderTitle"
                         >
-                          <div
-                            class="pf-v5-l-split ins-c-conditional-filter"
+                          convert-to-rhel-preanalysis task
+                        </h1>
+                        <div
+                          class="pf-v5-c-content"
+                        >
+                          <small
+                            class=""
+                            data-ouia-component-id="OUIA-Generated-Text-3"
+                            data-ouia-component-type="PF5/Text"
+                            data-ouia-safe="true"
+                            data-pf-content="true"
                           >
-                            <div
-                              class="pf-v5-l-split__item"
-                            >
-                              <button
-                                aria-expanded="false"
-                                aria-label="Conditional filter"
-                                class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
-                                type="button"
-                              >
-                                <span
-                                  class="pf-v5-c-menu-toggle__text"
-                                >
-                                  <span
-                                    class="pf-v5-c-icon pf-m-md"
-                                  >
-                                    <span
-                                      class="pf-v5-c-icon__content"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 512 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </span>
-                                  <span
-                                    class="ins-c-conditional-filter__value-selector"
-                                  >
-                                    Name
-                                  </span>
-                                </span>
-                                <span
-                                  class="pf-v5-c-menu-toggle__controls"
-                                >
-                                  <span
-                                    class="pf-v5-c-menu-toggle__toggle-icon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 320 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-l-split__item pf-m-fill"
-                            >
-                              <span
-                                class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
-                              >
-                                <input
-                                  aria-invalid="false"
-                                  aria-label="text input"
-                                  data-ouia-component-id="ConditionalFilter"
-                                  data-ouia-component-type="PF5/TextInput"
-                                  data-ouia-safe="true"
-                                  placeholder="Filter by name"
-                                  type="text"
-                                  value=""
-                                  widget-type="InsightsInput"
-                                />
-                                <span
-                                  class="pf-v5-c-form-control__utilities"
-                                >
-                                  <span
-                                    class="pf-v5-c-form-control__icon"
-                                  >
-                                    <span
-                                      class="pf-v5-c-icon pf-m-md ins-c-search-icon"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </div>
-                          </div>
+                            Convert to RHEL Preanalysis
+                          </small>
                         </div>
                       </div>
                       <div
-                        class="pf-v5-c-toolbar__item pf-m-spacer-sm"
+                        class=""
+                      >
+                        <p>
+                          For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="pf-v5-l-flex"
+                    >
+                      <div
+                        class=""
+                      >
+                        <button
+                          aria-disabled="false"
+                          aria-label="convert-to-rhel-preanalysis-run-task-button"
+                          class="pf-v5-c-button pf-m-secondary"
+                          data-ouia-component-id="OUIA-Generated-Button-secondary-2"
+                          data-ouia-component-type="PF5/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          Run task again
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="pf-v5-l-flex"
+                    >
+                      <div
+                        class=""
                       >
                         <button
                           aria-expanded="false"
-                          aria-label="Export"
+                          aria-label="Task details menu toggle"
                           class="pf-v5-c-menu-toggle pf-m-plain"
+                          id="executed-task-kebab"
                           type="button"
                         >
                           <svg
@@ -407,48 +151,293 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                             fill="currentColor"
                             height="1em"
                             role="img"
-                            viewBox="0 0 1024 1024"
+                            viewBox="0 0 192 512"
                             width="1em"
                           >
                             <path
-                              d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                             />
                           </svg>
                         </button>
                       </div>
+                    </div>
+                  </div>
+                </section>
+                <section
+                  class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
+                >
+                  <div
+                    class="pf-v5-c-card"
+                    data-ouia-component-id="OUIA-Generated-Card-3"
+                    data-ouia-component-type="PF5/Card"
+                    data-ouia-safe="true"
+                    id=""
+                  >
+                    <div
+                      class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
+                    >
                       <div
-                        class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
+                        class="pf-v5-l-flex pf-m-column"
                       >
                         <div
-                          class="pf-v5-c-pagination pf-m-compact"
-                          data-ouia-component-id="CompactPagination"
-                          data-ouia-component-type="PF5/Pagination"
-                          data-ouia-safe="true"
-                          id="options-menu-top-pagination"
-                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                          class=""
+                        >
+                          <b>
+                            Systems
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          3
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Run start
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          01 Jun 2023, 19:58 UTC
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Run end
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          -
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Initiated by
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          insights-qa
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Systems with alerts
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          -
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <br />
+                  <div
+                    class="pf-v5-c-card"
+                    data-ouia-component-id="OUIA-Generated-Card-4"
+                    data-ouia-component-type="PF5/Card"
+                    data-ouia-safe="true"
+                    id=""
+                  >
+                    <div
+                      class="pf-v5-c-toolbar  ins-c-primary-toolbar"
+                      data-ouia-component-id="PrimaryToolbar"
+                      data-ouia-component-type="PF5/Toolbar"
+                      data-ouia-safe="true"
+                      id="ins-primary-data-toolbar"
+                    >
+                      <div
+                        class="pf-v5-c-toolbar__content"
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__content-section"
                         >
                           <div
-                            class="pf-v5-c-pagination__total-items"
+                            class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
                           >
-                            <b>
-                              1 - 3
-                            </b>
-                             of 
-                            <b>
-                              3
-                            </b>
-                             
+                            <div
+                              class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                            >
+                              <div
+                                class="pf-v5-l-split ins-c-conditional-filter"
+                              >
+                                <div
+                                  class="pf-v5-l-split__item"
+                                >
+                                  <button
+                                    aria-expanded="false"
+                                    aria-label="Conditional filter"
+                                    class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="pf-v5-c-menu-toggle__text"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon pf-m-md"
+                                      >
+                                        <span
+                                          class="pf-v5-c-icon__content"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                      <span
+                                        class="ins-c-conditional-filter__value-selector"
+                                      >
+                                        Name
+                                      </span>
+                                    </span>
+                                    <span
+                                      class="pf-v5-c-menu-toggle__controls"
+                                    >
+                                      <span
+                                        class="pf-v5-c-menu-toggle__toggle-icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 320 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-l-split__item pf-m-fill"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      aria-label="text input"
+                                      data-ouia-component-id="ConditionalFilter"
+                                      data-ouia-component-type="PF5/TextInput"
+                                      data-ouia-safe="true"
+                                      placeholder="Filter by name"
+                                      type="text"
+                                      value=""
+                                      widget-type="InsightsInput"
+                                    />
+                                    <span
+                                      class="pf-v5-c-form-control__utilities"
+                                    >
+                                      <span
+                                        class="pf-v5-c-form-control__icon"
+                                      >
+                                        <span
+                                          class="pf-v5-c-icon pf-m-md ins-c-search-icon"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
                           </div>
-                          <div>
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-spacer-sm"
+                          >
                             <button
                               aria-expanded="false"
-                              aria-haspopup="listbox"
-                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                              id="options-menu-top-toggle"
+                              aria-label="Export"
+                              class="pf-v5-c-menu-toggle pf-m-plain"
                               type="button"
                             >
-                              <span
-                                class="pf-v5-c-menu-toggle__text"
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
+                          >
+                            <div
+                              class="pf-v5-c-pagination pf-m-compact"
+                              data-ouia-component-id="CompactPagination"
+                              data-ouia-component-type="PF5/Pagination"
+                              data-ouia-safe="true"
+                              id="options-menu-top-pagination"
+                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                            >
+                              <div
+                                class="pf-v5-c-pagination__total-items"
                               >
                                 <b>
                                   1 - 3
@@ -458,12 +447,171 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                   3
                                 </b>
                                  
-                              </span>
-                              <span
-                                class="pf-v5-c-menu-toggle__controls"
+                              </div>
+                              <div>
+                                <button
+                                  aria-expanded="false"
+                                  aria-haspopup="listbox"
+                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                                  id="options-menu-top-toggle"
+                                  type="button"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__text"
+                                  >
+                                    <b>
+                                      1 - 3
+                                    </b>
+                                     of 
+                                    <b>
+                                      3
+                                    </b>
+                                     
+                                  </span>
+                                  <span
+                                    class="pf-v5-c-menu-toggle__controls"
+                                  >
+                                    <span
+                                      class="pf-v5-c-menu-toggle__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                              <nav
+                                aria-label="Pagination"
+                                class="pf-v5-c-pagination__nav"
+                              >
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to previous page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="previous"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to next page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="next"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </nav>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__content pf-m-hidden"
+                        hidden=""
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__group"
+                        />
+                      </div>
+                    </div>
+                    <table
+                      aria-label="2909-completed-jobs"
+                      class="pf-v5-c-table pf-m-grid-md"
+                      data-ouia-component-id="2909-completed-jobs-table"
+                      data-ouia-component-type="PF5/Table"
+                      data-ouia-safe="true"
+                      role="grid"
+                    >
+                      <thead
+                        class="pf-v5-c-table__thead"
+                      >
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-7"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-key="0"
+                            data-label=""
+                            tabindex="-1"
+                          />
+                          <th
+                            aria-sort="none"
+                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
+                            data-key="1"
+                            data-label="System name"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            <button
+                              class="pf-v5-c-table__button"
+                              type="button"
+                            >
+                              <div
+                                class="pf-v5-c-table__button-content"
                               >
                                 <span
-                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                                  class="pf-v5-c-table__text"
+                                >
+                                  System name
+                                </span>
+                                <span
+                                  class="pf-v5-c-table__sort-indicator"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -471,510 +619,505 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                     fill="currentColor"
                                     height="1em"
                                     role="img"
-                                    viewBox="0 0 320 512"
+                                    viewBox="0 0 256 512"
                                     width="1em"
                                   >
                                     <path
-                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                     />
                                   </svg>
                                 </span>
-                              </span>
+                              </div>
                             </button>
-                          </div>
-                          <nav
-                            aria-label="Pagination"
-                            class="pf-v5-c-pagination__nav"
+                          </th>
+                          <th
+                            aria-sort="none"
+                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
+                            data-key="2"
+                            data-label="Status"
+                            scope="col"
+                            tabindex="-1"
                           >
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
+                            <button
+                              class="pf-v5-c-table__button"
+                              type="button"
                             >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to previous page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="previous"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-7"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
+                              <div
+                                class="pf-v5-c-table__button-content"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
+                                <span
+                                  class="pf-v5-c-table__text"
                                 >
-                                  <path
-                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to next page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="next"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-8"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
+                                  Status
+                                </span>
+                                <span
+                                  class="pf-v5-c-table__sort-indicator"
                                 >
-                                  <path
-                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                          </nav>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-c-toolbar__content pf-m-hidden"
-                    hidden=""
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__group"
-                    />
-                  </div>
-                </div>
-                <table
-                  aria-label="2909-completed-jobs"
-                  class="pf-v5-c-table pf-m-grid-md"
-                  data-ouia-component-id="2909-completed-jobs-table"
-                  data-ouia-component-type="PF5/Table"
-                  data-ouia-safe="true"
-                  role="grid"
-                >
-                  <thead
-                    class="pf-v5-c-table__thead"
-                  >
-                    <tr
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-7"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <th
-                        class="pf-v5-c-table__th"
-                        data-key="0"
-                        data-label=""
-                        tabindex="-1"
-                      />
-                      <th
-                        aria-sort="none"
-                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
-                        data-key="1"
-                        data-label="System name"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        <button
-                          class="pf-v5-c-table__button"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__button-content"
-                          >
-                            <span
-                              class="pf-v5-c-table__text"
-                            >
-                              System name
-                            </span>
-                            <span
-                              class="pf-v5-c-table__sort-indicator"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 256 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="none"
-                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
-                        data-key="2"
-                        data-label="Status"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        <button
-                          class="pf-v5-c-table__button"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__button-content"
-                          >
-                            <span
-                              class="pf-v5-c-table__text"
-                            >
-                              Status
-                            </span>
-                            <span
-                              class="pf-v5-c-table__sort-indicator"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 256 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
-                        data-key="3"
-                        data-label="Message"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        <button
-                          class="pf-v5-c-table__button"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__button-content"
-                          >
-                            <span
-                              class="pf-v5-c-table__text"
-                            >
-                              Message
-                            </span>
-                            <span
-                              class="pf-v5-c-table__sort-indicator"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 256 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </button>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody
-                    class="pf-v5-c-table__tbody"
-                    role="rowgroup"
-                  >
-                    <tr
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-13"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td"
-                        data-key="0"
-                        tabindex="-1"
-                      />
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="1"
-                        data-label="System name"
-                        tabindex="-1"
-                      >
-                        <a
-                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          centos7-test-device-1
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="2"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Success
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="3"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
-                          >
-                            No inhibtors found, conversion should run smoothly for this system.
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                  <tbody
-                    class="pf-v5-c-table__tbody"
-                    role="rowgroup"
-                  >
-                    <tr
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-14"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                        data-key="0"
-                        tabindex="-1"
-                      >
-                        <button
-                          aria-disabled="false"
-                          aria-expanded="false"
-                          aria-label="Details"
-                          aria-labelledby="simple-node1 expandable-toggle1"
-                          class="pf-v5-c-button pf-m-plain"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-9"
-                          data-ouia-component-type="PF5/Button"
-                          data-ouia-safe="true"
-                          id="expandable-toggle1"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__toggle-icon"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="pf-v5-svg"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 320 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                              />
-                            </svg>
-                          </div>
-                        </button>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="1"
-                        data-label="System name"
-                        tabindex="-1"
-                      >
-                        <a
-                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          centos7-test-device-3
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="2"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Success
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="3"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
-                          >
-                            No inhibtors found, conversion should run smoothly for this system.
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr
-                      class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                      data-ouia-component-id="OUIA-Generated-TableRow-15"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                      hidden=""
-                    >
-                      <td
-                        class="pf-v5-c-table__td"
-                        colspan="4"
-                        data-key="0"
-                        id="expanded-content2"
-                        tabindex="-1"
-                      >
-                        <div>
-                          <table
-                            class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                            data-ouia-component-id="OUIA-Generated-Table-5"
-                            data-ouia-component-type="PF5/Table"
-                            data-ouia-safe="true"
-                            role="grid"
-                            style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                          >
-                            <tbody
-                              class="pf-v5-c-table__tbody"
-                              role="rowgroup"
-                            >
-                              <tr
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-16"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node0 expand-toggle0"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-10"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle0"
-                                    type="button"
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 256 512"
+                                    width="1em"
                                   >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
+                                    <path
+                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </button>
+                          </th>
+                          <th
+                            aria-sort="ascending"
+                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
+                            data-key="3"
+                            data-label="Message"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            <button
+                              class="pf-v5-c-table__button"
+                              type="button"
+                            >
+                              <div
+                                class="pf-v5-c-table__button-content"
+                              >
+                                <span
+                                  class="pf-v5-c-table__text"
                                 >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
+                                  Message
+                                </span>
+                                <span
+                                  class="pf-v5-c-table__sort-indicator"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 256 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </button>
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
+                      >
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-13"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-key="0"
+                            tabindex="-1"
+                          />
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="1"
+                            data-label="System name"
+                            tabindex="-1"
+                          >
+                            <a
+                              href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              centos7-test-device-1
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="2"
+                            data-label="Status"
+                            tabindex="-1"
+                          >
+                            Success
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="3"
+                            data-label="Message"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="pf-v5-l-split"
+                            >
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
+                              >
+                                No inhibtors found, conversion should run smoothly for this system.
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
+                      >
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-14"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                            data-key="0"
+                            tabindex="-1"
+                          >
+                            <button
+                              aria-disabled="false"
+                              aria-expanded="false"
+                              aria-label="Details"
+                              aria-labelledby="simple-node1 expandable-toggle1"
+                              class="pf-v5-c-button pf-m-plain"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              id="expandable-toggle1"
+                              type="button"
+                            >
+                              <div
+                                class="pf-v5-c-table__toggle-icon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 320 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                  />
+                                </svg>
+                              </div>
+                            </button>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="1"
+                            data-label="System name"
+                            tabindex="-1"
+                          >
+                            <a
+                              href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              centos7-test-device-3
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="2"
+                            data-label="Status"
+                            tabindex="-1"
+                          >
+                            Success
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="3"
+                            data-label="Message"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="pf-v5-l-split"
+                            >
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
+                              >
+                                No inhibtors found, conversion should run smoothly for this system.
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr
+                          class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                          data-ouia-component-id="OUIA-Generated-TableRow-15"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                          hidden=""
+                        >
+                          <td
+                            class="pf-v5-c-table__td"
+                            colspan="4"
+                            data-key="0"
+                            id="expanded-content2"
+                            tabindex="-1"
+                          >
+                            <div>
+                              <table
+                                class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                                data-ouia-component-id="OUIA-Generated-Table-5"
+                                data-ouia-component-type="PF5/Table"
+                                data-ouia-safe="true"
+                                role="grid"
+                                style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                              >
+                                <tbody
+                                  class="pf-v5-c-table__tbody"
+                                  role="rowgroup"
+                                >
+                                  <tr
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-16"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
                                     >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-danger"
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node0 expand-toggle0"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle0"
+                                        type="button"
                                       >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
                                         >
-                                          <path
-                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(163, 0, 0);"
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
                                     >
-                                      <strong>
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-danger"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(163, 0, 0);"
+                                        >
+                                          <strong>
+                                            Third party packages detected
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-17"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-red pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              Inhibitor
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
                                         Third party packages detected
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-17"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-red pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            Third party packages will not be replaced during the conversion.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Diagnosis
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span>
+                                                Only packages signed by CentOS Linux are to be replaced. Red Hat support won't be provided for the following third party packages:convert2rhel-1.5.0-2.20231124114206033039.main.14.g938833b.el7.noarch
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Remediation
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                If you wish to ignore this message, set the environment variable 'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' to 1.
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            LIST_THIRD_PARTY_PACKAGES::THIRD_PARTY_PACKAGE_DETECTED
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-18"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
                                     >
-                                      <span
-                                        class="pf-v5-c-label__content"
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node1 expand-toggle1"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle1"
+                                        type="button"
                                       >
-                                        <span
-                                          class="pf-v5-c-label__icon"
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
                                         >
                                           <svg
                                             aria-hidden="true"
@@ -982,1099 +1125,886 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                             fill="currentColor"
                                             height="1em"
                                             role="img"
-                                            viewBox="0 0 512 512"
+                                            viewBox="0 0 320 512"
                                             width="1em"
                                           >
                                             <path
-                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
                                             />
                                           </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-warning"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 576 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
                                         </span>
                                         <span
-                                          class="pf-v5-c-label__text"
+                                          style="color: rgb(121, 80, 0);"
                                         >
-                                          Inhibitor
+                                          <strong>
+                                            Dbus is running check skip
+                                          </strong>
                                         </span>
                                       </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    Third party packages detected
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        Third party packages will not be replaced during the conversion.
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Diagnosis
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span>
-                                            Only packages signed by CentOS Linux are to be replaced. Red Hat support won't be provided for the following third party packages:convert2rhel-1.5.0-2.20231124114206033039.main.14.g938833b.el7.noarch
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Remediation
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span
-                                            class="remediations-font-family"
-                                          >
-                                            If you wish to ignore this message, set the environment variable 'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' to 1.
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        LIST_THIRD_PARTY_PACKAGES::THIRD_PARTY_PACKAGE_DETECTED
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-18"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node1 expand-toggle1"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-11"
-                                    data-ouia-component-type="PF5/Button"
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-19"
+                                    data-ouia-component-type="PF5/TableRow"
                                     data-ouia-safe="true"
-                                    id="expand-toggle1"
-                                    type="button"
+                                    hidden=""
                                   >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
                                     >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-warning"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 576 512"
-                                          width="1em"
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
                                         >
-                                          <path
-                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(121, 80, 0);"
-                                    >
-                                      <strong>
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 576 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              Warning
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
                                         Dbus is running check skip
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-19"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-orange pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 576 512"
-                                            width="1em"
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
                                           >
-                                            <path
-                                              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
-                                        >
-                                          Warning
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    Dbus is running check skip
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        Skipping the check because we have been asked not to subscribe this system to RHSM
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        DBUS_IS_RUNNING::SECURE_BOOT_DETECTED
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-20"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node2 expand-toggle2"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-12"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle2"
-                                    type="button"
-                                  >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-info"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(0, 41, 82);"
-                                    >
-                                      <strong>
-                                        Repository file package removal
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-21"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-blue pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
                                           >
-                                            <path
-                                              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
+                                            Skipping the check because we have been asked not to subscribe this system to RHSM
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
                                         >
-                                          Info
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    Repository file package removal
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                  <tbody
-                    class="pf-v5-c-table__tbody"
-                    role="rowgroup"
-                  >
-                    <tr
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-22"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                        data-key="0"
-                        tabindex="-1"
-                      >
-                        <button
-                          aria-disabled="false"
-                          aria-expanded="false"
-                          aria-label="Details"
-                          aria-labelledby="simple-node3 expandable-toggle3"
-                          class="pf-v5-c-button pf-m-plain"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-13"
-                          data-ouia-component-type="PF5/Button"
-                          data-ouia-safe="true"
-                          id="expandable-toggle3"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__toggle-icon"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="pf-v5-svg"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 320 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                              />
-                            </svg>
-                          </div>
-                        </button>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="1"
-                        data-label="System name"
-                        tabindex="-1"
-                      >
-                        <a
-                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc53bee"
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          centos7-test-device-2
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="2"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Success
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="3"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
-                          >
-                            Your system has 3 inhibitors out of 3 potential problems.
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr
-                      class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                      data-ouia-component-id="OUIA-Generated-TableRow-23"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                      hidden=""
-                    >
-                      <td
-                        class="pf-v5-c-table__td"
-                        colspan="4"
-                        data-key="0"
-                        id="expanded-content4"
-                        tabindex="-1"
-                      >
-                        <div>
-                          <table
-                            class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                            data-ouia-component-id="OUIA-Generated-Table-6"
-                            data-ouia-component-type="PF5/Table"
-                            data-ouia-safe="true"
-                            role="grid"
-                            style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                          >
-                            <tbody
-                              class="pf-v5-c-table__tbody"
-                              role="rowgroup"
-                            >
-                              <tr
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-24"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node0 expand-toggle0"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-14"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle0"
-                                    type="button"
-                                  >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-danger"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(163, 0, 0);"
-                                    >
-                                      <strong>
-                                        The version of the loaded kernel is different from the latest version
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-25"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-red pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
                                           >
-                                            <path
-                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
-                                        >
-                                          Inhibitor
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    The version of the loaded kernel is different from the latest version
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        The version of the loaded kernel is different from the latest version in the enabled system repositories.
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Diagnosis
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span>
-                                            Latest kernel version available in updates: 3.10.0-1160.90.1.el7
- Loaded kernel version: 3.10.0-1160.88.1.el7
-                                          </span>
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            DBUS_IS_RUNNING::SECURE_BOOT_DETECTED
+                                          </div>
                                         </div>
                                       </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-20"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
                                     >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node2 expand-toggle2"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle2"
+                                        type="button"
                                       >
-                                        Remediation
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-info"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(0, 41, 82);"
+                                        >
+                                          <strong>
+                                            Repository file package removal
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-21"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-blue pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              Info
+                                            </span>
+                                          </span>
+                                        </span>
                                       </div>
                                       <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
+                                        class="entry-title"
                                       >
-                                        <div>
-                                          <span
-                                            class="remediations-font-family"
+                                        Repository file package removal
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
                                           >
-                                            [hint] To proceed with the conversion, update the kernel version by executing the following steps:
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
+                      >
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-22"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                            data-key="0"
+                            tabindex="-1"
+                          >
+                            <button
+                              aria-disabled="false"
+                              aria-expanded="false"
+                              aria-label="Details"
+                              aria-labelledby="simple-node3 expandable-toggle3"
+                              class="pf-v5-c-button pf-m-plain"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              id="expandable-toggle3"
+                              type="button"
+                            >
+                              <div
+                                class="pf-v5-c-table__toggle-icon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 320 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                  />
+                                </svg>
+                              </div>
+                            </button>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="1"
+                            data-label="System name"
+                            tabindex="-1"
+                          >
+                            <a
+                              href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc53bee"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              centos7-test-device-2
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="2"
+                            data-label="Status"
+                            tabindex="-1"
+                          >
+                            Success
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="3"
+                            data-label="Message"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="pf-v5-l-split"
+                            >
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
+                              >
+                                Your system has 3 inhibitors out of 3 potential problems.
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr
+                          class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                          data-ouia-component-id="OUIA-Generated-TableRow-23"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                          hidden=""
+                        >
+                          <td
+                            class="pf-v5-c-table__td"
+                            colspan="4"
+                            data-key="0"
+                            id="expanded-content4"
+                            tabindex="-1"
+                          >
+                            <div>
+                              <table
+                                class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                                data-ouia-component-id="OUIA-Generated-Table-6"
+                                data-ouia-component-type="PF5/Table"
+                                data-ouia-safe="true"
+                                role="grid"
+                                style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                              >
+                                <tbody
+                                  class="pf-v5-c-table__tbody"
+                                  role="rowgroup"
+                                >
+                                  <tr
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-24"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node0 expand-toggle0"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle0"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-danger"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(163, 0, 0);"
+                                        >
+                                          <strong>
+                                            The version of the loaded kernel is different from the latest version
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-25"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-red pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              Inhibitor
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
+                                        The version of the loaded kernel is different from the latest version
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            The version of the loaded kernel is different from the latest version in the enabled system repositories.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Diagnosis
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span>
+                                                Latest kernel version available in updates: 3.10.0-1160.90.1.el7
+ Loaded kernel version: 3.10.0-1160.88.1.el7
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Remediation
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                [hint] To proceed with the conversion, update the kernel version by executing the following steps:
 
 1. yum install kernel-3.10.0-1160.90.1.el7 -y
 2. reboot
-                                          </span>
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            IS_LOADED_KERNEL_LATEST::INVALID_KERNEL_VERSION
+                                          </div>
                                         </div>
                                       </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        IS_LOADED_KERNEL_LATEST::INVALID_KERNEL_VERSION
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-26"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node1 expand-toggle1"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-15"
-                                    data-ouia-component-type="PF5/Button"
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-26"
+                                    data-ouia-component-type="PF5/TableRow"
                                     data-ouia-safe="true"
-                                    id="expand-toggle1"
-                                    type="button"
                                   >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
                                     >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node1 expand-toggle1"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle1"
+                                        type="button"
                                       >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-danger"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
                                         >
-                                          <path
-                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(163, 0, 0);"
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
                                     >
-                                      <strong>
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-danger"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(163, 0, 0);"
+                                        >
+                                          <strong>
+                                            Secure boot detected
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-27"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-red pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              Inhibitor
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
                                         Secure boot detected
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-27"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-red pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
                                           >
-                                            <path
-                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            The conversion with secure boot is currently not possible.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
                                         >
-                                          Inhibitor
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    Secure boot detected
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        The conversion with secure boot is currently not possible.
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Diagnosis
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span>
-                                            In order to continue the conversion, secure boot must be disabled
-                                          </span>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Diagnosis
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span>
+                                                In order to continue the conversion, secure boot must be disabled
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Remediation
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                [hint] To disable the secure boot, follow the instructions available in this article: https://access.redhat.com/solutions/6753681
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            EFI::SECURE_BOOT_DETECTED
+                                          </div>
                                         </div>
                                       </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Remediation
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span
-                                            class="remediations-font-family"
-                                          >
-                                            [hint] To disable the secure boot, follow the instructions available in this article: https://access.redhat.com/solutions/6753681
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        EFI::SECURE_BOOT_DETECTED
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-28"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node2 expand-toggle2"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-16"
-                                    data-ouia-component-type="PF5/Button"
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-28"
+                                    data-ouia-component-type="PF5/TableRow"
                                     data-ouia-safe="true"
-                                    id="expand-toggle2"
-                                    type="button"
                                   >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
                                     >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node2 expand-toggle2"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle2"
+                                        type="button"
                                       >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-danger"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(163, 0, 0);"
-                                    >
-                                      <strong>
-                                        Package up to date check fail
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-29"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-red pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
                                         >
                                           <svg
                                             aria-hidden="true"
@@ -2082,375 +2012,455 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                             fill="currentColor"
                                             height="1em"
                                             role="img"
-                                            viewBox="0 0 512 512"
+                                            viewBox="0 0 320 512"
                                             width="1em"
                                           >
                                             <path
-                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
                                             />
                                           </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-danger"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
                                         </span>
                                         <span
-                                          class="pf-v5-c-label__text"
+                                          style="color: rgb(163, 0, 0);"
                                         >
-                                          Inhibitor
+                                          <strong>
+                                            Package up to date check fail
+                                          </strong>
                                         </span>
                                       </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-29"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
                                   >
-                                    Package up to date check fail
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
                                     >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        The conversion with secure boot is currently not possible.
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Diagnosis
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span>
-                                            There was an error while checking whether the installed packages are up-to-date. Having an updated system is an important prerequisite for a successful conversion.
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Remediation
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-red pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
                                           <span
-                                            class="remediations-font-family"
+                                            class="pf-v5-c-label__content"
                                           >
-                                            [hint] Consider verifyng the system is up to date manually before proceeding with the conversion.
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              Inhibitor
+                                            </span>
                                           </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
+                                        Package up to date check fail
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            The conversion with secure boot is currently not possible.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Diagnosis
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span>
+                                                There was an error while checking whether the installed packages are up-to-date. Having an updated system is an important prerequisite for a successful conversion.
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Remediation
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                [hint] Consider verifyng the system is up to date manually before proceeding with the conversion.
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            PACKAGE_UPDATES::PACKAGE_UP_TO_DATE_CHECK_FAIL
+                                          </div>
                                         </div>
                                       </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        PACKAGE_UPDATES::PACKAGE_UP_TO_DATE_CHECK_FAIL
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div
-                  class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
-                  data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-2"
-                  data-ouia-component-type="RHI/TableToolbar"
-                  data-ouia-safe="true"
-                  id="pf-random-id-3"
-                >
-                  <div
-                    class="pf-v5-c-toolbar__content"
-                  >
+                                    </td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
                     <div
-                      class="pf-v5-c-toolbar__content-section"
+                      class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
+                      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-2"
+                      data-ouia-component-type="RHI/TableToolbar"
+                      data-ouia-safe="true"
+                      id="pf-random-id-3"
                     >
                       <div
-                        class="pf-v5-c-toolbar__item pf-m-align-self-center"
+                        class="pf-v5-c-toolbar__content"
                       >
-                        <div>
+                        <div
+                          class="pf-v5-c-toolbar__content-section"
+                        >
                           <div
-                            style="display: contents;"
+                            class="pf-v5-c-toolbar__item pf-m-align-self-center"
+                          >
+                            <div>
+                              <div
+                                style="display: contents;"
+                              >
+                                <div
+                                  class="pf-v5-c-content"
+                                >
+                                  <small
+                                    class=""
+                                    data-ouia-component-id="OUIA-Generated-Text-4"
+                                    data-ouia-component-type="PF5/Text"
+                                    data-ouia-safe="true"
+                                    data-pf-content="true"
+                                  >
+                                    Last updated: All jobs completed
+                                  </small>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
                           >
                             <div
-                              class="pf-v5-c-content"
+                              class="pf-v5-c-pagination pf-m-bottom"
+                              data-ouia-component-id="OUIA-Generated-Pagination-bottom-2"
+                              data-ouia-component-type="PF5/Pagination"
+                              data-ouia-safe="true"
+                              id="options-menu-bottom-pagination"
+                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                             >
-                              <small
-                                class=""
-                                data-ouia-component-id="OUIA-Generated-Text-4"
-                                data-ouia-component-type="PF5/Text"
-                                data-ouia-safe="true"
-                                data-pf-content="true"
+                              <div>
+                                <button
+                                  aria-expanded="false"
+                                  aria-haspopup="listbox"
+                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                                  id="options-menu-bottom-toggle"
+                                  type="button"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__text"
+                                  >
+                                    <b>
+                                      1 - 3
+                                    </b>
+                                     of 
+                                    <b>
+                                      3
+                                    </b>
+                                     
+                                  </span>
+                                  <span
+                                    class="pf-v5-c-menu-toggle__controls"
+                                  >
+                                    <span
+                                      class="pf-v5-c-menu-toggle__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                              <nav
+                                aria-label="Pagination"
+                                class="pf-v5-c-pagination__nav"
                               >
-                                Last updated: All jobs completed
-                              </small>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-first"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to first page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="first"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-17"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to previous page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="previous"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-page-select"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control pf-m-disabled"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      aria-label="Current page"
+                                      data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+                                      data-ouia-component-type="PF5/TextInput"
+                                      data-ouia-safe="true"
+                                      disabled=""
+                                      max="1"
+                                      min="1"
+                                      type="number"
+                                      value="1"
+                                    />
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                  >
+                                    of 1
+                                  </span>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to next page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="next"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-19"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-last"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to last page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="last"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-20"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </nav>
                             </div>
                           </div>
                         </div>
                       </div>
                       <div
-                        class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
+                        class="pf-v5-c-toolbar__content pf-m-hidden"
+                        hidden=""
                       >
                         <div
-                          class="pf-v5-c-pagination pf-m-bottom"
-                          data-ouia-component-id="OUIA-Generated-Pagination-bottom-2"
-                          data-ouia-component-type="PF5/Pagination"
-                          data-ouia-safe="true"
-                          id="options-menu-bottom-pagination"
-                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-                        >
-                          <div>
-                            <button
-                              aria-expanded="false"
-                              aria-haspopup="listbox"
-                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                              id="options-menu-bottom-toggle"
-                              type="button"
-                            >
-                              <span
-                                class="pf-v5-c-menu-toggle__text"
-                              >
-                                <b>
-                                  1 - 3
-                                </b>
-                                 of 
-                                <b>
-                                  3
-                                </b>
-                                 
-                              </span>
-                              <span
-                                class="pf-v5-c-menu-toggle__controls"
-                              >
-                                <span
-                                  class="pf-v5-c-menu-toggle__toggle-icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 320 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                    />
-                                  </svg>
-                                </span>
-                              </span>
-                            </button>
-                          </div>
-                          <nav
-                            aria-label="Pagination"
-                            class="pf-v5-c-pagination__nav"
-                          >
-                            <div
-                              class="pf-v5-c-pagination__nav-control pf-m-first"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to first page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="first"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-17"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 448 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to previous page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="previous"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-18"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-page-select"
-                            >
-                              <span
-                                class="pf-v5-c-form-control pf-m-disabled"
-                              >
-                                <input
-                                  aria-invalid="false"
-                                  aria-label="Current page"
-                                  data-ouia-component-id="OUIA-Generated-TextInputBase-4"
-                                  data-ouia-component-type="PF5/TextInput"
-                                  data-ouia-safe="true"
-                                  disabled=""
-                                  max="1"
-                                  min="1"
-                                  type="number"
-                                  value="1"
-                                />
-                              </span>
-                              <span
-                                aria-hidden="true"
-                              >
-                                of 1
-                              </span>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to next page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="next"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-19"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control pf-m-last"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to last page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="last"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-20"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 448 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                          </nav>
-                        </div>
+                          class="pf-v5-c-toolbar__group"
+                        />
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="pf-v5-c-toolbar__content pf-m-hidden"
-                    hidden=""
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__group"
-                    />
-                  </div>
-                </div>
-              </div>
-            </section>
+                </section>
+              </main>
+            </div>
           </div>
+          <div
+            class="pf-v5-c-drawer__panel"
+            hidden=""
+            id="pf-drawer-panel-2"
+          />
         </div>
-        <div
-          class="pf-v5-c-drawer__panel pf-m-resizable"
-          hidden=""
-          id="end-resize-panel"
-          style="--pf-v5-c-drawer__panel--md--FlexBasis: 1000px; --pf-v5-c-drawer__panel--md--FlexBasis--min: 500px;"
-        />
       </div>
     </div>
   </div>
@@ -2459,403 +2469,147 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
 
 exports[`CompletedTaskDetails should render correctly completed 1`] = `
 <DocumentFragment>
-  <div>
+  <div
+    class="pf-v5-c-page my-app-modified-drawer-width"
+  >
     <div
-      class="pf-v5-c-drawer"
+      class="pf-v5-c-page__drawer"
     >
       <div
-        class="pf-v5-c-drawer__main"
+        class="pf-v5-c-drawer"
       >
         <div
-          class="pf-v5-c-drawer__content"
+          class="pf-v5-c-drawer__main"
         >
           <div
-            class="pf-v5-c-drawer__body"
+            class="pf-v5-c-drawer__content"
           >
-            <section
-              class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
-              widget-type="InsightsPageHeader"
+            <div
+              class="pf-v5-c-drawer__body"
             >
-              <nav
-                aria-label="Breadcrumb"
-                class="pf-v5-c-breadcrumb"
-                data-ouia-component-id="completed-tasks-details-breadcrumb"
-                data-ouia-component-type="PF5/Breadcrumb"
-                data-ouia-safe="true"
+              <main
+                class="pf-v5-c-page__main"
+                tabindex="-1"
               >
-                <ol
-                  class="pf-v5-c-breadcrumb__list"
-                  role="list"
+                <section
+                  class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+                  widget-type="InsightsPageHeader"
                 >
-                  <li
-                    class="pf-v5-c-breadcrumb__item"
+                  <nav
+                    aria-label="Breadcrumb"
+                    class="pf-v5-c-breadcrumb"
+                    data-ouia-component-id="completed-tasks-details-breadcrumb"
+                    data-ouia-component-type="PF5/Breadcrumb"
+                    data-ouia-safe="true"
                   >
-                    <a
-                      class="pf-v5-c-breadcrumb__link"
-                      href="/insights/tasks/executed"
+                    <ol
+                      class="pf-v5-c-breadcrumb__list"
+                      role="list"
                     >
-                      Tasks
-                    </a>
-                  </li>
-                  <li
-                    class="pf-v5-c-breadcrumb__item"
-                  >
-                    <span
-                      class="pf-v5-c-breadcrumb__item-divider"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
+                      <li
+                        class="pf-v5-c-breadcrumb__item"
                       >
-                        <path
-                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                        />
-                      </svg>
-                    </span>
-                    log4j task
-                  </li>
-                </ol>
-              </nav>
-              <div
-                class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
-              >
-                <div
-                  class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
-                >
-                  <div
-                    class=""
-                  >
-                    <h1
-                      class="pf-v5-c-title pf-m-2xl"
-                      data-ouia-component-id="OUIA-Generated-Title-1"
-                      data-ouia-component-type="PF5/Title"
-                      data-ouia-safe="true"
-                      widget-type="InsightsPageHeaderTitle"
-                    >
-                      log4j task
-                    </h1>
-                    <div
-                      class="pf-v5-c-content"
-                    >
-                      <small
-                        class=""
-                        data-ouia-component-id="OUIA-Generated-Text-1"
-                        data-ouia-component-type="PF5/Text"
-                        data-ouia-safe="true"
-                        data-pf-content="true"
+                        <a
+                          class="pf-v5-c-breadcrumb__link"
+                          href="/insights/tasks/executed"
+                        >
+                          Tasks
+                        </a>
+                      </li>
+                      <li
+                        class="pf-v5-c-breadcrumb__item"
                       >
-                        Log4J Detection
-                      </small>
-                    </div>
-                  </div>
+                        <span
+                          class="pf-v5-c-breadcrumb__item-divider"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </span>
+                        log4j task
+                      </li>
+                    </ol>
+                  </nav>
                   <div
-                    class=""
-                  >
-                    <p>
-                      Uses the insights-client to determine if systems are affected by the LogShell vulnerability. Resource intensive scan
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="pf-v5-l-flex"
-                >
-                  <div
-                    class=""
-                  >
-                    <button
-                      aria-disabled="false"
-                      aria-label="log4j-run-task-button"
-                      class="pf-v5-c-button pf-m-secondary"
-                      data-ouia-component-id="OUIA-Generated-Button-secondary-1"
-                      data-ouia-component-type="PF5/Button"
-                      data-ouia-safe="true"
-                      type="button"
-                    >
-                      Run task again
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="pf-v5-l-flex"
-                >
-                  <div
-                    class=""
-                  >
-                    <button
-                      aria-expanded="false"
-                      aria-label="Task details menu toggle"
-                      class="pf-v5-c-menu-toggle pf-m-plain"
-                      id="executed-task-kebab"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 192 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </section>
-            <section
-              class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
-            >
-              <div
-                class="pf-v5-c-card"
-                data-ouia-component-id="OUIA-Generated-Card-1"
-                data-ouia-component-type="PF5/Card"
-                data-ouia-safe="true"
-                id=""
-              >
-                <div
-                  class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
-                >
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
+                    class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
                   >
                     <div
-                      class=""
-                    >
-                      <b>
-                        Systems
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      3
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Run start
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      21 Apr 2022, 10:10 UTC
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Run end
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      25 Apr 2022, 10:10 UTC (5760 min)
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Initiated by
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      UserX
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Systems with alerts
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      2
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <br />
-              <div
-                class="pf-v5-c-card"
-                data-ouia-component-id="OUIA-Generated-Card-2"
-                data-ouia-component-type="PF5/Card"
-                data-ouia-safe="true"
-                id=""
-              >
-                <div
-                  class="pf-v5-c-toolbar  ins-c-primary-toolbar"
-                  data-ouia-component-id="PrimaryToolbar"
-                  data-ouia-component-type="PF5/Toolbar"
-                  data-ouia-safe="true"
-                  id="ins-primary-data-toolbar"
-                >
-                  <div
-                    class="pf-v5-c-toolbar__content"
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__content-section"
+                      class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
                     >
                       <div
-                        class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+                        class=""
                       >
-                        <div
-                          class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                        <h1
+                          class="pf-v5-c-title pf-m-2xl"
+                          data-ouia-component-id="OUIA-Generated-Title-1"
+                          data-ouia-component-type="PF5/Title"
+                          data-ouia-safe="true"
+                          widget-type="InsightsPageHeaderTitle"
                         >
-                          <div
-                            class="pf-v5-l-split ins-c-conditional-filter"
+                          log4j task
+                        </h1>
+                        <div
+                          class="pf-v5-c-content"
+                        >
+                          <small
+                            class=""
+                            data-ouia-component-id="OUIA-Generated-Text-1"
+                            data-ouia-component-type="PF5/Text"
+                            data-ouia-safe="true"
+                            data-pf-content="true"
                           >
-                            <div
-                              class="pf-v5-l-split__item"
-                            >
-                              <button
-                                aria-expanded="false"
-                                aria-label="Conditional filter"
-                                class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
-                                type="button"
-                              >
-                                <span
-                                  class="pf-v5-c-menu-toggle__text"
-                                >
-                                  <span
-                                    class="pf-v5-c-icon pf-m-md"
-                                  >
-                                    <span
-                                      class="pf-v5-c-icon__content"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 512 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </span>
-                                  <span
-                                    class="ins-c-conditional-filter__value-selector"
-                                  >
-                                    Name
-                                  </span>
-                                </span>
-                                <span
-                                  class="pf-v5-c-menu-toggle__controls"
-                                >
-                                  <span
-                                    class="pf-v5-c-menu-toggle__toggle-icon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 320 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-l-split__item pf-m-fill"
-                            >
-                              <span
-                                class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
-                              >
-                                <input
-                                  aria-invalid="false"
-                                  aria-label="text input"
-                                  data-ouia-component-id="ConditionalFilter"
-                                  data-ouia-component-type="PF5/TextInput"
-                                  data-ouia-safe="true"
-                                  placeholder="Filter by name"
-                                  type="text"
-                                  value=""
-                                  widget-type="InsightsInput"
-                                />
-                                <span
-                                  class="pf-v5-c-form-control__utilities"
-                                >
-                                  <span
-                                    class="pf-v5-c-form-control__icon"
-                                  >
-                                    <span
-                                      class="pf-v5-c-icon pf-m-md ins-c-search-icon"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </div>
-                          </div>
+                            Log4J Detection
+                          </small>
                         </div>
                       </div>
                       <div
-                        class="pf-v5-c-toolbar__item pf-m-spacer-sm"
+                        class=""
+                      >
+                        <p>
+                          Uses the insights-client to determine if systems are affected by the LogShell vulnerability. Resource intensive scan
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="pf-v5-l-flex"
+                    >
+                      <div
+                        class=""
+                      >
+                        <button
+                          aria-disabled="false"
+                          aria-label="log4j-run-task-button"
+                          class="pf-v5-c-button pf-m-secondary"
+                          data-ouia-component-id="OUIA-Generated-Button-secondary-1"
+                          data-ouia-component-type="PF5/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          Run task again
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="pf-v5-l-flex"
+                    >
+                      <div
+                        class=""
                       >
                         <button
                           aria-expanded="false"
-                          aria-label="Export"
+                          aria-label="Task details menu toggle"
                           class="pf-v5-c-menu-toggle pf-m-plain"
+                          id="executed-task-kebab"
                           type="button"
                         >
                           <svg
@@ -2864,48 +2618,293 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                             fill="currentColor"
                             height="1em"
                             role="img"
-                            viewBox="0 0 1024 1024"
+                            viewBox="0 0 192 512"
                             width="1em"
                           >
                             <path
-                              d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                             />
                           </svg>
                         </button>
                       </div>
+                    </div>
+                  </div>
+                </section>
+                <section
+                  class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
+                >
+                  <div
+                    class="pf-v5-c-card"
+                    data-ouia-component-id="OUIA-Generated-Card-1"
+                    data-ouia-component-type="PF5/Card"
+                    data-ouia-safe="true"
+                    id=""
+                  >
+                    <div
+                      class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
+                    >
                       <div
-                        class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
+                        class="pf-v5-l-flex pf-m-column"
                       >
                         <div
-                          class="pf-v5-c-pagination pf-m-compact"
-                          data-ouia-component-id="CompactPagination"
-                          data-ouia-component-type="PF5/Pagination"
-                          data-ouia-safe="true"
-                          id="options-menu-top-pagination"
-                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                          class=""
+                        >
+                          <b>
+                            Systems
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          3
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Run start
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          21 Apr 2022, 10:10 UTC
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Run end
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          25 Apr 2022, 10:10 UTC (5760 min)
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Initiated by
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          UserX
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Systems with alerts
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          2
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <br />
+                  <div
+                    class="pf-v5-c-card"
+                    data-ouia-component-id="OUIA-Generated-Card-2"
+                    data-ouia-component-type="PF5/Card"
+                    data-ouia-safe="true"
+                    id=""
+                  >
+                    <div
+                      class="pf-v5-c-toolbar  ins-c-primary-toolbar"
+                      data-ouia-component-id="PrimaryToolbar"
+                      data-ouia-component-type="PF5/Toolbar"
+                      data-ouia-safe="true"
+                      id="ins-primary-data-toolbar"
+                    >
+                      <div
+                        class="pf-v5-c-toolbar__content"
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__content-section"
                         >
                           <div
-                            class="pf-v5-c-pagination__total-items"
+                            class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
                           >
-                            <b>
-                              1 - 3
-                            </b>
-                             of 
-                            <b>
-                              3
-                            </b>
-                             
+                            <div
+                              class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                            >
+                              <div
+                                class="pf-v5-l-split ins-c-conditional-filter"
+                              >
+                                <div
+                                  class="pf-v5-l-split__item"
+                                >
+                                  <button
+                                    aria-expanded="false"
+                                    aria-label="Conditional filter"
+                                    class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="pf-v5-c-menu-toggle__text"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon pf-m-md"
+                                      >
+                                        <span
+                                          class="pf-v5-c-icon__content"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                      <span
+                                        class="ins-c-conditional-filter__value-selector"
+                                      >
+                                        Name
+                                      </span>
+                                    </span>
+                                    <span
+                                      class="pf-v5-c-menu-toggle__controls"
+                                    >
+                                      <span
+                                        class="pf-v5-c-menu-toggle__toggle-icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 320 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-l-split__item pf-m-fill"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      aria-label="text input"
+                                      data-ouia-component-id="ConditionalFilter"
+                                      data-ouia-component-type="PF5/TextInput"
+                                      data-ouia-safe="true"
+                                      placeholder="Filter by name"
+                                      type="text"
+                                      value=""
+                                      widget-type="InsightsInput"
+                                    />
+                                    <span
+                                      class="pf-v5-c-form-control__utilities"
+                                    >
+                                      <span
+                                        class="pf-v5-c-form-control__icon"
+                                      >
+                                        <span
+                                          class="pf-v5-c-icon pf-m-md ins-c-search-icon"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
                           </div>
-                          <div>
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-spacer-sm"
+                          >
                             <button
                               aria-expanded="false"
-                              aria-haspopup="listbox"
-                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                              id="options-menu-top-toggle"
+                              aria-label="Export"
+                              class="pf-v5-c-menu-toggle pf-m-plain"
                               type="button"
                             >
-                              <span
-                                class="pf-v5-c-menu-toggle__text"
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
+                          >
+                            <div
+                              class="pf-v5-c-pagination pf-m-compact"
+                              data-ouia-component-id="CompactPagination"
+                              data-ouia-component-type="PF5/Pagination"
+                              data-ouia-safe="true"
+                              id="options-menu-top-pagination"
+                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                            >
+                              <div
+                                class="pf-v5-c-pagination__total-items"
                               >
                                 <b>
                                   1 - 3
@@ -2915,533 +2914,165 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                                   3
                                 </b>
                                  
-                              </span>
-                              <span
-                                class="pf-v5-c-menu-toggle__controls"
-                              >
-                                <span
-                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                              </div>
+                              <div>
+                                <button
+                                  aria-expanded="false"
+                                  aria-haspopup="listbox"
+                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                                  id="options-menu-top-toggle"
+                                  type="button"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 320 512"
-                                    width="1em"
+                                  <span
+                                    class="pf-v5-c-menu-toggle__text"
                                   >
-                                    <path
-                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                    />
-                                  </svg>
-                                </span>
-                              </span>
-                            </button>
+                                    <b>
+                                      1 - 3
+                                    </b>
+                                     of 
+                                    <b>
+                                      3
+                                    </b>
+                                     
+                                  </span>
+                                  <span
+                                    class="pf-v5-c-menu-toggle__controls"
+                                  >
+                                    <span
+                                      class="pf-v5-c-menu-toggle__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                              <nav
+                                aria-label="Pagination"
+                                class="pf-v5-c-pagination__nav"
+                              >
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to previous page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="previous"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to next page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="next"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </nav>
+                            </div>
                           </div>
-                          <nav
-                            aria-label="Pagination"
-                            class="pf-v5-c-pagination__nav"
-                          >
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to previous page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="previous"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to next page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="next"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                          </nav>
                         </div>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__content pf-m-hidden"
+                        hidden=""
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__group"
+                        />
                       </div>
                     </div>
-                  </div>
-                  <div
-                    class="pf-v5-c-toolbar__content pf-m-hidden"
-                    hidden=""
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__group"
-                    />
-                  </div>
-                </div>
-                <table
-                  aria-label="42-completed-jobs"
-                  class="pf-v5-c-table pf-m-grid-md"
-                  data-ouia-component-id="42-completed-jobs-table"
-                  data-ouia-component-type="PF5/Table"
-                  data-ouia-safe="true"
-                  role="grid"
-                >
-                  <thead
-                    class="pf-v5-c-table__thead"
-                  >
-                    <tr
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-1"
-                      data-ouia-component-type="PF5/TableRow"
+                    <table
+                      aria-label="42-completed-jobs"
+                      class="pf-v5-c-table pf-m-grid-md"
+                      data-ouia-component-id="42-completed-jobs-table"
+                      data-ouia-component-type="PF5/Table"
                       data-ouia-safe="true"
+                      role="grid"
                     >
-                      <th
-                        aria-sort="none"
-                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
-                        data-key="0"
-                        data-label="System name"
-                        scope="col"
-                        tabindex="-1"
+                      <thead
+                        class="pf-v5-c-table__thead"
                       >
-                        <button
-                          class="pf-v5-c-table__button"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__button-content"
-                          >
-                            <span
-                              class="pf-v5-c-table__text"
-                            >
-                              System name
-                            </span>
-                            <span
-                              class="pf-v5-c-table__sort-indicator"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 256 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="none"
-                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
-                        data-key="1"
-                        data-label="Status"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        <button
-                          class="pf-v5-c-table__button"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__button-content"
-                          >
-                            <span
-                              class="pf-v5-c-table__text"
-                            >
-                              Status
-                            </span>
-                            <span
-                              class="pf-v5-c-table__sort-indicator"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 256 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="none"
-                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-35"
-                        data-key="2"
-                        data-label="Message"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        <button
-                          class="pf-v5-c-table__button"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__button-content"
-                          >
-                            <span
-                              class="pf-v5-c-table__text"
-                            >
-                              Message
-                            </span>
-                            <span
-                              class="pf-v5-c-table__sort-indicator"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 256 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </button>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody
-                    class="pf-v5-c-table__tbody"
-                    role="rowgroup"
-                  >
-                    <tr
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-2"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="0"
-                        data-label="System name"
-                        tabindex="-1"
-                      >
-                        <a
-                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          dl-test-device-2
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="1"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Success
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="2"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
-                          >
-                            This was a success.
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-3"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="0"
-                        data-label="System name"
-                        tabindex="-1"
-                      >
-                        <a
-                          href="/insights/inventory/3262b268-23ed-4c5a-a918-d8c4923fdfbf"
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          MG-test-device
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="1"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Failure
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="2"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 8px;"
-                          >
-                            <span
-                              class="pf-v5-c-icon"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 16px;"
-                          >
-                            <span
-                              style="color: rgb(201, 25, 11);"
-                            >
-                              Alert
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
-                          >
-                            Task failed to complete for an unknown reason. Retry this task at a later time.
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-4"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="0"
-                        data-label="System name"
-                        tabindex="-1"
-                      >
-                        <a
-                          href="/insights/inventory/42438801-c384-491a-943b-f5f621f0c882"
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          YL-test-device-85
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="1"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Timeout
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="2"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 8px;"
-                          >
-                            <span
-                              class="pf-v5-c-icon"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 16px;"
-                          >
-                            <span
-                              style="color: rgb(201, 25, 11);"
-                            >
-                              Alert
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
-                          >
-                            Task failed to complete due to timing out. Retry this task at a later time.
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div
-                  class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
-                  data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
-                  data-ouia-component-type="RHI/TableToolbar"
-                  data-ouia-safe="true"
-                  id="pf-random-id-1"
-                >
-                  <div
-                    class="pf-v5-c-toolbar__content"
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__content-section"
-                    >
-                      <div
-                        class="pf-v5-c-toolbar__item pf-m-align-self-center"
-                      >
-                        <div>
-                          <div
-                            style="display: contents;"
-                          >
-                            <div
-                              class="pf-v5-c-content"
-                            >
-                              <small
-                                class=""
-                                data-ouia-component-id="OUIA-Generated-Text-2"
-                                data-ouia-component-type="PF5/Text"
-                                data-ouia-safe="true"
-                                data-pf-content="true"
-                              >
-                                Last updated: All jobs completed
-                              </small>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
-                      >
-                        <div
-                          class="pf-v5-c-pagination pf-m-bottom"
-                          data-ouia-component-id="OUIA-Generated-Pagination-bottom-1"
-                          data-ouia-component-type="PF5/Pagination"
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-1"
+                          data-ouia-component-type="PF5/TableRow"
                           data-ouia-safe="true"
-                          id="options-menu-bottom-pagination"
-                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                         >
-                          <div>
+                          <th
+                            aria-sort="none"
+                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
+                            data-key="0"
+                            data-label="System name"
+                            scope="col"
+                            tabindex="-1"
+                          >
                             <button
-                              aria-expanded="false"
-                              aria-haspopup="listbox"
-                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                              id="options-menu-bottom-toggle"
+                              class="pf-v5-c-table__button"
                               type="button"
                             >
-                              <span
-                                class="pf-v5-c-menu-toggle__text"
-                              >
-                                <b>
-                                  1 - 3
-                                </b>
-                                 of 
-                                <b>
-                                  3
-                                </b>
-                                 
-                              </span>
-                              <span
-                                class="pf-v5-c-menu-toggle__controls"
+                              <div
+                                class="pf-v5-c-table__button-content"
                               >
                                 <span
-                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                                  class="pf-v5-c-table__text"
+                                >
+                                  System name
+                                </span>
+                                <span
+                                  class="pf-v5-c-table__sort-indicator"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -3449,186 +3080,575 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                                     fill="currentColor"
                                     height="1em"
                                     role="img"
-                                    viewBox="0 0 320 512"
+                                    viewBox="0 0 256 512"
                                     width="1em"
                                   >
                                     <path
-                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                     />
                                   </svg>
                                 </span>
-                              </span>
+                              </div>
                             </button>
-                          </div>
-                          <nav
-                            aria-label="Pagination"
-                            class="pf-v5-c-pagination__nav"
+                          </th>
+                          <th
+                            aria-sort="none"
+                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
+                            data-key="1"
+                            data-label="Status"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            <button
+                              class="pf-v5-c-table__button"
+                              type="button"
+                            >
+                              <div
+                                class="pf-v5-c-table__button-content"
+                              >
+                                <span
+                                  class="pf-v5-c-table__text"
+                                >
+                                  Status
+                                </span>
+                                <span
+                                  class="pf-v5-c-table__sort-indicator"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 256 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </button>
+                          </th>
+                          <th
+                            aria-sort="none"
+                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-35"
+                            data-key="2"
+                            data-label="Message"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            <button
+                              class="pf-v5-c-table__button"
+                              type="button"
+                            >
+                              <div
+                                class="pf-v5-c-table__button-content"
+                              >
+                                <span
+                                  class="pf-v5-c-table__text"
+                                >
+                                  Message
+                                </span>
+                                <span
+                                  class="pf-v5-c-table__sort-indicator"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 256 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </button>
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
+                      >
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-2"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="0"
+                            data-label="System name"
+                            tabindex="-1"
+                          >
+                            <a
+                              href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              dl-test-device-2
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="1"
+                            data-label="Status"
+                            tabindex="-1"
+                          >
+                            Success
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="2"
+                            data-label="Message"
+                            tabindex="-1"
                           >
                             <div
-                              class="pf-v5-c-pagination__nav-control pf-m-first"
+                              class="pf-v5-l-split"
                             >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to first page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="first"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 448 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                                  />
-                                </svg>
-                              </button>
+                                This was a success.
+                              </div>
                             </div>
+                          </td>
+                        </tr>
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-3"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="0"
+                            data-label="System name"
+                            tabindex="-1"
+                          >
+                            <a
+                              href="/insights/inventory/3262b268-23ed-4c5a-a918-d8c4923fdfbf"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              MG-test-device
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="1"
+                            data-label="Status"
+                            tabindex="-1"
+                          >
+                            Failure
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="2"
+                            data-label="Message"
+                            tabindex="-1"
+                          >
                             <div
-                              class="pf-v5-c-pagination__nav-control"
+                              class="pf-v5-l-split"
                             >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to previous page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="previous"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-4"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 8px;"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
+                                <span
+                                  class="pf-v5-c-icon"
                                 >
-                                  <path
-                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-page-select"
-                            >
-                              <span
-                                class="pf-v5-c-form-control pf-m-disabled"
+                                  <span
+                                    class="pf-v5-c-icon__content pf-m-danger"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 16px;"
                               >
-                                <input
-                                  aria-invalid="false"
-                                  aria-label="Current page"
-                                  data-ouia-component-id="OUIA-Generated-TextInputBase-2"
-                                  data-ouia-component-type="PF5/TextInput"
-                                  data-ouia-safe="true"
-                                  disabled=""
-                                  max="1"
-                                  min="1"
-                                  type="number"
-                                  value="1"
-                                />
-                              </span>
-                              <span
-                                aria-hidden="true"
-                              >
-                                of 1
-                              </span>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to next page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="next"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-5"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
+                                <span
+                                  style="color: rgb(201, 25, 11);"
                                 >
-                                  <path
-                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control pf-m-last"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to last page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="last"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-6"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
+                                  Alert
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 448 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                                  />
-                                </svg>
-                              </button>
+                                Task failed to complete for an unknown reason. Retry this task at a later time.
+                              </div>
                             </div>
-                          </nav>
+                          </td>
+                        </tr>
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-4"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="0"
+                            data-label="System name"
+                            tabindex="-1"
+                          >
+                            <a
+                              href="/insights/inventory/42438801-c384-491a-943b-f5f621f0c882"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              YL-test-device-85
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="1"
+                            data-label="Status"
+                            tabindex="-1"
+                          >
+                            Timeout
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="2"
+                            data-label="Message"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="pf-v5-l-split"
+                            >
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 8px;"
+                              >
+                                <span
+                                  class="pf-v5-c-icon"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon__content pf-m-danger"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 16px;"
+                              >
+                                <span
+                                  style="color: rgb(201, 25, 11);"
+                                >
+                                  Alert
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
+                              >
+                                Task failed to complete due to timing out. Retry this task at a later time.
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <div
+                      class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
+                      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
+                      data-ouia-component-type="RHI/TableToolbar"
+                      data-ouia-safe="true"
+                      id="pf-random-id-1"
+                    >
+                      <div
+                        class="pf-v5-c-toolbar__content"
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__content-section"
+                        >
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-align-self-center"
+                          >
+                            <div>
+                              <div
+                                style="display: contents;"
+                              >
+                                <div
+                                  class="pf-v5-c-content"
+                                >
+                                  <small
+                                    class=""
+                                    data-ouia-component-id="OUIA-Generated-Text-2"
+                                    data-ouia-component-type="PF5/Text"
+                                    data-ouia-safe="true"
+                                    data-pf-content="true"
+                                  >
+                                    Last updated: All jobs completed
+                                  </small>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
+                          >
+                            <div
+                              class="pf-v5-c-pagination pf-m-bottom"
+                              data-ouia-component-id="OUIA-Generated-Pagination-bottom-1"
+                              data-ouia-component-type="PF5/Pagination"
+                              data-ouia-safe="true"
+                              id="options-menu-bottom-pagination"
+                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                            >
+                              <div>
+                                <button
+                                  aria-expanded="false"
+                                  aria-haspopup="listbox"
+                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                                  id="options-menu-bottom-toggle"
+                                  type="button"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__text"
+                                  >
+                                    <b>
+                                      1 - 3
+                                    </b>
+                                     of 
+                                    <b>
+                                      3
+                                    </b>
+                                     
+                                  </span>
+                                  <span
+                                    class="pf-v5-c-menu-toggle__controls"
+                                  >
+                                    <span
+                                      class="pf-v5-c-menu-toggle__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                              <nav
+                                aria-label="Pagination"
+                                class="pf-v5-c-pagination__nav"
+                              >
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-first"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to first page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="first"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to previous page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="previous"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-page-select"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control pf-m-disabled"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      aria-label="Current page"
+                                      data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+                                      data-ouia-component-type="PF5/TextInput"
+                                      data-ouia-safe="true"
+                                      disabled=""
+                                      max="1"
+                                      min="1"
+                                      type="number"
+                                      value="1"
+                                    />
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                  >
+                                    of 1
+                                  </span>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to next page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="next"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-last"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to last page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="last"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </nav>
+                            </div>
+                          </div>
                         </div>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__content pf-m-hidden"
+                        hidden=""
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__group"
+                        />
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="pf-v5-c-toolbar__content pf-m-hidden"
-                    hidden=""
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__group"
-                    />
-                  </div>
-                </div>
-              </div>
-            </section>
+                </section>
+              </main>
+            </div>
           </div>
+          <div
+            class="pf-v5-c-drawer__panel"
+            hidden=""
+            id="pf-drawer-panel-0"
+          />
         </div>
-        <div
-          class="pf-v5-c-drawer__panel pf-m-resizable"
-          hidden=""
-          id="end-resize-panel"
-          style="--pf-v5-c-drawer__panel--md--FlexBasis: 1000px; --pf-v5-c-drawer__panel--md--FlexBasis--min: 500px;"
-        />
       </div>
     </div>
   </div>
@@ -3637,403 +3657,147 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
 
 exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
 <DocumentFragment>
-  <div>
+  <div
+    class="pf-v5-c-page my-app-modified-drawer-width"
+  >
     <div
-      class="pf-v5-c-drawer"
+      class="pf-v5-c-page__drawer"
     >
       <div
-        class="pf-v5-c-drawer__main"
+        class="pf-v5-c-drawer"
       >
         <div
-          class="pf-v5-c-drawer__content"
+          class="pf-v5-c-drawer__main"
         >
           <div
-            class="pf-v5-c-drawer__body"
+            class="pf-v5-c-drawer__content"
           >
-            <section
-              class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
-              widget-type="InsightsPageHeader"
+            <div
+              class="pf-v5-c-drawer__body"
             >
-              <nav
-                aria-label="Breadcrumb"
-                class="pf-v5-c-breadcrumb"
-                data-ouia-component-id="completed-tasks-details-breadcrumb"
-                data-ouia-component-type="PF5/Breadcrumb"
-                data-ouia-safe="true"
+              <main
+                class="pf-v5-c-page__main"
+                tabindex="-1"
               >
-                <ol
-                  class="pf-v5-c-breadcrumb__list"
-                  role="list"
+                <section
+                  class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+                  widget-type="InsightsPageHeader"
                 >
-                  <li
-                    class="pf-v5-c-breadcrumb__item"
+                  <nav
+                    aria-label="Breadcrumb"
+                    class="pf-v5-c-breadcrumb"
+                    data-ouia-component-id="completed-tasks-details-breadcrumb"
+                    data-ouia-component-type="PF5/Breadcrumb"
+                    data-ouia-safe="true"
                   >
-                    <a
-                      class="pf-v5-c-breadcrumb__link"
-                      href="/insights/tasks/executed"
+                    <ol
+                      class="pf-v5-c-breadcrumb__list"
+                      role="list"
                     >
-                      Tasks
-                    </a>
-                  </li>
-                  <li
-                    class="pf-v5-c-breadcrumb__item"
-                  >
-                    <span
-                      class="pf-v5-c-breadcrumb__item-divider"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
+                      <li
+                        class="pf-v5-c-breadcrumb__item"
                       >
-                        <path
-                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                        />
-                      </svg>
-                    </span>
-                    leapp task
-                  </li>
-                </ol>
-              </nav>
-              <div
-                class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
-              >
-                <div
-                  class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
-                >
-                  <div
-                    class=""
-                  >
-                    <h1
-                      class="pf-v5-c-title pf-m-2xl"
-                      data-ouia-component-id="OUIA-Generated-Title-3"
-                      data-ouia-component-type="PF5/Title"
-                      data-ouia-safe="true"
-                      widget-type="InsightsPageHeaderTitle"
-                    >
-                      leapp task
-                    </h1>
-                    <div
-                      class="pf-v5-c-content"
-                    >
-                      <small
-                        class=""
-                        data-ouia-component-id="OUIA-Generated-Text-5"
-                        data-ouia-component-type="PF5/Text"
-                        data-ouia-safe="true"
-                        data-pf-content="true"
+                        <a
+                          class="pf-v5-c-breadcrumb__link"
+                          href="/insights/tasks/executed"
+                        >
+                          Tasks
+                        </a>
+                      </li>
+                      <li
+                        class="pf-v5-c-breadcrumb__item"
                       >
-                        Upgrade RHEL version with LEAP tool
-                      </small>
-                    </div>
-                  </div>
+                        <span
+                          class="pf-v5-c-breadcrumb__item-divider"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </span>
+                        leapp task
+                      </li>
+                    </ol>
+                  </nav>
                   <div
-                    class=""
-                  >
-                    <p>
-                      Uses the insights-client to determine if RHEL version can be upgraded with LEAP tool. Resource intensive scan
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="pf-v5-l-flex"
-                >
-                  <div
-                    class=""
-                  >
-                    <button
-                      aria-disabled="false"
-                      aria-label="leapp-preupgrade-run-task-button"
-                      class="pf-v5-c-button pf-m-secondary"
-                      data-ouia-component-id="OUIA-Generated-Button-secondary-3"
-                      data-ouia-component-type="PF5/Button"
-                      data-ouia-safe="true"
-                      type="button"
-                    >
-                      Run task again
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="pf-v5-l-flex"
-                >
-                  <div
-                    class=""
-                  >
-                    <button
-                      aria-expanded="false"
-                      aria-label="Task details menu toggle"
-                      class="pf-v5-c-menu-toggle pf-m-plain"
-                      id="executed-task-kebab"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 192 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </section>
-            <section
-              class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
-            >
-              <div
-                class="pf-v5-c-card"
-                data-ouia-component-id="OUIA-Generated-Card-5"
-                data-ouia-component-type="PF5/Card"
-                data-ouia-safe="true"
-                id=""
-              >
-                <div
-                  class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
-                >
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
+                    class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
                   >
                     <div
-                      class=""
-                    >
-                      <b>
-                        Systems
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      6
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Run start
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      21 Apr 2022, 10:10 UTC
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Run end
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      -
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Initiated by
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      Michael
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-l-flex pf-m-column"
-                  >
-                    <div
-                      class=""
-                    >
-                      <b>
-                        Systems with alerts
-                      </b>
-                    </div>
-                    <div
-                      class=""
-                    >
-                      5
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <br />
-              <div
-                class="pf-v5-c-card"
-                data-ouia-component-id="OUIA-Generated-Card-6"
-                data-ouia-component-type="PF5/Card"
-                data-ouia-safe="true"
-                id=""
-              >
-                <div
-                  class="pf-v5-c-toolbar  ins-c-primary-toolbar"
-                  data-ouia-component-id="PrimaryToolbar"
-                  data-ouia-component-type="PF5/Toolbar"
-                  data-ouia-safe="true"
-                  id="ins-primary-data-toolbar"
-                >
-                  <div
-                    class="pf-v5-c-toolbar__content"
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__content-section"
+                      class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
                     >
                       <div
-                        class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+                        class=""
                       >
-                        <div
-                          class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                        <h1
+                          class="pf-v5-c-title pf-m-2xl"
+                          data-ouia-component-id="OUIA-Generated-Title-3"
+                          data-ouia-component-type="PF5/Title"
+                          data-ouia-safe="true"
+                          widget-type="InsightsPageHeaderTitle"
                         >
-                          <div
-                            class="pf-v5-l-split ins-c-conditional-filter"
+                          leapp task
+                        </h1>
+                        <div
+                          class="pf-v5-c-content"
+                        >
+                          <small
+                            class=""
+                            data-ouia-component-id="OUIA-Generated-Text-5"
+                            data-ouia-component-type="PF5/Text"
+                            data-ouia-safe="true"
+                            data-pf-content="true"
                           >
-                            <div
-                              class="pf-v5-l-split__item"
-                            >
-                              <button
-                                aria-expanded="false"
-                                aria-label="Conditional filter"
-                                class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
-                                type="button"
-                              >
-                                <span
-                                  class="pf-v5-c-menu-toggle__text"
-                                >
-                                  <span
-                                    class="pf-v5-c-icon pf-m-md"
-                                  >
-                                    <span
-                                      class="pf-v5-c-icon__content"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 512 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </span>
-                                  <span
-                                    class="ins-c-conditional-filter__value-selector"
-                                  >
-                                    Name
-                                  </span>
-                                </span>
-                                <span
-                                  class="pf-v5-c-menu-toggle__controls"
-                                >
-                                  <span
-                                    class="pf-v5-c-menu-toggle__toggle-icon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 320 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-l-split__item pf-m-fill"
-                            >
-                              <span
-                                class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
-                              >
-                                <input
-                                  aria-invalid="false"
-                                  aria-label="text input"
-                                  data-ouia-component-id="ConditionalFilter"
-                                  data-ouia-component-type="PF5/TextInput"
-                                  data-ouia-safe="true"
-                                  placeholder="Filter by name"
-                                  type="text"
-                                  value=""
-                                  widget-type="InsightsInput"
-                                />
-                                <span
-                                  class="pf-v5-c-form-control__utilities"
-                                >
-                                  <span
-                                    class="pf-v5-c-form-control__icon"
-                                  >
-                                    <span
-                                      class="pf-v5-c-icon pf-m-md ins-c-search-icon"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                  </span>
-                                </span>
-                              </span>
-                            </div>
-                          </div>
+                            Upgrade RHEL version with LEAP tool
+                          </small>
                         </div>
                       </div>
                       <div
-                        class="pf-v5-c-toolbar__item pf-m-spacer-sm"
+                        class=""
+                      >
+                        <p>
+                          Uses the insights-client to determine if RHEL version can be upgraded with LEAP tool. Resource intensive scan
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="pf-v5-l-flex"
+                    >
+                      <div
+                        class=""
+                      >
+                        <button
+                          aria-disabled="false"
+                          aria-label="leapp-preupgrade-run-task-button"
+                          class="pf-v5-c-button pf-m-secondary"
+                          data-ouia-component-id="OUIA-Generated-Button-secondary-3"
+                          data-ouia-component-type="PF5/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          Run task again
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="pf-v5-l-flex"
+                    >
+                      <div
+                        class=""
                       >
                         <button
                           aria-expanded="false"
-                          aria-label="Export"
+                          aria-label="Task details menu toggle"
                           class="pf-v5-c-menu-toggle pf-m-plain"
+                          id="executed-task-kebab"
                           type="button"
                         >
                           <svg
@@ -4042,48 +3806,293 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                             fill="currentColor"
                             height="1em"
                             role="img"
-                            viewBox="0 0 1024 1024"
+                            viewBox="0 0 192 512"
                             width="1em"
                           >
                             <path
-                              d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                             />
                           </svg>
                         </button>
                       </div>
+                    </div>
+                  </div>
+                </section>
+                <section
+                  class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
+                >
+                  <div
+                    class="pf-v5-c-card"
+                    data-ouia-component-id="OUIA-Generated-Card-5"
+                    data-ouia-component-type="PF5/Card"
+                    data-ouia-safe="true"
+                    id=""
+                  >
+                    <div
+                      class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
+                    >
                       <div
-                        class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
+                        class="pf-v5-l-flex pf-m-column"
                       >
                         <div
-                          class="pf-v5-c-pagination pf-m-compact"
-                          data-ouia-component-id="CompactPagination"
-                          data-ouia-component-type="PF5/Pagination"
-                          data-ouia-safe="true"
-                          id="options-menu-top-pagination"
-                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                          class=""
+                        >
+                          <b>
+                            Systems
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          6
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Run start
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          21 Apr 2022, 10:10 UTC
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Run end
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          -
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Initiated by
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          Michael
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-l-flex pf-m-column"
+                      >
+                        <div
+                          class=""
+                        >
+                          <b>
+                            Systems with alerts
+                          </b>
+                        </div>
+                        <div
+                          class=""
+                        >
+                          5
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <br />
+                  <div
+                    class="pf-v5-c-card"
+                    data-ouia-component-id="OUIA-Generated-Card-6"
+                    data-ouia-component-type="PF5/Card"
+                    data-ouia-safe="true"
+                    id=""
+                  >
+                    <div
+                      class="pf-v5-c-toolbar  ins-c-primary-toolbar"
+                      data-ouia-component-id="PrimaryToolbar"
+                      data-ouia-component-type="PF5/Toolbar"
+                      data-ouia-safe="true"
+                      id="ins-primary-data-toolbar"
+                    >
+                      <div
+                        class="pf-v5-c-toolbar__content"
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__content-section"
                         >
                           <div
-                            class="pf-v5-c-pagination__total-items"
+                            class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
                           >
-                            <b>
-                              1 - 6
-                            </b>
-                             of 
-                            <b>
-                              6
-                            </b>
-                             
+                            <div
+                              class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                            >
+                              <div
+                                class="pf-v5-l-split ins-c-conditional-filter"
+                              >
+                                <div
+                                  class="pf-v5-l-split__item"
+                                >
+                                  <button
+                                    aria-expanded="false"
+                                    aria-label="Conditional filter"
+                                    class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="pf-v5-c-menu-toggle__text"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon pf-m-md"
+                                      >
+                                        <span
+                                          class="pf-v5-c-icon__content"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                      <span
+                                        class="ins-c-conditional-filter__value-selector"
+                                      >
+                                        Name
+                                      </span>
+                                    </span>
+                                    <span
+                                      class="pf-v5-c-menu-toggle__controls"
+                                    >
+                                      <span
+                                        class="pf-v5-c-menu-toggle__toggle-icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 320 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-l-split__item pf-m-fill"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      aria-label="text input"
+                                      data-ouia-component-id="ConditionalFilter"
+                                      data-ouia-component-type="PF5/TextInput"
+                                      data-ouia-safe="true"
+                                      placeholder="Filter by name"
+                                      type="text"
+                                      value=""
+                                      widget-type="InsightsInput"
+                                    />
+                                    <span
+                                      class="pf-v5-c-form-control__utilities"
+                                    >
+                                      <span
+                                        class="pf-v5-c-form-control__icon"
+                                      >
+                                        <span
+                                          class="pf-v5-c-icon pf-m-md ins-c-search-icon"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
                           </div>
-                          <div>
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-spacer-sm"
+                          >
                             <button
                               aria-expanded="false"
-                              aria-haspopup="listbox"
-                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                              id="options-menu-top-toggle"
+                              aria-label="Export"
+                              class="pf-v5-c-menu-toggle pf-m-plain"
                               type="button"
                             >
-                              <span
-                                class="pf-v5-c-menu-toggle__text"
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
+                          >
+                            <div
+                              class="pf-v5-c-pagination pf-m-compact"
+                              data-ouia-component-id="CompactPagination"
+                              data-ouia-component-type="PF5/Pagination"
+                              data-ouia-safe="true"
+                              id="options-menu-top-pagination"
+                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                            >
+                              <div
+                                class="pf-v5-c-pagination__total-items"
                               >
                                 <b>
                                   1 - 6
@@ -4093,12 +4102,171 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                   6
                                 </b>
                                  
-                              </span>
-                              <span
-                                class="pf-v5-c-menu-toggle__controls"
+                              </div>
+                              <div>
+                                <button
+                                  aria-expanded="false"
+                                  aria-haspopup="listbox"
+                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                                  id="options-menu-top-toggle"
+                                  type="button"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__text"
+                                  >
+                                    <b>
+                                      1 - 6
+                                    </b>
+                                     of 
+                                    <b>
+                                      6
+                                    </b>
+                                     
+                                  </span>
+                                  <span
+                                    class="pf-v5-c-menu-toggle__controls"
+                                  >
+                                    <span
+                                      class="pf-v5-c-menu-toggle__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                              <nav
+                                aria-label="Pagination"
+                                class="pf-v5-c-pagination__nav"
+                              >
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to previous page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="previous"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-21"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to next page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="next"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-22"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </nav>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__content pf-m-hidden"
+                        hidden=""
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__group"
+                        />
+                      </div>
+                    </div>
+                    <table
+                      aria-label="43-completed-jobs"
+                      class="pf-v5-c-table pf-m-grid-md"
+                      data-ouia-component-id="43-completed-jobs-table"
+                      data-ouia-component-type="PF5/Table"
+                      data-ouia-safe="true"
+                      role="grid"
+                    >
+                      <thead
+                        class="pf-v5-c-table__thead"
+                      >
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-30"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <th
+                            class="pf-v5-c-table__th"
+                            data-key="0"
+                            data-label=""
+                            tabindex="-1"
+                          />
+                          <th
+                            aria-sort="none"
+                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
+                            data-key="1"
+                            data-label="System name"
+                            scope="col"
+                            tabindex="-1"
+                          >
+                            <button
+                              class="pf-v5-c-table__button"
+                              type="button"
+                            >
+                              <div
+                                class="pf-v5-c-table__button-content"
                               >
                                 <span
-                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                                  class="pf-v5-c-table__text"
+                                >
+                                  System name
+                                </span>
+                                <span
+                                  class="pf-v5-c-table__sort-indicator"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -4106,1542 +4274,1403 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     fill="currentColor"
                                     height="1em"
                                     role="img"
-                                    viewBox="0 0 320 512"
+                                    viewBox="0 0 256 512"
                                     width="1em"
                                   >
                                     <path
-                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                     />
                                   </svg>
                                 </span>
-                              </span>
+                              </div>
                             </button>
-                          </div>
-                          <nav
-                            aria-label="Pagination"
-                            class="pf-v5-c-pagination__nav"
+                          </th>
+                          <th
+                            aria-sort="none"
+                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
+                            data-key="2"
+                            data-label="Status"
+                            scope="col"
+                            tabindex="-1"
                           >
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
+                            <button
+                              class="pf-v5-c-table__button"
+                              type="button"
                             >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to previous page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="previous"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-21"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
+                              <div
+                                class="pf-v5-c-table__button-content"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
+                                <span
+                                  class="pf-v5-c-table__text"
                                 >
-                                  <path
-                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to next page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="next"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-22"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
+                                  Status
+                                </span>
+                                <span
+                                  class="pf-v5-c-table__sort-indicator"
                                 >
-                                  <path
-                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                          </nav>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="pf-v5-c-toolbar__content pf-m-hidden"
-                    hidden=""
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__group"
-                    />
-                  </div>
-                </div>
-                <table
-                  aria-label="43-completed-jobs"
-                  class="pf-v5-c-table pf-m-grid-md"
-                  data-ouia-component-id="43-completed-jobs-table"
-                  data-ouia-component-type="PF5/Table"
-                  data-ouia-safe="true"
-                  role="grid"
-                >
-                  <thead
-                    class="pf-v5-c-table__thead"
-                  >
-                    <tr
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-30"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <th
-                        class="pf-v5-c-table__th"
-                        data-key="0"
-                        data-label=""
-                        tabindex="-1"
-                      />
-                      <th
-                        aria-sort="none"
-                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
-                        data-key="1"
-                        data-label="System name"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        <button
-                          class="pf-v5-c-table__button"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__button-content"
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 256 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </button>
+                          </th>
+                          <th
+                            aria-sort="ascending"
+                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
+                            data-key="3"
+                            data-label="Message"
+                            scope="col"
+                            tabindex="-1"
                           >
-                            <span
-                              class="pf-v5-c-table__text"
+                            <button
+                              class="pf-v5-c-table__button"
+                              type="button"
                             >
-                              System name
-                            </span>
-                            <span
-                              class="pf-v5-c-table__sort-indicator"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 256 512"
-                                width="1em"
+                              <div
+                                class="pf-v5-c-table__button-content"
                               >
-                                <path
-                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="none"
-                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
-                        data-key="2"
-                        data-label="Status"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        <button
-                          class="pf-v5-c-table__button"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__button-content"
-                          >
-                            <span
-                              class="pf-v5-c-table__text"
-                            >
-                              Status
-                            </span>
-                            <span
-                              class="pf-v5-c-table__sort-indicator"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 256 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
-                        data-key="3"
-                        data-label="Message"
-                        scope="col"
-                        tabindex="-1"
-                      >
-                        <button
-                          class="pf-v5-c-table__button"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__button-content"
-                          >
-                            <span
-                              class="pf-v5-c-table__text"
-                            >
-                              Message
-                            </span>
-                            <span
-                              class="pf-v5-c-table__sort-indicator"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 256 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </button>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody
-                    class="pf-v5-c-table__tbody"
-                    role="rowgroup"
-                  >
-                    <tr
-                      aria-label=""
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-36"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td"
-                        data-key="0"
-                        tabindex="-1"
-                      />
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="1"
-                        data-label="System name"
-                        tabindex="-1"
-                      >
-                        <a
-                          href="/insights/inventory/42438801-c384-491a-943b-f5f621f0c882"
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          YL-test-device-85
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="2"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Timeout
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="3"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 8px;"
-                          >
-                            <span
-                              class="pf-v5-c-icon"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
+                                <span
+                                  class="pf-v5-c-table__text"
                                 >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 16px;"
-                          >
-                            <span
-                              style="color: rgb(201, 25, 11);"
-                            >
-                              Alert
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
-                          >
-                            Task failed to complete due to timing out. Retry this task at a later time.
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                  <tbody
-                    class="pf-v5-c-table__tbody"
-                    role="rowgroup"
-                  >
-                    <tr
-                      aria-label=""
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-37"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td"
-                        data-key="0"
-                        tabindex="-1"
-                      />
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="1"
-                        data-label="System name"
-                        tabindex="-1"
-                      >
-                        <a
-                          href="/insights/inventory/3262b268-23ed-4c5a-a918-d8c4923fdfbf"
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          MG-test-device
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="2"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Failure
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="3"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 8px;"
-                          >
-                            <span
-                              class="pf-v5-c-icon"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
+                                  Message
+                                </span>
+                                <span
+                                  class="pf-v5-c-table__sort-indicator"
                                 >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 16px;"
-                          >
-                            <span
-                              style="color: rgb(201, 25, 11);"
-                            >
-                              Alert
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
-                          >
-                            Task failed to complete for an unknown reason. Retry this task at a later time.
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                  <tbody
-                    class="pf-v5-c-table__tbody"
-                    role="rowgroup"
-                  >
-                    <tr
-                      aria-label=""
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-38"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td"
-                        data-key="0"
-                        tabindex="-1"
-                      />
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="1"
-                        data-label="System name"
-                        tabindex="-1"
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 256 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </button>
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
                       >
-                        <a
-                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
-                          rel="noreferrer"
-                          target="_blank"
+                        <tr
+                          aria-label=""
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-36"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
                         >
-                          dl-test-device-2
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="2"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Success
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="3"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-key="0"
+                            tabindex="-1"
                           />
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                  <tbody
-                    class="pf-v5-c-table__tbody"
-                    role="rowgroup"
-                  >
-                    <tr
-                      aria-label=""
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-39"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                        data-key="0"
-                        tabindex="-1"
-                      >
-                        <button
-                          aria-disabled="false"
-                          aria-expanded="false"
-                          aria-label="Details"
-                          aria-labelledby="simple-node3 expandable-toggle3"
-                          class="pf-v5-c-button pf-m-plain"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-23"
-                          data-ouia-component-type="PF5/Button"
-                          data-ouia-safe="true"
-                          id="expandable-toggle3"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__toggle-icon"
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="1"
+                            data-label="System name"
+                            tabindex="-1"
                           >
-                            <svg
-                              aria-hidden="true"
-                              class="pf-v5-svg"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 320 512"
-                              width="1em"
+                            <a
+                              href="/insights/inventory/42438801-c384-491a-943b-f5f621f0c882"
+                              rel="noreferrer"
+                              target="_blank"
                             >
-                              <path
-                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                              />
-                            </svg>
-                          </div>
-                        </button>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="1"
-                        data-label="System name"
-                        tabindex="-1"
-                      >
-                        <a
-                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cf29c99"
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          dl-test-device-4
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="2"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Success
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="3"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 8px;"
+                              YL-test-device-85
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="2"
+                            data-label="Status"
+                            tabindex="-1"
                           >
-                            <span
-                              class="pf-v5-c-icon"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 16px;"
-                          >
-                            <span
-                              style="color: rgb(201, 25, 11);"
-                            >
-                              Alert
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
-                          >
-                            Your system has 1 inhibitor out of 4 potential problems
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr
-                      aria-label=""
-                      class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                      data-ouia-component-id="OUIA-Generated-TableRow-40"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                      hidden=""
-                    >
-                      <td
-                        class="pf-v5-c-table__td"
-                        colspan="4"
-                        data-key="0"
-                        id="expanded-content4"
-                        tabindex="-1"
-                      >
-                        <div>
-                          <table
-                            class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                            data-ouia-component-id="OUIA-Generated-Table-9"
-                            data-ouia-component-type="PF5/Table"
-                            data-ouia-safe="true"
-                            role="grid"
-                            style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                          >
-                            <tbody
-                              class="pf-v5-c-table__tbody"
-                              role="rowgroup"
-                            >
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-41"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node0 expand-toggle0"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-24"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle0"
-                                    type="button"
-                                  >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-danger"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(163, 0, 0);"
-                                    >
-                                      <strong>
-                                        Leapp could not identify where GRUB core is located
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-42"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-red pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
-                                        >
-                                          High risk
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    Leapp could not identify where GRUB core is located
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Remediation
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span
-                                            class="remediations-font-family"
-                                          >
-                                            [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        ca7a1a66906a7df3da890aa538562708d3ea6ecd
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-43"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node1 expand-toggle1"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-25"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle1"
-                                    type="button"
-                                  >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-warning"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 576 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(121, 80, 0);"
-                                    >
-                                      <strong>
-                                        SElinux will be set to permissive mode
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-44"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-orange pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 576 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
-                                        >
-                                          Low risk
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    SElinux will be set to permissive mode
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Remediation
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span
-                                            class="remediations-font-family"
-                                          >
-                                            [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-45"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node2 expand-toggle2"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-26"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle2"
-                                    type="button"
-                                  >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-warning"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 576 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(121, 80, 0);"
-                                    >
-                                      <strong>
-                                        The subscription-manager release is going to be set after the upgrade
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-46"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-orange pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 576 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
-                                        >
-                                          Low risk
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    The subscription-manager release is going to be set after the upgrade
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        After the upgrade has completed the release of the subscription-manager will be set to 9.0. This will ensure that you will receive and keep the version you choose to upgrade to.
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Remediation
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span
-                                            class="remediations-font-family"
-                                          >
-                                            [hint] If you wish to receive updates for the latest released version of the target system, run \`subscription-manager release --unset\` after the upgrade.
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        747a4ca25303eda17d1891bb85eeb226be14f252
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-47"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node3 expand-toggle3"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-27"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle3"
-                                    type="button"
-                                  >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-info"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(0, 41, 82);"
-                                    >
-                                      <strong>
-                                        SElinux relabeling will be scheduled
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-48"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-blue pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
-                                        >
-                                          Info
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    SElinux relabeling will be scheduled
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        SElinux relabeling will be scheduled as the status is permissive/enforcing.
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        8fb81863f8413bd617c2a55b69b8e10ff03d7c72
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                  <tbody
-                    class="pf-v5-c-table__tbody"
-                    role="rowgroup"
-                  >
-                    <tr
-                      aria-label=""
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-49"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                        data-key="0"
-                        tabindex="-1"
-                      >
-                        <button
-                          aria-disabled="false"
-                          aria-expanded="false"
-                          aria-label="Details"
-                          aria-labelledby="simple-node5 expandable-toggle5"
-                          class="pf-v5-c-button pf-m-plain"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-28"
-                          data-ouia-component-type="PF5/Button"
-                          data-ouia-safe="true"
-                          id="expandable-toggle5"
-                          type="button"
-                        >
-                          <div
-                            class="pf-v5-c-table__toggle-icon"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="pf-v5-svg"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 320 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                              />
-                            </svg>
-                          </div>
-                        </button>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="1"
-                        data-label="System name"
-                        tabindex="-1"
-                      >
-                        <a
-                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cf29c91"
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          dl-test-device-5
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="2"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Success
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="3"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 8px;"
-                          >
-                            <span
-                              class="pf-v5-c-icon"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 16px;"
-                          >
-                            <span
-                              style="color: rgb(201, 25, 11);"
-                            >
-                              Alert
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
-                          >
-                            Your system has 1 inhibitor out of 4 potential problems
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr
-                      aria-label=""
-                      class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                      data-ouia-component-id="OUIA-Generated-TableRow-50"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                      hidden=""
-                    >
-                      <td
-                        class="pf-v5-c-table__td"
-                        colspan="4"
-                        data-key="0"
-                        id="expanded-content6"
-                        tabindex="-1"
-                      >
-                        <div>
-                          <div
-                            class="pf-v5-c-code-block"
-                            style="--pf-v5-c-code-block__header--BorderBottomColor: [object Object]; background-color: rgb(255, 255, 255);"
+                            Timeout
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="3"
+                            data-label="Message"
+                            tabindex="-1"
                           >
                             <div
-                              class="pf-v5-c-code-block__content"
+                              class="pf-v5-l-split"
                             >
-                              <pre
-                                class="pf-v5-c-code-block__pre"
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 8px;"
                               >
-                                <code
-                                  class="pf-v5-c-code-block__code"
+                                <span
+                                  class="pf-v5-c-icon"
                                 >
-                                  Risk Factor: high
+                                  <span
+                                    class="pf-v5-c-icon__content pf-m-danger"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 16px;"
+                              >
+                                <span
+                                  style="color: rgb(201, 25, 11);"
+                                >
+                                  Alert
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
+                              >
+                                Task failed to complete due to timing out. Retry this task at a later time.
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
+                      >
+                        <tr
+                          aria-label=""
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-37"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-key="0"
+                            tabindex="-1"
+                          />
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="1"
+                            data-label="System name"
+                            tabindex="-1"
+                          >
+                            <a
+                              href="/insights/inventory/3262b268-23ed-4c5a-a918-d8c4923fdfbf"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              MG-test-device
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="2"
+                            data-label="Status"
+                            tabindex="-1"
+                          >
+                            Failure
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="3"
+                            data-label="Message"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="pf-v5-l-split"
+                            >
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 8px;"
+                              >
+                                <span
+                                  class="pf-v5-c-icon"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon__content pf-m-danger"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 16px;"
+                              >
+                                <span
+                                  style="color: rgb(201, 25, 11);"
+                                >
+                                  Alert
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
+                              >
+                                Task failed to complete for an unknown reason. Retry this task at a later time.
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
+                      >
+                        <tr
+                          aria-label=""
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-38"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-key="0"
+                            tabindex="-1"
+                          />
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="1"
+                            data-label="System name"
+                            tabindex="-1"
+                          >
+                            <a
+                              href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              dl-test-device-2
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="2"
+                            data-label="Status"
+                            tabindex="-1"
+                          >
+                            Success
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="3"
+                            data-label="Message"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="pf-v5-l-split"
+                            >
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
+                              />
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
+                      >
+                        <tr
+                          aria-label=""
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-39"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                            data-key="0"
+                            tabindex="-1"
+                          >
+                            <button
+                              aria-disabled="false"
+                              aria-expanded="false"
+                              aria-label="Details"
+                              aria-labelledby="simple-node3 expandable-toggle3"
+                              class="pf-v5-c-button pf-m-plain"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-23"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              id="expandable-toggle3"
+                              type="button"
+                            >
+                              <div
+                                class="pf-v5-c-table__toggle-icon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 320 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                  />
+                                </svg>
+                              </div>
+                            </button>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="1"
+                            data-label="System name"
+                            tabindex="-1"
+                          >
+                            <a
+                              href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cf29c99"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              dl-test-device-4
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="2"
+                            data-label="Status"
+                            tabindex="-1"
+                          >
+                            Success
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="3"
+                            data-label="Message"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="pf-v5-l-split"
+                            >
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 8px;"
+                              >
+                                <span
+                                  class="pf-v5-c-icon"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon__content pf-m-danger"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 16px;"
+                              >
+                                <span
+                                  style="color: rgb(201, 25, 11);"
+                                >
+                                  Alert
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
+                              >
+                                Your system has 1 inhibitor out of 4 potential problems
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr
+                          aria-label=""
+                          class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                          data-ouia-component-id="OUIA-Generated-TableRow-40"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                          hidden=""
+                        >
+                          <td
+                            class="pf-v5-c-table__td"
+                            colspan="4"
+                            data-key="0"
+                            id="expanded-content4"
+                            tabindex="-1"
+                          >
+                            <div>
+                              <table
+                                class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                                data-ouia-component-id="OUIA-Generated-Table-9"
+                                data-ouia-component-type="PF5/Table"
+                                data-ouia-safe="true"
+                                role="grid"
+                                style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                              >
+                                <tbody
+                                  class="pf-v5-c-table__tbody"
+                                  role="rowgroup"
+                                >
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-41"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node0 expand-toggle0"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-24"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle0"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-danger"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(163, 0, 0);"
+                                        >
+                                          <strong>
+                                            Leapp could not identify where GRUB core is located
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-42"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-red pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              High risk
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
+                                        Leapp could not identify where GRUB core is located
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Remediation
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            ca7a1a66906a7df3da890aa538562708d3ea6ecd
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-43"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node1 expand-toggle1"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-25"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle1"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-warning"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 576 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(121, 80, 0);"
+                                        >
+                                          <strong>
+                                            SElinux will be set to permissive mode
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-44"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 576 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              Low risk
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
+                                        SElinux will be set to permissive mode
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Remediation
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-45"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node2 expand-toggle2"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-26"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle2"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-warning"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 576 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(121, 80, 0);"
+                                        >
+                                          <strong>
+                                            The subscription-manager release is going to be set after the upgrade
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-46"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 576 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              Low risk
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
+                                        The subscription-manager release is going to be set after the upgrade
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            After the upgrade has completed the release of the subscription-manager will be set to 9.0. This will ensure that you will receive and keep the version you choose to upgrade to.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Remediation
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                [hint] If you wish to receive updates for the latest released version of the target system, run \`subscription-manager release --unset\` after the upgrade.
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            747a4ca25303eda17d1891bb85eeb226be14f252
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-47"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node3 expand-toggle3"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-27"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle3"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-info"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(0, 41, 82);"
+                                        >
+                                          <strong>
+                                            SElinux relabeling will be scheduled
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-48"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-blue pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              Info
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
+                                        SElinux relabeling will be scheduled
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            SElinux relabeling will be scheduled as the status is permissive/enforcing.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            8fb81863f8413bd617c2a55b69b8e10ff03d7c72
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
+                      >
+                        <tr
+                          aria-label=""
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-49"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                            data-key="0"
+                            tabindex="-1"
+                          >
+                            <button
+                              aria-disabled="false"
+                              aria-expanded="false"
+                              aria-label="Details"
+                              aria-labelledby="simple-node5 expandable-toggle5"
+                              class="pf-v5-c-button pf-m-plain"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-28"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              id="expandable-toggle5"
+                              type="button"
+                            >
+                              <div
+                                class="pf-v5-c-table__toggle-icon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 320 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                  />
+                                </svg>
+                              </div>
+                            </button>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="1"
+                            data-label="System name"
+                            tabindex="-1"
+                          >
+                            <a
+                              href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cf29c91"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              dl-test-device-5
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="2"
+                            data-label="Status"
+                            tabindex="-1"
+                          >
+                            Success
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="3"
+                            data-label="Message"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="pf-v5-l-split"
+                            >
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 8px;"
+                              >
+                                <span
+                                  class="pf-v5-c-icon"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon__content pf-m-danger"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 16px;"
+                              >
+                                <span
+                                  style="color: rgb(201, 25, 11);"
+                                >
+                                  Alert
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
+                              >
+                                Your system has 1 inhibitor out of 4 potential problems
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr
+                          aria-label=""
+                          class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                          data-ouia-component-id="OUIA-Generated-TableRow-50"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                          hidden=""
+                        >
+                          <td
+                            class="pf-v5-c-table__td"
+                            colspan="4"
+                            data-key="0"
+                            id="expanded-content6"
+                            tabindex="-1"
+                          >
+                            <div>
+                              <div
+                                class="pf-v5-c-code-block"
+                                style="--pf-v5-c-code-block__header--BorderBottomColor: [object Object]; background-color: rgb(255, 255, 255);"
+                              >
+                                <div
+                                  class="pf-v5-c-code-block__content"
+                                >
+                                  <pre
+                                    class="pf-v5-c-code-block__pre"
+                                  >
+                                    <code
+                                      class="pf-v5-c-code-block__code"
+                                    >
+                                      Risk Factor: high
 Title: Leapp could not identify where GRUB core is located
 Summary: We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
 Remediation: [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
@@ -5665,114 +5694,57 @@ Summary: SElinux relabeling will be scheduled as the status is permissive/enforc
 Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
 ----------------------------------------
 
-                                </code>
-                              </pre>
+                                    </code>
+                                  </pre>
+                                </div>
+                              </div>
+                              <table
+                                class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                                data-ouia-component-id="OUIA-Generated-Table-10"
+                                data-ouia-component-type="PF5/Table"
+                                data-ouia-safe="true"
+                                role="grid"
+                                style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                              >
+                                <tbody
+                                  class="pf-v5-c-table__tbody"
+                                  role="rowgroup"
+                                />
+                              </table>
                             </div>
-                          </div>
-                          <table
-                            class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                            data-ouia-component-id="OUIA-Generated-Table-10"
-                            data-ouia-component-type="PF5/Table"
-                            data-ouia-safe="true"
-                            role="grid"
-                            style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                          >
-                            <tbody
-                              class="pf-v5-c-table__tbody"
-                              role="rowgroup"
-                            />
-                          </table>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                  <tbody
-                    class="pf-v5-c-table__tbody"
-                    role="rowgroup"
-                  >
-                    <tr
-                      aria-label=""
-                      class="pf-v5-c-table__tr"
-                      data-ouia-component-id="OUIA-Generated-TableRow-51"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                    >
-                      <td
-                        class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                        data-key="0"
-                        tabindex="-1"
+                          </td>
+                        </tr>
+                      </tbody>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
                       >
-                        <button
-                          aria-disabled="false"
-                          aria-expanded="false"
-                          aria-label="Details"
-                          aria-labelledby="simple-node7 expandable-toggle7"
-                          class="pf-v5-c-button pf-m-plain"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-29"
-                          data-ouia-component-type="PF5/Button"
+                        <tr
+                          aria-label=""
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-51"
+                          data-ouia-component-type="PF5/TableRow"
                           data-ouia-safe="true"
-                          id="expandable-toggle7"
-                          type="button"
                         >
-                          <div
-                            class="pf-v5-c-table__toggle-icon"
+                          <td
+                            class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                            data-key="0"
+                            tabindex="-1"
                           >
-                            <svg
-                              aria-hidden="true"
-                              class="pf-v5-svg"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 320 512"
-                              width="1em"
+                            <button
+                              aria-disabled="false"
+                              aria-expanded="false"
+                              aria-label="Details"
+                              aria-labelledby="simple-node7 expandable-toggle7"
+                              class="pf-v5-c-button pf-m-plain"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-29"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              id="expandable-toggle7"
+                              type="button"
                             >
-                              <path
-                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                              />
-                            </svg>
-                          </div>
-                        </button>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-30"
-                        data-key="1"
-                        data-label="System name"
-                        tabindex="-1"
-                      >
-                        <a
-                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc53bee"
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          dl-test-device-3
-                        </a>
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-10"
-                        data-key="2"
-                        data-label="Status"
-                        tabindex="-1"
-                      >
-                        Success
-                      </td>
-                      <td
-                        class="pf-v5-c-table__td pf-m-width-35"
-                        data-key="3"
-                        data-label="Message"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="pf-v5-l-split"
-                        >
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 8px;"
-                          >
-                            <span
-                              class="pf-v5-c-icon"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
+                              <div
+                                class="pf-v5-c-table__toggle-icon"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -5780,1286 +5752,1344 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                   fill="currentColor"
                                   height="1em"
                                   role="img"
-                                  viewBox="0 0 512 512"
+                                  viewBox="0 0 320 512"
                                   width="1em"
                                 >
                                   <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                    d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
                                   />
                                 </svg>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            style="padding-right: 16px;"
+                              </div>
+                            </button>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-30"
+                            data-key="1"
+                            data-label="System name"
+                            tabindex="-1"
                           >
-                            <span
-                              style="color: rgb(201, 25, 11);"
+                            <a
+                              href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc53bee"
+                              rel="noreferrer"
+                              target="_blank"
                             >
-                              Alert
-                            </span>
-                          </div>
-                          <div
-                            class="pf-v5-l-split__item"
-                            color="#A30000"
+                              dl-test-device-3
+                            </a>
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-10"
+                            data-key="2"
+                            data-label="Status"
+                            tabindex="-1"
                           >
-                            Your system has 3 inhibitors out of 5 potential problems.
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr
-                      aria-label=""
-                      class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                      data-ouia-component-id="OUIA-Generated-TableRow-52"
-                      data-ouia-component-type="PF5/TableRow"
-                      data-ouia-safe="true"
-                      hidden=""
-                    >
-                      <td
-                        class="pf-v5-c-table__td"
-                        colspan="4"
-                        data-key="0"
-                        id="expanded-content8"
-                        tabindex="-1"
-                      >
-                        <div>
-                          <table
-                            class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                            data-ouia-component-id="OUIA-Generated-Table-11"
-                            data-ouia-component-type="PF5/Table"
-                            data-ouia-safe="true"
-                            role="grid"
-                            style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                          >
-                            <tbody
-                              class="pf-v5-c-table__tbody"
-                              role="rowgroup"
-                            >
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-53"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node0 expand-toggle0"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-30"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle0"
-                                    type="button"
-                                  >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-danger"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(163, 0, 0);"
-                                    >
-                                      <strong>
-                                        Leapp could not identify where GRUB core is located
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-54"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-red pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
-                                        >
-                                          High risk
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    Leapp could not identify where GRUB core is located
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Remediation
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span
-                                            class="remediations-font-family"
-                                          >
-                                            [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        ca7a1a66906a7df3da890aa538562708d3ea6ecd
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-55"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node1 expand-toggle1"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-31"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle1"
-                                    type="button"
-                                  >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-danger"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(163, 0, 0);"
-                                    >
-                                      <strong>
-                                        Firewalld Configuration AllowZoneDrifting Is Unsupported
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-56"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-red pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
-                                        >
-                                          High risk
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    Firewalld Configuration AllowZoneDrifting Is Unsupported
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        Firewalld has enabled configuration option "AllowZoneDrifiting" which has been removed in RHEL-9. New behavior is as if "AllowZoneDrifiting" was set to "no".
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Remediation
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span
-                                            class="remediations-font-family"
-                                          >
-                                            [hint] Set AllowZoneDrifting=no in /etc/firewalld/firewalld.conf
-                                          </span>
-                                        </div>
-                                        <div>
-                                          <span>
-                                            <br />
-                                          </span>
-                                          <span
-                                            class="remediations-font-family"
-                                          >
-                                            [command] sed -i "s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/" /etc/firewalld/firewalld.conf
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        5b1cf050e1a877b0358b6e8c612277c591d40c13
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-57"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node2 expand-toggle2"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-32"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle2"
-                                    type="button"
-                                  >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-danger"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(163, 0, 0);"
-                                    >
-                                      <strong>
-                                        VDO devices migration to LVM management
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-58"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-red pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
-                                        >
-                                          High risk
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    VDO devices migration to LVM management
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        VDO devices 'vda, vda1, vda2' require migration to LVM management.After performing the upgrade VDO devices can only be managed via LVM. Any VDO device not currently managed by LVM must be converted to LVM management before upgrading. The data on any VDO device not converted to LVM management will be inaccessible after upgrading.
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Remediation
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span
-                                            class="remediations-font-family"
-                                          >
-                                            [hint] Consult the VDO to LVM conversion process documentation for how to perform the conversion.
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        f7c335398cc449f5d7baf4e73255d44c34ad2620
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-59"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node3 expand-toggle3"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-33"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle3"
-                                    type="button"
-                                  >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-warning"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 576 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(121, 80, 0);"
-                                    >
-                                      <strong>
-                                        SElinux will be set to permissive mode
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-60"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-orange pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 576 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
-                                        >
-                                          Low risk
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    SElinux will be set to permissive mode
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Remediation
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        <div>
-                                          <span
-                                            class="remediations-font-family"
-                                          >
-                                            [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
-                                          </span>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr"
-                                data-ouia-component-id="OUIA-Generated-TableRow-61"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                              >
-                                <td
-                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                  tabindex="-1"
-                                >
-                                  <button
-                                    aria-disabled="false"
-                                    aria-expanded="false"
-                                    aria-label="Details"
-                                    aria-labelledby="simple-node4 expand-toggle4"
-                                    class="pf-v5-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-34"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    id="expand-toggle4"
-                                    type="button"
-                                  >
-                                    <div
-                                      class="pf-v5-c-table__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                        />
-                                      </svg>
-                                    </div>
-                                  </button>
-                                </td>
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <span>
-                                    <span
-                                      class="pf-v5-c-icon"
-                                      style="margin-right: 8px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon__content pf-m-info"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 512 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                    <span
-                                      style="color: rgb(0, 41, 82);"
-                                    >
-                                      <strong>
-                                        SElinux relabeling will be scheduled
-                                      </strong>
-                                    </span>
-                                  </span>
-                                </td>
-                              </tr>
-                              <tr
-                                aria-label=""
-                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                data-ouia-component-id="OUIA-Generated-TableRow-62"
-                                data-ouia-component-type="PF5/TableRow"
-                                data-ouia-safe="true"
-                                hidden=""
-                              >
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                />
-                                <td
-                                  class="pf-v5-c-table__td"
-                                  tabindex="-1"
-                                >
-                                  <div>
-                                    <span
-                                      class="pf-v5-c-label pf-m-blue pf-m-compact"
-                                      style="margin-top: 16px; margin-bottom: 4px;"
-                                    >
-                                      <span
-                                        class="pf-v5-c-label__content"
-                                      >
-                                        <span
-                                          class="pf-v5-c-label__icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                            />
-                                          </svg>
-                                        </span>
-                                        <span
-                                          class="pf-v5-c-label__text"
-                                        >
-                                          Info
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="entry-title"
-                                  >
-                                    SElinux relabeling will be scheduled
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Summary
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        SElinux relabeling will be scheduled as the status is permissive/enforcing.
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                    >
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                      >
-                                        Key
-                                      </div>
-                                      <div
-                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                        l="6"
-                                        m="7"
-                                        style="white-space: pre-line;"
-                                      >
-                                        8fb81863f8413bd617c2a55b69b8e10ff03d7c72
-                                      </div>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-                <div
-                  class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
-                  data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-3"
-                  data-ouia-component-type="RHI/TableToolbar"
-                  data-ouia-safe="true"
-                  id="pf-random-id-5"
-                >
-                  <div
-                    class="pf-v5-c-toolbar__content"
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__content-section"
-                    >
-                      <div
-                        class="pf-v5-c-toolbar__item pf-m-align-self-center"
-                      >
-                        <div>
-                          <div
-                            style="display: contents;"
+                            Success
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td pf-m-width-35"
+                            data-key="3"
+                            data-label="Message"
+                            tabindex="-1"
                           >
                             <div
-                              class="pf-v5-c-content"
+                              class="pf-v5-l-split"
                             >
-                              <small
-                                class=""
-                                data-ouia-component-id="OUIA-Generated-Text-6"
-                                data-ouia-component-type="PF5/Text"
-                                data-ouia-safe="true"
-                                data-pf-content="true"
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 8px;"
                               >
-                                Last updated: All jobs completed
-                              </small>
+                                <span
+                                  class="pf-v5-c-icon"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon__content pf-m-danger"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                style="padding-right: 16px;"
+                              >
+                                <span
+                                  style="color: rgb(201, 25, 11);"
+                                >
+                                  Alert
+                                </span>
+                              </div>
+                              <div
+                                class="pf-v5-l-split__item"
+                                color="#A30000"
+                              >
+                                Your system has 3 inhibitors out of 5 potential problems.
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr
+                          aria-label=""
+                          class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                          data-ouia-component-id="OUIA-Generated-TableRow-52"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                          hidden=""
+                        >
+                          <td
+                            class="pf-v5-c-table__td"
+                            colspan="4"
+                            data-key="0"
+                            id="expanded-content8"
+                            tabindex="-1"
+                          >
+                            <div>
+                              <table
+                                class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                                data-ouia-component-id="OUIA-Generated-Table-11"
+                                data-ouia-component-type="PF5/Table"
+                                data-ouia-safe="true"
+                                role="grid"
+                                style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                              >
+                                <tbody
+                                  class="pf-v5-c-table__tbody"
+                                  role="rowgroup"
+                                >
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-53"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node0 expand-toggle0"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-30"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle0"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-danger"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(163, 0, 0);"
+                                        >
+                                          <strong>
+                                            Leapp could not identify where GRUB core is located
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-54"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-red pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              High risk
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
+                                        Leapp could not identify where GRUB core is located
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Remediation
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            ca7a1a66906a7df3da890aa538562708d3ea6ecd
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-55"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node1 expand-toggle1"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-31"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle1"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-danger"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(163, 0, 0);"
+                                        >
+                                          <strong>
+                                            Firewalld Configuration AllowZoneDrifting Is Unsupported
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-56"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-red pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              High risk
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
+                                        Firewalld Configuration AllowZoneDrifting Is Unsupported
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            Firewalld has enabled configuration option "AllowZoneDrifiting" which has been removed in RHEL-9. New behavior is as if "AllowZoneDrifiting" was set to "no".
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Remediation
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                [hint] Set AllowZoneDrifting=no in /etc/firewalld/firewalld.conf
+                                              </span>
+                                            </div>
+                                            <div>
+                                              <span>
+                                                <br />
+                                              </span>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                [command] sed -i "s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/" /etc/firewalld/firewalld.conf
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            5b1cf050e1a877b0358b6e8c612277c591d40c13
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-57"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node2 expand-toggle2"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-32"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle2"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-danger"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(163, 0, 0);"
+                                        >
+                                          <strong>
+                                            VDO devices migration to LVM management
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-58"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-red pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              High risk
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
+                                        VDO devices migration to LVM management
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            VDO devices 'vda, vda1, vda2' require migration to LVM management.After performing the upgrade VDO devices can only be managed via LVM. Any VDO device not currently managed by LVM must be converted to LVM management before upgrading. The data on any VDO device not converted to LVM management will be inaccessible after upgrading.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Remediation
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                [hint] Consult the VDO to LVM conversion process documentation for how to perform the conversion.
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            f7c335398cc449f5d7baf4e73255d44c34ad2620
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-59"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node3 expand-toggle3"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-33"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle3"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-warning"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 576 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(121, 80, 0);"
+                                        >
+                                          <strong>
+                                            SElinux will be set to permissive mode
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-60"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 576 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              Low risk
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
+                                        SElinux will be set to permissive mode
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Remediation
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            <div>
+                                              <span
+                                                class="remediations-font-family"
+                                              >
+                                                [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-61"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                      tabindex="-1"
+                                    >
+                                      <button
+                                        aria-disabled="false"
+                                        aria-expanded="false"
+                                        aria-label="Details"
+                                        aria-labelledby="simple-node4 expand-toggle4"
+                                        class="pf-v5-c-button pf-m-plain"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-34"
+                                        data-ouia-component-type="PF5/Button"
+                                        data-ouia-safe="true"
+                                        id="expand-toggle4"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="pf-v5-c-table__toggle-icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </button>
+                                    </td>
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <span>
+                                        <span
+                                          class="pf-v5-c-icon"
+                                          style="margin-right: 8px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-icon__content pf-m-info"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="pf-v5-svg"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                        <span
+                                          style="color: rgb(0, 41, 82);"
+                                        >
+                                          <strong>
+                                            SElinux relabeling will be scheduled
+                                          </strong>
+                                        </span>
+                                      </span>
+                                    </td>
+                                  </tr>
+                                  <tr
+                                    aria-label=""
+                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                    data-ouia-component-id="OUIA-Generated-TableRow-62"
+                                    data-ouia-component-type="PF5/TableRow"
+                                    data-ouia-safe="true"
+                                    hidden=""
+                                  >
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    />
+                                    <td
+                                      class="pf-v5-c-table__td"
+                                      tabindex="-1"
+                                    >
+                                      <div>
+                                        <span
+                                          class="pf-v5-c-label pf-m-blue pf-m-compact"
+                                          style="margin-top: 16px; margin-bottom: 4px;"
+                                        >
+                                          <span
+                                            class="pf-v5-c-label__content"
+                                          >
+                                            <span
+                                              class="pf-v5-c-label__icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="pf-v5-svg"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                viewBox="0 0 512 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                                />
+                                              </svg>
+                                            </span>
+                                            <span
+                                              class="pf-v5-c-label__text"
+                                            >
+                                              Info
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div
+                                        class="entry-title"
+                                      >
+                                        SElinux relabeling will be scheduled
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Summary
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            SElinux relabeling will be scheduled as the status is permissive/enforcing.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        >
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          >
+                                            Key
+                                          </div>
+                                          <div
+                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                            l="6"
+                                            m="7"
+                                            style="white-space: pre-line;"
+                                          >
+                                            8fb81863f8413bd617c2a55b69b8e10ff03d7c72
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <div
+                      class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
+                      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-3"
+                      data-ouia-component-type="RHI/TableToolbar"
+                      data-ouia-safe="true"
+                      id="pf-random-id-5"
+                    >
+                      <div
+                        class="pf-v5-c-toolbar__content"
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__content-section"
+                        >
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-align-self-center"
+                          >
+                            <div>
+                              <div
+                                style="display: contents;"
+                              >
+                                <div
+                                  class="pf-v5-c-content"
+                                >
+                                  <small
+                                    class=""
+                                    data-ouia-component-id="OUIA-Generated-Text-6"
+                                    data-ouia-component-type="PF5/Text"
+                                    data-ouia-safe="true"
+                                    data-pf-content="true"
+                                  >
+                                    Last updated: All jobs completed
+                                  </small>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
+                          >
+                            <div
+                              class="pf-v5-c-pagination pf-m-bottom"
+                              data-ouia-component-id="OUIA-Generated-Pagination-bottom-3"
+                              data-ouia-component-type="PF5/Pagination"
+                              data-ouia-safe="true"
+                              id="options-menu-bottom-pagination"
+                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                            >
+                              <div>
+                                <button
+                                  aria-expanded="false"
+                                  aria-haspopup="listbox"
+                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                                  id="options-menu-bottom-toggle"
+                                  type="button"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__text"
+                                  >
+                                    <b>
+                                      1 - 6
+                                    </b>
+                                     of 
+                                    <b>
+                                      6
+                                    </b>
+                                     
+                                  </span>
+                                  <span
+                                    class="pf-v5-c-menu-toggle__controls"
+                                  >
+                                    <span
+                                      class="pf-v5-c-menu-toggle__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                              <nav
+                                aria-label="Pagination"
+                                class="pf-v5-c-pagination__nav"
+                              >
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-first"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to first page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="first"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-35"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to previous page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="previous"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-36"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-page-select"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control pf-m-disabled"
+                                  >
+                                    <input
+                                      aria-invalid="false"
+                                      aria-label="Current page"
+                                      data-ouia-component-id="OUIA-Generated-TextInputBase-6"
+                                      data-ouia-component-type="PF5/TextInput"
+                                      data-ouia-safe="true"
+                                      disabled=""
+                                      max="1"
+                                      min="1"
+                                      type="number"
+                                      value="1"
+                                    />
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                  >
+                                    of 1
+                                  </span>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to next page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="next"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-37"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                                <div
+                                  class="pf-v5-c-pagination__nav-control pf-m-last"
+                                >
+                                  <button
+                                    aria-disabled="true"
+                                    aria-label="Go to last page"
+                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                    data-action="last"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-38"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </nav>
                             </div>
                           </div>
                         </div>
                       </div>
                       <div
-                        class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
+                        class="pf-v5-c-toolbar__content pf-m-hidden"
+                        hidden=""
                       >
                         <div
-                          class="pf-v5-c-pagination pf-m-bottom"
-                          data-ouia-component-id="OUIA-Generated-Pagination-bottom-3"
-                          data-ouia-component-type="PF5/Pagination"
-                          data-ouia-safe="true"
-                          id="options-menu-bottom-pagination"
-                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-                        >
-                          <div>
-                            <button
-                              aria-expanded="false"
-                              aria-haspopup="listbox"
-                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                              id="options-menu-bottom-toggle"
-                              type="button"
-                            >
-                              <span
-                                class="pf-v5-c-menu-toggle__text"
-                              >
-                                <b>
-                                  1 - 6
-                                </b>
-                                 of 
-                                <b>
-                                  6
-                                </b>
-                                 
-                              </span>
-                              <span
-                                class="pf-v5-c-menu-toggle__controls"
-                              >
-                                <span
-                                  class="pf-v5-c-menu-toggle__toggle-icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 320 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                    />
-                                  </svg>
-                                </span>
-                              </span>
-                            </button>
-                          </div>
-                          <nav
-                            aria-label="Pagination"
-                            class="pf-v5-c-pagination__nav"
-                          >
-                            <div
-                              class="pf-v5-c-pagination__nav-control pf-m-first"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to first page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="first"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-35"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 448 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to previous page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="previous"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-36"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-page-select"
-                            >
-                              <span
-                                class="pf-v5-c-form-control pf-m-disabled"
-                              >
-                                <input
-                                  aria-invalid="false"
-                                  aria-label="Current page"
-                                  data-ouia-component-id="OUIA-Generated-TextInputBase-6"
-                                  data-ouia-component-type="PF5/TextInput"
-                                  data-ouia-safe="true"
-                                  disabled=""
-                                  max="1"
-                                  min="1"
-                                  type="number"
-                                  value="1"
-                                />
-                              </span>
-                              <span
-                                aria-hidden="true"
-                              >
-                                of 1
-                              </span>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to next page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="next"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-37"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 256 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                            <div
-                              class="pf-v5-c-pagination__nav-control pf-m-last"
-                            >
-                              <button
-                                aria-disabled="true"
-                                aria-label="Go to last page"
-                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                data-action="last"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-38"
-                                data-ouia-component-type="PF5/Button"
-                                data-ouia-safe="true"
-                                disabled=""
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 448 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                          </nav>
-                        </div>
+                          class="pf-v5-c-toolbar__group"
+                        />
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="pf-v5-c-toolbar__content pf-m-hidden"
-                    hidden=""
-                  >
-                    <div
-                      class="pf-v5-c-toolbar__group"
-                    />
-                  </div>
-                </div>
-              </div>
-            </section>
+                </section>
+              </main>
+            </div>
           </div>
+          <div
+            class="pf-v5-c-drawer__panel"
+            hidden=""
+            id="pf-drawer-panel-4"
+          />
         </div>
-        <div
-          class="pf-v5-c-drawer__panel pf-m-resizable"
-          hidden=""
-          id="end-resize-panel"
-          style="--pf-v5-c-drawer__panel--md--FlexBasis: 1000px; --pf-v5-c-drawer__panel--md--FlexBasis--min: 500px;"
-        />
       </div>
     </div>
   </div>

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -3,287 +3,606 @@
 exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`] = `
 <DocumentFragment>
   <div>
-    <section
-      class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
-      widget-type="InsightsPageHeader"
+    <div
+      class="pf-v5-c-drawer"
     >
-      <nav
-        aria-label="Breadcrumb"
-        class="pf-v5-c-breadcrumb"
-        data-ouia-component-id="completed-tasks-details-breadcrumb"
-        data-ouia-component-type="PF5/Breadcrumb"
-        data-ouia-safe="true"
-      >
-        <ol
-          class="pf-v5-c-breadcrumb__list"
-          role="list"
-        >
-          <li
-            class="pf-v5-c-breadcrumb__item"
-          >
-            <a
-              class="pf-v5-c-breadcrumb__link"
-              href="/insights/tasks/executed"
-            >
-              Tasks
-            </a>
-          </li>
-          <li
-            class="pf-v5-c-breadcrumb__item"
-          >
-            <span
-              class="pf-v5-c-breadcrumb__item-divider"
-            >
-              <svg
-                aria-hidden="true"
-                class="pf-v5-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 256 512"
-                width="1em"
-              >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </span>
-            convert-to-rhel-preanalysis task
-          </li>
-        </ol>
-      </nav>
       <div
-        class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
+        class="pf-v5-c-drawer__main"
       >
         <div
-          class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
+          class="pf-v5-c-drawer__content"
         >
           <div
-            class=""
+            class="pf-v5-c-drawer__body"
           >
-            <h1
-              class="pf-v5-c-title pf-m-2xl"
-              data-ouia-component-id="OUIA-Generated-Title-2"
-              data-ouia-component-type="PF5/Title"
-              data-ouia-safe="true"
-              widget-type="InsightsPageHeaderTitle"
+            <section
+              class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+              widget-type="InsightsPageHeader"
             >
-              convert-to-rhel-preanalysis task
-            </h1>
-            <div
-              class="pf-v5-c-content"
-            >
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-3"
-                data-ouia-component-type="PF5/Text"
+              <nav
+                aria-label="Breadcrumb"
+                class="pf-v5-c-breadcrumb"
+                data-ouia-component-id="completed-tasks-details-breadcrumb"
+                data-ouia-component-type="PF5/Breadcrumb"
                 data-ouia-safe="true"
-                data-pf-content="true"
               >
-                Convert to RHEL Preanalysis
-              </small>
-            </div>
-          </div>
-          <div
-            class=""
-          >
-            <p>
-              For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.
-            </p>
-          </div>
-        </div>
-        <div
-          class="pf-v5-l-flex"
-        >
-          <div
-            class=""
-          >
-            <button
-              aria-disabled="false"
-              aria-label="convert-to-rhel-preanalysis-run-task-button"
-              class="pf-v5-c-button pf-m-secondary"
-              data-ouia-component-id="OUIA-Generated-Button-secondary-2"
-              data-ouia-component-type="PF5/Button"
-              data-ouia-safe="true"
-              type="button"
-            >
-              Run task again
-            </button>
-          </div>
-        </div>
-        <div
-          class="pf-v5-l-flex"
-        >
-          <div
-            class=""
-          >
-            <button
-              aria-expanded="false"
-              aria-label="Task details menu toggle"
-              class="pf-v5-c-menu-toggle pf-m-plain"
-              id="executed-task-kebab"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="pf-v5-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 192 512"
-                width="1em"
-              >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section
-      class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
-    >
-      <div
-        class="pf-v5-c-card"
-        data-ouia-component-id="OUIA-Generated-Card-3"
-        data-ouia-component-type="PF5/Card"
-        data-ouia-safe="true"
-        id=""
-      >
-        <div
-          class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
-        >
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Systems
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              3
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Run start
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              01 Jun 2023, 19:58 UTC
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Run end
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              -
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Initiated by
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              insights-qa
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Systems with alerts
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              -
-            </div>
-          </div>
-        </div>
-      </div>
-      <br />
-      <div
-        class="pf-v5-c-card"
-        data-ouia-component-id="OUIA-Generated-Card-4"
-        data-ouia-component-type="PF5/Card"
-        data-ouia-safe="true"
-        id=""
-      >
-        <div
-          class="pf-v5-c-toolbar  ins-c-primary-toolbar"
-          data-ouia-component-id="PrimaryToolbar"
-          data-ouia-component-type="PF5/Toolbar"
-          data-ouia-safe="true"
-          id="ins-primary-data-toolbar"
-        >
-          <div
-            class="pf-v5-c-toolbar__content"
-          >
-            <div
-              class="pf-v5-c-toolbar__content-section"
-            >
+                <ol
+                  class="pf-v5-c-breadcrumb__list"
+                  role="list"
+                >
+                  <li
+                    class="pf-v5-c-breadcrumb__item"
+                  >
+                    <a
+                      class="pf-v5-c-breadcrumb__link"
+                      href="/insights/tasks/executed"
+                    >
+                      Tasks
+                    </a>
+                  </li>
+                  <li
+                    class="pf-v5-c-breadcrumb__item"
+                  >
+                    <span
+                      class="pf-v5-c-breadcrumb__item-divider"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 256 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                        />
+                      </svg>
+                    </span>
+                    convert-to-rhel-preanalysis task
+                  </li>
+                </ol>
+              </nav>
               <div
-                class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+                class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
               >
                 <div
-                  class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                  class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
                 >
                   <div
-                    class="pf-v5-l-split ins-c-conditional-filter"
+                    class=""
+                  >
+                    <h1
+                      class="pf-v5-c-title pf-m-2xl"
+                      data-ouia-component-id="OUIA-Generated-Title-2"
+                      data-ouia-component-type="PF5/Title"
+                      data-ouia-safe="true"
+                      widget-type="InsightsPageHeaderTitle"
+                    >
+                      convert-to-rhel-preanalysis task
+                    </h1>
+                    <div
+                      class="pf-v5-c-content"
+                    >
+                      <small
+                        class=""
+                        data-ouia-component-id="OUIA-Generated-Text-3"
+                        data-ouia-component-type="PF5/Text"
+                        data-ouia-safe="true"
+                        data-pf-content="true"
+                      >
+                        Convert to RHEL Preanalysis
+                      </small>
+                    </div>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    <p>
+                      For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex"
+                >
+                  <div
+                    class=""
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="convert-to-rhel-preanalysis-run-task-button"
+                      class="pf-v5-c-button pf-m-secondary"
+                      data-ouia-component-id="OUIA-Generated-Button-secondary-2"
+                      data-ouia-component-type="PF5/Button"
+                      data-ouia-safe="true"
+                      type="button"
+                    >
+                      Run task again
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex"
+                >
+                  <div
+                    class=""
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-label="Task details menu toggle"
+                      class="pf-v5-c-menu-toggle pf-m-plain"
+                      id="executed-task-kebab"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 192 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section
+              class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
+            >
+              <div
+                class="pf-v5-c-card"
+                data-ouia-component-id="OUIA-Generated-Card-3"
+                data-ouia-component-type="PF5/Card"
+                data-ouia-safe="true"
+                id=""
+              >
+                <div
+                  class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
+                >
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
                   >
                     <div
-                      class="pf-v5-l-split__item"
+                      class=""
                     >
-                      <button
-                        aria-expanded="false"
-                        aria-label="Conditional filter"
-                        class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
-                        type="button"
+                      <b>
+                        Systems
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      3
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Run start
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      01 Jun 2023, 19:58 UTC
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Run end
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      -
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Initiated by
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      insights-qa
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Systems with alerts
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      -
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <br />
+              <div
+                class="pf-v5-c-card"
+                data-ouia-component-id="OUIA-Generated-Card-4"
+                data-ouia-component-type="PF5/Card"
+                data-ouia-safe="true"
+                id=""
+              >
+                <div
+                  class="pf-v5-c-toolbar  ins-c-primary-toolbar"
+                  data-ouia-component-id="PrimaryToolbar"
+                  data-ouia-component-type="PF5/Toolbar"
+                  data-ouia-safe="true"
+                  id="ins-primary-data-toolbar"
+                >
+                  <div
+                    class="pf-v5-c-toolbar__content"
+                  >
+                    <div
+                      class="pf-v5-c-toolbar__content-section"
+                    >
+                      <div
+                        class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
                       >
-                        <span
-                          class="pf-v5-c-menu-toggle__text"
+                        <div
+                          class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
                         >
-                          <span
-                            class="pf-v5-c-icon pf-m-md"
+                          <div
+                            class="pf-v5-l-split ins-c-conditional-filter"
+                          >
+                            <div
+                              class="pf-v5-l-split__item"
+                            >
+                              <button
+                                aria-expanded="false"
+                                aria-label="Conditional filter"
+                                class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
+                                type="button"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__text"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon pf-m-md"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    class="ins-c-conditional-filter__value-selector"
+                                  >
+                                    Name
+                                  </span>
+                                </span>
+                                <span
+                                  class="pf-v5-c-menu-toggle__controls"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-l-split__item pf-m-fill"
+                            >
+                              <span
+                                class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
+                              >
+                                <input
+                                  aria-invalid="false"
+                                  aria-label="text input"
+                                  data-ouia-component-id="ConditionalFilter"
+                                  data-ouia-component-type="PF5/TextInput"
+                                  data-ouia-safe="true"
+                                  placeholder="Filter by name"
+                                  type="text"
+                                  value=""
+                                  widget-type="InsightsInput"
+                                />
+                                <span
+                                  class="pf-v5-c-form-control__utilities"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control__icon"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon pf-m-md ins-c-search-icon"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__item pf-m-spacer-sm"
+                      >
+                        <button
+                          aria-expanded="false"
+                          aria-label="Export"
+                          class="pf-v5-c-menu-toggle pf-m-plain"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 1024 1024"
+                            width="1em"
+                          >
+                            <path
+                              d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
+                      >
+                        <div
+                          class="pf-v5-c-pagination pf-m-compact"
+                          data-ouia-component-id="CompactPagination"
+                          data-ouia-component-type="PF5/Pagination"
+                          data-ouia-safe="true"
+                          id="options-menu-top-pagination"
+                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                        >
+                          <div
+                            class="pf-v5-c-pagination__total-items"
+                          >
+                            <b>
+                              1 - 3
+                            </b>
+                             of 
+                            <b>
+                              3
+                            </b>
+                             
+                          </div>
+                          <div>
+                            <button
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                              id="options-menu-top-toggle"
+                              type="button"
+                            >
+                              <span
+                                class="pf-v5-c-menu-toggle__text"
+                              >
+                                <b>
+                                  1 - 3
+                                </b>
+                                 of 
+                                <b>
+                                  3
+                                </b>
+                                 
+                              </span>
+                              <span
+                                class="pf-v5-c-menu-toggle__controls"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                          <nav
+                            aria-label="Pagination"
+                            class="pf-v5-c-pagination__nav"
+                          >
+                            <div
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to previous page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="previous"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 256 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to next page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="next"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 256 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </nav>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-c-toolbar__content pf-m-hidden"
+                    hidden=""
+                  >
+                    <div
+                      class="pf-v5-c-toolbar__group"
+                    />
+                  </div>
+                </div>
+                <table
+                  aria-label="2909-completed-jobs"
+                  class="pf-v5-c-table pf-m-grid-md"
+                  data-ouia-component-id="2909-completed-jobs-table"
+                  data-ouia-component-type="PF5/Table"
+                  data-ouia-safe="true"
+                  role="grid"
+                >
+                  <thead
+                    class="pf-v5-c-table__thead"
+                  >
+                    <tr
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-7"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <th
+                        class="pf-v5-c-table__th"
+                        data-key="0"
+                        data-label=""
+                        tabindex="-1"
+                      />
+                      <th
+                        aria-sort="none"
+                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
+                        data-key="1"
+                        data-label="System name"
+                        scope="col"
+                        tabindex="-1"
+                      >
+                        <button
+                          class="pf-v5-c-table__button"
+                          type="button"
+                        >
+                          <div
+                            class="pf-v5-c-table__button-content"
                           >
                             <span
-                              class="pf-v5-c-icon__content"
+                              class="pf-v5-c-table__text"
+                            >
+                              System name
+                            </span>
+                            <span
+                              class="pf-v5-c-table__sort-indicator"
                             >
                               <svg
                                 aria-hidden="true"
@@ -291,26 +610,184 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                 fill="currentColor"
                                 height="1em"
                                 role="img"
-                                viewBox="0 0 512 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                 />
                               </svg>
                             </span>
-                          </span>
-                          <span
-                            class="ins-c-conditional-filter__value-selector"
-                          >
-                            Name
-                          </span>
-                        </span>
-                        <span
-                          class="pf-v5-c-menu-toggle__controls"
+                          </div>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
+                        data-key="2"
+                        data-label="Status"
+                        scope="col"
+                        tabindex="-1"
+                      >
+                        <button
+                          class="pf-v5-c-table__button"
+                          type="button"
                         >
-                          <span
-                            class="pf-v5-c-menu-toggle__toggle-icon"
+                          <div
+                            class="pf-v5-c-table__button-content"
+                          >
+                            <span
+                              class="pf-v5-c-table__text"
+                            >
+                              Status
+                            </span>
+                            <span
+                              class="pf-v5-c-table__sort-indicator"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="ascending"
+                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
+                        data-key="3"
+                        data-label="Message"
+                        scope="col"
+                        tabindex="-1"
+                      >
+                        <button
+                          class="pf-v5-c-table__button"
+                          type="button"
+                        >
+                          <div
+                            class="pf-v5-c-table__button-content"
+                          >
+                            <span
+                              class="pf-v5-c-table__text"
+                            >
+                              Message
+                            </span>
+                            <span
+                              class="pf-v5-c-table__sort-indicator"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </button>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="pf-v5-c-table__tbody"
+                    role="rowgroup"
+                  >
+                    <tr
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-13"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <td
+                        class="pf-v5-c-table__td"
+                        data-key="0"
+                        tabindex="-1"
+                      />
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="1"
+                        data-label="System name"
+                        tabindex="-1"
+                      >
+                        <a
+                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          centos7-test-device-1
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="2"
+                        data-label="Status"
+                        tabindex="-1"
+                      >
+                        Success
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="3"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
+                        >
+                          <div
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
+                          >
+                            No inhibtors found, conversion should run smoothly for this system.
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                  <tbody
+                    class="pf-v5-c-table__tbody"
+                    role="rowgroup"
+                  >
+                    <tr
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-14"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <td
+                        class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                        data-key="0"
+                        tabindex="-1"
+                      >
+                        <button
+                          aria-disabled="false"
+                          aria-expanded="false"
+                          aria-label="Details"
+                          aria-labelledby="simple-node1 expandable-toggle1"
+                          class="pf-v5-c-button pf-m-plain"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                          data-ouia-component-type="PF5/Button"
+                          data-ouia-safe="true"
+                          id="expandable-toggle1"
+                          type="button"
+                        >
+                          <div
+                            class="pf-v5-c-table__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -322,2115 +799,1660 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                               width="1em"
                             >
                               <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
                               />
                             </svg>
-                          </span>
-                        </span>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-l-split__item pf-m-fill"
-                    >
-                      <span
-                        class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
+                          </div>
+                        </button>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="1"
+                        data-label="System name"
+                        tabindex="-1"
                       >
-                        <input
-                          aria-invalid="false"
-                          aria-label="text input"
-                          data-ouia-component-id="ConditionalFilter"
-                          data-ouia-component-type="PF5/TextInput"
+                        <a
+                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          centos7-test-device-3
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="2"
+                        data-label="Status"
+                        tabindex="-1"
+                      >
+                        Success
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="3"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
+                        >
+                          <div
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
+                          >
+                            No inhibtors found, conversion should run smoothly for this system.
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                      data-ouia-component-id="OUIA-Generated-TableRow-15"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                      hidden=""
+                    >
+                      <td
+                        class="pf-v5-c-table__td"
+                        colspan="4"
+                        data-key="0"
+                        id="expanded-content2"
+                        tabindex="-1"
+                      >
+                        <div>
+                          <table
+                            class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                            data-ouia-component-id="OUIA-Generated-Table-5"
+                            data-ouia-component-type="PF5/Table"
+                            data-ouia-safe="true"
+                            role="grid"
+                            style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                          >
+                            <tbody
+                              class="pf-v5-c-table__tbody"
+                              role="rowgroup"
+                            >
+                              <tr
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-16"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node0 expand-toggle0"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle0"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-danger"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(163, 0, 0);"
+                                    >
+                                      <strong>
+                                        Third party packages detected
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-17"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-red pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          Inhibitor
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    Third party packages detected
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        Third party packages will not be replaced during the conversion.
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Diagnosis
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span>
+                                            Only packages signed by CentOS Linux are to be replaced. Red Hat support won't be provided for the following third party packages:convert2rhel-1.5.0-2.20231124114206033039.main.14.g938833b.el7.noarch
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Remediation
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            If you wish to ignore this message, set the environment variable 'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' to 1.
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        LIST_THIRD_PARTY_PACKAGES::THIRD_PARTY_PACKAGE_DETECTED
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-18"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node1 expand-toggle1"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle1"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-warning"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 576 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(121, 80, 0);"
+                                    >
+                                      <strong>
+                                        Dbus is running check skip
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-19"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 576 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          Warning
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    Dbus is running check skip
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        Skipping the check because we have been asked not to subscribe this system to RHSM
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        DBUS_IS_RUNNING::SECURE_BOOT_DETECTED
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-20"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node2 expand-toggle2"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle2"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-info"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(0, 41, 82);"
+                                    >
+                                      <strong>
+                                        Repository file package removal
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-21"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-blue pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          Info
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    Repository file package removal
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                  <tbody
+                    class="pf-v5-c-table__tbody"
+                    role="rowgroup"
+                  >
+                    <tr
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-22"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <td
+                        class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                        data-key="0"
+                        tabindex="-1"
+                      >
+                        <button
+                          aria-disabled="false"
+                          aria-expanded="false"
+                          aria-label="Details"
+                          aria-labelledby="simple-node3 expandable-toggle3"
+                          class="pf-v5-c-button pf-m-plain"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                          data-ouia-component-type="PF5/Button"
                           data-ouia-safe="true"
-                          placeholder="Filter by name"
-                          type="text"
-                          value=""
-                          widget-type="InsightsInput"
-                        />
-                        <span
-                          class="pf-v5-c-form-control__utilities"
+                          id="expandable-toggle3"
+                          type="button"
                         >
-                          <span
-                            class="pf-v5-c-form-control__icon"
-                          >
-                            <span
-                              class="pf-v5-c-icon pf-m-md ins-c-search-icon"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="pf-v5-c-toolbar__item pf-m-spacer-sm"
-              >
-                <button
-                  aria-expanded="false"
-                  aria-label="Export"
-                  class="pf-v5-c-menu-toggle pf-m-plain"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v5-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 1024 1024"
-                    width="1em"
-                  >
-                    <path
-                      d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <div
-                class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
-              >
-                <div
-                  class="pf-v5-c-pagination pf-m-compact"
-                  data-ouia-component-id="CompactPagination"
-                  data-ouia-component-type="PF5/Pagination"
-                  data-ouia-safe="true"
-                  id="options-menu-top-pagination"
-                  style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-                >
-                  <div
-                    class="pf-v5-c-pagination__total-items"
-                  >
-                    <b>
-                      1 - 3
-                    </b>
-                     of 
-                    <b>
-                      3
-                    </b>
-                     
-                  </div>
-                  <div>
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                      id="options-menu-top-toggle"
-                      type="button"
-                    >
-                      <span
-                        class="pf-v5-c-menu-toggle__text"
-                      >
-                        <b>
-                          1 - 3
-                        </b>
-                         of 
-                        <b>
-                          3
-                        </b>
-                         
-                      </span>
-                      <span
-                        class="pf-v5-c-menu-toggle__controls"
-                      >
-                        <span
-                          class="pf-v5-c-menu-toggle__toggle-icon"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 320 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </button>
-                  </div>
-                  <nav
-                    aria-label="Pagination"
-                    class="pf-v5-c-pagination__nav"
-                  >
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to previous page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="previous"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-7"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to next page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="next"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-8"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </nav>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="pf-v5-c-toolbar__content pf-m-hidden"
-            hidden=""
-          >
-            <div
-              class="pf-v5-c-toolbar__group"
-            />
-          </div>
-        </div>
-        <table
-          aria-label="2909-completed-jobs"
-          class="pf-v5-c-table pf-m-grid-md"
-          data-ouia-component-id="2909-completed-jobs-table"
-          data-ouia-component-type="PF5/Table"
-          data-ouia-safe="true"
-          role="grid"
-        >
-          <thead
-            class="pf-v5-c-table__thead"
-          >
-            <tr
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-7"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <th
-                class="pf-v5-c-table__th"
-                data-key="0"
-                data-label=""
-                tabindex="-1"
-              />
-              <th
-                aria-sort="none"
-                class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
-                data-key="1"
-                data-label="System name"
-                scope="col"
-                tabindex="-1"
-              >
-                <button
-                  class="pf-v5-c-table__button"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__button-content"
-                  >
-                    <span
-                      class="pf-v5-c-table__text"
-                    >
-                      System name
-                    </span>
-                    <span
-                      class="pf-v5-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
-              </th>
-              <th
-                aria-sort="none"
-                class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
-                data-key="2"
-                data-label="Status"
-                scope="col"
-                tabindex="-1"
-              >
-                <button
-                  class="pf-v5-c-table__button"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__button-content"
-                  >
-                    <span
-                      class="pf-v5-c-table__text"
-                    >
-                      Status
-                    </span>
-                    <span
-                      class="pf-v5-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
-              </th>
-              <th
-                aria-sort="ascending"
-                class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
-                data-key="3"
-                data-label="Message"
-                scope="col"
-                tabindex="-1"
-              >
-                <button
-                  class="pf-v5-c-table__button"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__button-content"
-                  >
-                    <span
-                      class="pf-v5-c-table__text"
-                    >
-                      Message
-                    </span>
-                    <span
-                      class="pf-v5-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            class="pf-v5-c-table__tbody"
-            role="rowgroup"
-          >
-            <tr
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-13"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td"
-                data-key="0"
-                tabindex="-1"
-              />
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="1"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  centos7-test-device-1
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="2"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Success
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="3"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  >
-                    No inhibtors found, conversion should run smoothly for this system.
-                  </div>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-          <tbody
-            class="pf-v5-c-table__tbody"
-            role="rowgroup"
-          >
-            <tr
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-14"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                data-key="0"
-                tabindex="-1"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-expanded="false"
-                  aria-label="Details"
-                  aria-labelledby="simple-node1 expandable-toggle1"
-                  class="pf-v5-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-9"
-                  data-ouia-component-type="PF5/Button"
-                  data-ouia-safe="true"
-                  id="expandable-toggle1"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__toggle-icon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="pf-v5-svg"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                      />
-                    </svg>
-                  </div>
-                </button>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="1"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  centos7-test-device-3
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="2"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Success
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="3"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  >
-                    No inhibtors found, conversion should run smoothly for this system.
-                  </div>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-              data-ouia-component-id="OUIA-Generated-TableRow-15"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-              hidden=""
-            >
-              <td
-                class="pf-v5-c-table__td"
-                colspan="4"
-                data-key="0"
-                id="expanded-content2"
-                tabindex="-1"
-              >
-                <div>
-                  <table
-                    class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                    data-ouia-component-id="OUIA-Generated-Table-5"
-                    data-ouia-component-type="PF5/Table"
-                    data-ouia-safe="true"
-                    role="grid"
-                    style="margin-bottom: 30px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                  >
-                    <tbody
-                      class="pf-v5-c-table__tbody"
-                      role="rowgroup"
-                    >
-                      <tr
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-16"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node0 expand-toggle0"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-10"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle0"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(163, 0, 0);"
-                            >
-                              <strong>
-                                Third party packages detected
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-17"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-red pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 512 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  Inhibitor
-                                </span>
-                              </span>
-                            </span>
-                          </div>
                           <div
-                            class="entry-title"
+                            class="pf-v5-c-table__toggle-icon"
                           >
-                            Third party packages detected
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                              />
+                            </svg>
                           </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                        </button>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="1"
+                        data-label="System name"
+                        tabindex="-1"
+                      >
+                        <a
+                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc53bee"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          centos7-test-device-2
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="2"
+                        data-label="Status"
+                        tabindex="-1"
+                      >
+                        Success
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="3"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
+                        >
+                          <div
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
+                          >
+                            Your system has 3 inhibitors out of 3 potential problems.
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                      data-ouia-component-id="OUIA-Generated-TableRow-23"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                      hidden=""
+                    >
+                      <td
+                        class="pf-v5-c-table__td"
+                        colspan="4"
+                        data-key="0"
+                        id="expanded-content4"
+                        tabindex="-1"
+                      >
+                        <div>
+                          <table
+                            class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                            data-ouia-component-id="OUIA-Generated-Table-6"
+                            data-ouia-component-type="PF5/Table"
+                            data-ouia-safe="true"
+                            role="grid"
+                            style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                          >
+                            <tbody
+                              class="pf-v5-c-table__tbody"
+                              role="rowgroup"
                             >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                              <tr
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-24"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
                               >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                Third party packages will not be replaced during the conversion.
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Diagnosis
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node0 expand-toggle0"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle0"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
                                   <span>
-                                    Only packages signed by CentOS Linux are to be replaced. Red Hat support won't be provided for the following third party packages:convert2rhel-1.5.0-2.20231124114206033039.main.14.g938833b.el7.noarch
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-danger"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(163, 0, 0);"
+                                    >
+                                      <strong>
+                                        The version of the loaded kernel is different from the latest version
+                                      </strong>
+                                    </span>
                                   </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                </td>
+                              </tr>
+                              <tr
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-25"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
                               >
-                                Remediation
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span
-                                    class="remediations-font-family"
-                                  >
-                                    If you wish to ignore this message, set the environment variable 'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' to 1.
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                LIST_THIRD_PARTY_PACKAGES::THIRD_PARTY_PACKAGE_DETECTED
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-18"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node1 expand-toggle1"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-11"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle1"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
                                 />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-warning"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 576 512"
-                                  width="1em"
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
                                 >
-                                  <path
-                                    d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(121, 80, 0);"
-                            >
-                              <strong>
-                                Dbus is running check skip
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-19"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-orange pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 576 512"
-                                    width="1em"
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-red pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          Inhibitor
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
                                   >
-                                    <path
-                                      d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  Warning
-                                </span>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="entry-title"
-                          >
-                            Dbus is running check skip
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                Skipping the check because we have been asked not to subscribe this system to RHSM
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                DBUS_IS_RUNNING::SECURE_BOOT_DETECTED
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-20"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node2 expand-toggle2"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-12"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle2"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-info"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(0, 41, 82);"
-                            >
-                              <strong>
-                                Repository file package removal
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-21"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-blue pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 512 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  Info
-                                </span>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="entry-title"
-                          >
-                            Repository file package removal
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-          <tbody
-            class="pf-v5-c-table__tbody"
-            role="rowgroup"
-          >
-            <tr
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-22"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                data-key="0"
-                tabindex="-1"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-expanded="false"
-                  aria-label="Details"
-                  aria-labelledby="simple-node3 expandable-toggle3"
-                  class="pf-v5-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-13"
-                  data-ouia-component-type="PF5/Button"
-                  data-ouia-safe="true"
-                  id="expandable-toggle3"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__toggle-icon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="pf-v5-svg"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                      />
-                    </svg>
-                  </div>
-                </button>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="1"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc53bee"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  centos7-test-device-2
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="2"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Success
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="3"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  >
-                    Your system has 3 inhibitors out of 3 potential problems.
-                  </div>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-              data-ouia-component-id="OUIA-Generated-TableRow-23"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-              hidden=""
-            >
-              <td
-                class="pf-v5-c-table__td"
-                colspan="4"
-                data-key="0"
-                id="expanded-content4"
-                tabindex="-1"
-              >
-                <div>
-                  <table
-                    class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                    data-ouia-component-id="OUIA-Generated-Table-6"
-                    data-ouia-component-type="PF5/Table"
-                    data-ouia-safe="true"
-                    role="grid"
-                    style="margin-bottom: 30px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                  >
-                    <tbody
-                      class="pf-v5-c-table__tbody"
-                      role="rowgroup"
-                    >
-                      <tr
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-24"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node0 expand-toggle0"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-14"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle0"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(163, 0, 0);"
-                            >
-                              <strong>
-                                The version of the loaded kernel is different from the latest version
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-25"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-red pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 512 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  Inhibitor
-                                </span>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="entry-title"
-                          >
-                            The version of the loaded kernel is different from the latest version
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                The version of the loaded kernel is different from the latest version in the enabled system repositories.
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Diagnosis
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span>
-                                    Latest kernel version available in updates: 3.10.0-1160.90.1.el7
+                                    The version of the loaded kernel is different from the latest version
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        The version of the loaded kernel is different from the latest version in the enabled system repositories.
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Diagnosis
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span>
+                                            Latest kernel version available in updates: 3.10.0-1160.90.1.el7
  Loaded kernel version: 3.10.0-1160.88.1.el7
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Remediation
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span
-                                    class="remediations-font-family"
-                                  >
-                                    [hint] To proceed with the conversion, update the kernel version by executing the following steps:
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Remediation
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            [hint] To proceed with the conversion, update the kernel version by executing the following steps:
 
 1. yum install kernel-3.10.0-1160.90.1.el7 -y
 2. reboot
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        IS_LOADED_KERNEL_LATEST::INVALID_KERNEL_VERSION
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-26"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
                               >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                IS_LOADED_KERNEL_LATEST::INVALID_KERNEL_VERSION
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-26"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node1 expand-toggle1"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-15"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle1"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
                                 >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(163, 0, 0);"
-                            >
-                              <strong>
-                                Secure boot detected
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-27"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-red pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 512 512"
-                                    width="1em"
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node1 expand-toggle1"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle1"
+                                    type="button"
                                   >
-                                    <path
-                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
                                 >
-                                  Inhibitor
-                                </span>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="entry-title"
-                          >
-                            Secure boot detected
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                The conversion with secure boot is currently not possible.
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Diagnosis
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
                                   <span>
-                                    In order to continue the conversion, secure boot must be disabled
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-danger"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(163, 0, 0);"
+                                    >
+                                      <strong>
+                                        Secure boot detected
+                                      </strong>
+                                    </span>
                                   </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                </td>
+                              </tr>
+                              <tr
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-27"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
                               >
-                                Remediation
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span
-                                    class="remediations-font-family"
-                                  >
-                                    [hint] To disable the secure boot, follow the instructions available in this article: https://access.redhat.com/solutions/6753681
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                EFI::SECURE_BOOT_DETECTED
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-28"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node2 expand-toggle2"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-16"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle2"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
                                 />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
                                 >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(163, 0, 0);"
-                            >
-                              <strong>
-                                Package up to date check fail
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-29"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-red pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 512 512"
-                                    width="1em"
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-red pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          Inhibitor
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
                                   >
-                                    <path
-                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
+                                    Secure boot detected
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        The conversion with secure boot is currently not possible.
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Diagnosis
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span>
+                                            In order to continue the conversion, secure boot must be disabled
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Remediation
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            [hint] To disable the secure boot, follow the instructions available in this article: https://access.redhat.com/solutions/6753681
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        EFI::SECURE_BOOT_DETECTED
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-28"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
                                 >
-                                  Inhibitor
-                                </span>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="entry-title"
-                          >
-                            Package up to date check fail
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                The conversion with secure boot is currently not possible.
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Diagnosis
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node2 expand-toggle2"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle2"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
                                   <span>
-                                    There was an error while checking whether the installed packages are up-to-date. Having an updated system is an important prerequisite for a successful conversion.
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-danger"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(163, 0, 0);"
+                                    >
+                                      <strong>
+                                        Package up to date check fail
+                                      </strong>
+                                    </span>
                                   </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                </td>
+                              </tr>
+                              <tr
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-29"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
                               >
-                                Remediation
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span
-                                    class="remediations-font-family"
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-red pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          Inhibitor
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
                                   >
-                                    [hint] Consider verifyng the system is up to date manually before proceeding with the conversion.
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                PACKAGE_UPDATES::PACKAGE_UP_TO_DATE_CHECK_FAIL
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <div
-          class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
-          data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-2"
-          data-ouia-component-type="RHI/TableToolbar"
-          data-ouia-safe="true"
-          id="pf-random-id-1"
-        >
-          <div
-            class="pf-v5-c-toolbar__content"
-          >
-            <div
-              class="pf-v5-c-toolbar__content-section"
-            >
-              <div
-                class="pf-v5-c-toolbar__item pf-m-align-self-center"
-              >
-                <div>
-                  <div
-                    style="display: contents;"
-                  >
-                    <div
-                      class="pf-v5-c-content"
-                    >
-                      <small
-                        class=""
-                        data-ouia-component-id="OUIA-Generated-Text-4"
-                        data-ouia-component-type="PF5/Text"
-                        data-ouia-safe="true"
-                        data-pf-content="true"
-                      >
-                        Last updated: All jobs completed
-                      </small>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
-              >
+                                    Package up to date check fail
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        The conversion with secure boot is currently not possible.
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Diagnosis
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span>
+                                            There was an error while checking whether the installed packages are up-to-date. Having an updated system is an important prerequisite for a successful conversion.
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Remediation
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            [hint] Consider verifyng the system is up to date manually before proceeding with the conversion.
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        PACKAGE_UPDATES::PACKAGE_UP_TO_DATE_CHECK_FAIL
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
                 <div
-                  class="pf-v5-c-pagination pf-m-bottom"
-                  data-ouia-component-id="OUIA-Generated-Pagination-bottom-2"
-                  data-ouia-component-type="PF5/Pagination"
+                  class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
+                  data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-2"
+                  data-ouia-component-type="RHI/TableToolbar"
                   data-ouia-safe="true"
-                  id="options-menu-bottom-pagination"
-                  style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                  id="pf-random-id-3"
                 >
-                  <div>
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                      id="options-menu-bottom-toggle"
-                      type="button"
-                    >
-                      <span
-                        class="pf-v5-c-menu-toggle__text"
-                      >
-                        <b>
-                          1 - 3
-                        </b>
-                         of 
-                        <b>
-                          3
-                        </b>
-                         
-                      </span>
-                      <span
-                        class="pf-v5-c-menu-toggle__controls"
-                      >
-                        <span
-                          class="pf-v5-c-menu-toggle__toggle-icon"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 320 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </button>
-                  </div>
-                  <nav
-                    aria-label="Pagination"
-                    class="pf-v5-c-pagination__nav"
+                  <div
+                    class="pf-v5-c-toolbar__content"
                   >
                     <div
-                      class="pf-v5-c-pagination__nav-control pf-m-first"
+                      class="pf-v5-c-toolbar__content-section"
                     >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to first page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="first"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-17"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
+                      <div
+                        class="pf-v5-c-toolbar__item pf-m-align-self-center"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 448 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to previous page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="previous"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-18"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
+                        <div>
+                          <div
+                            style="display: contents;"
+                          >
+                            <div
+                              class="pf-v5-c-content"
+                            >
+                              <small
+                                class=""
+                                data-ouia-component-id="OUIA-Generated-Text-4"
+                                data-ouia-component-type="PF5/Text"
+                                data-ouia-safe="true"
+                                data-pf-content="true"
+                              >
+                                Last updated: All jobs completed
+                              </small>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-page-select"
-                    >
-                      <span
-                        class="pf-v5-c-form-control pf-m-disabled"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-label="Current page"
-                          data-ouia-component-id="OUIA-Generated-TextInputBase-4"
-                          data-ouia-component-type="PF5/TextInput"
+                        <div
+                          class="pf-v5-c-pagination pf-m-bottom"
+                          data-ouia-component-id="OUIA-Generated-Pagination-bottom-2"
+                          data-ouia-component-type="PF5/Pagination"
                           data-ouia-safe="true"
-                          disabled=""
-                          max="1"
-                          min="1"
-                          type="number"
-                          value="1"
-                        />
-                      </span>
-                      <span
-                        aria-hidden="true"
-                      >
-                        of 1
-                      </span>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to next page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="next"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-19"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
+                          id="options-menu-bottom-pagination"
+                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                         >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </button>
+                          <div>
+                            <button
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                              id="options-menu-bottom-toggle"
+                              type="button"
+                            >
+                              <span
+                                class="pf-v5-c-menu-toggle__text"
+                              >
+                                <b>
+                                  1 - 3
+                                </b>
+                                 of 
+                                <b>
+                                  3
+                                </b>
+                                 
+                              </span>
+                              <span
+                                class="pf-v5-c-menu-toggle__controls"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                          <nav
+                            aria-label="Pagination"
+                            class="pf-v5-c-pagination__nav"
+                          >
+                            <div
+                              class="pf-v5-c-pagination__nav-control pf-m-first"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to first page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="first"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-17"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 448 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to previous page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="previous"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 256 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-page-select"
+                            >
+                              <span
+                                class="pf-v5-c-form-control pf-m-disabled"
+                              >
+                                <input
+                                  aria-invalid="false"
+                                  aria-label="Current page"
+                                  data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+                                  data-ouia-component-type="PF5/TextInput"
+                                  data-ouia-safe="true"
+                                  disabled=""
+                                  max="1"
+                                  min="1"
+                                  type="number"
+                                  value="1"
+                                />
+                              </span>
+                              <span
+                                aria-hidden="true"
+                              >
+                                of 1
+                              </span>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to next page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="next"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-19"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 256 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-control pf-m-last"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to last page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="last"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-20"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 448 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </nav>
+                        </div>
+                      </div>
                     </div>
+                  </div>
+                  <div
+                    class="pf-v5-c-toolbar__content pf-m-hidden"
+                    hidden=""
+                  >
                     <div
-                      class="pf-v5-c-pagination__nav-control pf-m-last"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to last page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="last"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-20"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 448 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </nav>
+                      class="pf-v5-c-toolbar__group"
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-          </div>
-          <div
-            class="pf-v5-c-toolbar__content pf-m-hidden"
-            hidden=""
-          >
-            <div
-              class="pf-v5-c-toolbar__group"
-            />
+            </section>
           </div>
         </div>
+        <div
+          class="pf-v5-c-drawer__panel pf-m-resizable"
+          hidden=""
+          id="end-resize-panel"
+          style="--pf-v5-c-drawer__panel--md--FlexBasis: 1000px; --pf-v5-c-drawer__panel--md--FlexBasis--min: 500px;"
+        />
       </div>
-    </section>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -2438,588 +2460,48 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
 exports[`CompletedTaskDetails should render correctly completed 1`] = `
 <DocumentFragment>
   <div>
-    <section
-      class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
-      widget-type="InsightsPageHeader"
+    <div
+      class="pf-v5-c-drawer"
     >
-      <nav
-        aria-label="Breadcrumb"
-        class="pf-v5-c-breadcrumb"
-        data-ouia-component-id="completed-tasks-details-breadcrumb"
-        data-ouia-component-type="PF5/Breadcrumb"
-        data-ouia-safe="true"
-      >
-        <ol
-          class="pf-v5-c-breadcrumb__list"
-          role="list"
-        >
-          <li
-            class="pf-v5-c-breadcrumb__item"
-          >
-            <a
-              class="pf-v5-c-breadcrumb__link"
-              href="/insights/tasks/executed"
-            >
-              Tasks
-            </a>
-          </li>
-          <li
-            class="pf-v5-c-breadcrumb__item"
-          >
-            <span
-              class="pf-v5-c-breadcrumb__item-divider"
-            >
-              <svg
-                aria-hidden="true"
-                class="pf-v5-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 256 512"
-                width="1em"
-              >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </span>
-            log4j task
-          </li>
-        </ol>
-      </nav>
       <div
-        class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
+        class="pf-v5-c-drawer__main"
       >
         <div
-          class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
+          class="pf-v5-c-drawer__content"
         >
           <div
-            class=""
+            class="pf-v5-c-drawer__body"
           >
-            <h1
-              class="pf-v5-c-title pf-m-2xl"
-              data-ouia-component-id="OUIA-Generated-Title-1"
-              data-ouia-component-type="PF5/Title"
-              data-ouia-safe="true"
-              widget-type="InsightsPageHeaderTitle"
+            <section
+              class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+              widget-type="InsightsPageHeader"
             >
-              log4j task
-            </h1>
-            <div
-              class="pf-v5-c-content"
-            >
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-1"
-                data-ouia-component-type="PF5/Text"
+              <nav
+                aria-label="Breadcrumb"
+                class="pf-v5-c-breadcrumb"
+                data-ouia-component-id="completed-tasks-details-breadcrumb"
+                data-ouia-component-type="PF5/Breadcrumb"
                 data-ouia-safe="true"
-                data-pf-content="true"
               >
-                Log4J Detection
-              </small>
-            </div>
-          </div>
-          <div
-            class=""
-          >
-            <p>
-              Uses the insights-client to determine if systems are affected by the LogShell vulnerability. Resource intensive scan
-            </p>
-          </div>
-        </div>
-        <div
-          class="pf-v5-l-flex"
-        >
-          <div
-            class=""
-          >
-            <button
-              aria-disabled="false"
-              aria-label="log4j-run-task-button"
-              class="pf-v5-c-button pf-m-secondary"
-              data-ouia-component-id="OUIA-Generated-Button-secondary-1"
-              data-ouia-component-type="PF5/Button"
-              data-ouia-safe="true"
-              type="button"
-            >
-              Run task again
-            </button>
-          </div>
-        </div>
-        <div
-          class="pf-v5-l-flex"
-        >
-          <div
-            class=""
-          >
-            <button
-              aria-expanded="false"
-              aria-label="Task details menu toggle"
-              class="pf-v5-c-menu-toggle pf-m-plain"
-              id="executed-task-kebab"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="pf-v5-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 192 512"
-                width="1em"
-              >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section
-      class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
-    >
-      <div
-        class="pf-v5-c-card"
-        data-ouia-component-id="OUIA-Generated-Card-1"
-        data-ouia-component-type="PF5/Card"
-        data-ouia-safe="true"
-        id=""
-      >
-        <div
-          class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
-        >
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Systems
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              3
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Run start
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              21 Apr 2022, 10:10 UTC
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Run end
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              25 Apr 2022, 10:10 UTC (5760 min)
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Initiated by
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              UserX
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Systems with alerts
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              2
-            </div>
-          </div>
-        </div>
-      </div>
-      <br />
-      <div
-        class="pf-v5-c-card"
-        data-ouia-component-id="OUIA-Generated-Card-2"
-        data-ouia-component-type="PF5/Card"
-        data-ouia-safe="true"
-        id=""
-      >
-        <div
-          class="pf-v5-c-toolbar  ins-c-primary-toolbar"
-          data-ouia-component-id="PrimaryToolbar"
-          data-ouia-component-type="PF5/Toolbar"
-          data-ouia-safe="true"
-          id="ins-primary-data-toolbar"
-        >
-          <div
-            class="pf-v5-c-toolbar__content"
-          >
-            <div
-              class="pf-v5-c-toolbar__content-section"
-            >
-              <div
-                class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
-              >
-                <div
-                  class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                <ol
+                  class="pf-v5-c-breadcrumb__list"
+                  role="list"
                 >
-                  <div
-                    class="pf-v5-l-split ins-c-conditional-filter"
+                  <li
+                    class="pf-v5-c-breadcrumb__item"
                   >
-                    <div
-                      class="pf-v5-l-split__item"
+                    <a
+                      class="pf-v5-c-breadcrumb__link"
+                      href="/insights/tasks/executed"
                     >
-                      <button
-                        aria-expanded="false"
-                        aria-label="Conditional filter"
-                        class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
-                        type="button"
-                      >
-                        <span
-                          class="pf-v5-c-menu-toggle__text"
-                        >
-                          <span
-                            class="pf-v5-c-icon pf-m-md"
-                          >
-                            <span
-                              class="pf-v5-c-icon__content"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 512 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
-                                />
-                              </svg>
-                            </span>
-                          </span>
-                          <span
-                            class="ins-c-conditional-filter__value-selector"
-                          >
-                            Name
-                          </span>
-                        </span>
-                        <span
-                          class="pf-v5-c-menu-toggle__controls"
-                        >
-                          <span
-                            class="pf-v5-c-menu-toggle__toggle-icon"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="pf-v5-svg"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 320 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              />
-                            </svg>
-                          </span>
-                        </span>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-l-split__item pf-m-fill"
-                    >
-                      <span
-                        class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-label="text input"
-                          data-ouia-component-id="ConditionalFilter"
-                          data-ouia-component-type="PF5/TextInput"
-                          data-ouia-safe="true"
-                          placeholder="Filter by name"
-                          type="text"
-                          value=""
-                          widget-type="InsightsInput"
-                        />
-                        <span
-                          class="pf-v5-c-form-control__utilities"
-                        >
-                          <span
-                            class="pf-v5-c-form-control__icon"
-                          >
-                            <span
-                              class="pf-v5-c-icon pf-m-md ins-c-search-icon"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="pf-v5-c-toolbar__item pf-m-spacer-sm"
-              >
-                <button
-                  aria-expanded="false"
-                  aria-label="Export"
-                  class="pf-v5-c-menu-toggle pf-m-plain"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v5-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 1024 1024"
-                    width="1em"
-                  >
-                    <path
-                      d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <div
-                class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
-              >
-                <div
-                  class="pf-v5-c-pagination pf-m-compact"
-                  data-ouia-component-id="CompactPagination"
-                  data-ouia-component-type="PF5/Pagination"
-                  data-ouia-safe="true"
-                  id="options-menu-top-pagination"
-                  style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-                >
-                  <div
-                    class="pf-v5-c-pagination__total-items"
-                  >
-                    <b>
-                      1 - 3
-                    </b>
-                     of 
-                    <b>
-                      3
-                    </b>
-                     
-                  </div>
-                  <div>
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                      id="options-menu-top-toggle"
-                      type="button"
-                    >
-                      <span
-                        class="pf-v5-c-menu-toggle__text"
-                      >
-                        <b>
-                          1 - 3
-                        </b>
-                         of 
-                        <b>
-                          3
-                        </b>
-                         
-                      </span>
-                      <span
-                        class="pf-v5-c-menu-toggle__controls"
-                      >
-                        <span
-                          class="pf-v5-c-menu-toggle__toggle-icon"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 320 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </button>
-                  </div>
-                  <nav
-                    aria-label="Pagination"
-                    class="pf-v5-c-pagination__nav"
-                  >
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to previous page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="previous"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to next page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="next"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </nav>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="pf-v5-c-toolbar__content pf-m-hidden"
-            hidden=""
-          >
-            <div
-              class="pf-v5-c-toolbar__group"
-            />
-          </div>
-        </div>
-        <table
-          aria-label="42-completed-jobs"
-          class="pf-v5-c-table pf-m-grid-md"
-          data-ouia-component-id="42-completed-jobs-table"
-          data-ouia-component-type="PF5/Table"
-          data-ouia-safe="true"
-          role="grid"
-        >
-          <thead
-            class="pf-v5-c-table__thead"
-          >
-            <tr
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-1"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <th
-                aria-sort="none"
-                class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
-                data-key="0"
-                data-label="System name"
-                scope="col"
-                tabindex="-1"
-              >
-                <button
-                  class="pf-v5-c-table__button"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__button-content"
+                      Tasks
+                    </a>
+                  </li>
+                  <li
+                    class="pf-v5-c-breadcrumb__item"
                   >
                     <span
-                      class="pf-v5-c-table__text"
-                    >
-                      System name
-                    </span>
-                    <span
-                      class="pf-v5-c-table__sort-indicator"
+                      class="pf-v5-c-breadcrumb__item-divider"
                     >
                       <svg
                         aria-hidden="true"
@@ -3031,383 +2513,350 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                         width="1em"
                       >
                         <path
-                          d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
                         />
                       </svg>
                     </span>
-                  </div>
-                </button>
-              </th>
-              <th
-                aria-sort="none"
-                class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
-                data-key="1"
-                data-label="Status"
-                scope="col"
-                tabindex="-1"
-              >
-                <button
-                  class="pf-v5-c-table__button"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__button-content"
-                  >
-                    <span
-                      class="pf-v5-c-table__text"
-                    >
-                      Status
-                    </span>
-                    <span
-                      class="pf-v5-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
-              </th>
-              <th
-                aria-sort="none"
-                class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-35"
-                data-key="2"
-                data-label="Message"
-                scope="col"
-                tabindex="-1"
-              >
-                <button
-                  class="pf-v5-c-table__button"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__button-content"
-                  >
-                    <span
-                      class="pf-v5-c-table__text"
-                    >
-                      Message
-                    </span>
-                    <span
-                      class="pf-v5-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            class="pf-v5-c-table__tbody"
-            role="rowgroup"
-          >
-            <tr
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-2"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="0"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  dl-test-device-2
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="1"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Success
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="2"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  >
-                    This was a success.
-                  </div>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-3"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="0"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/3262b268-23ed-4c5a-a918-d8c4923fdfbf"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  MG-test-device
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="1"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Failure
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="2"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 8px;"
-                  >
-                    <span
-                      class="pf-v5-c-icon"
-                    >
-                      <span
-                        class="pf-v5-c-icon__content pf-m-danger"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 512 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 16px;"
-                  >
-                    <span
-                      style="color: rgb(201, 25, 11);"
-                    >
-                      Alert
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  >
-                    Task failed to complete for an unknown reason. Retry this task at a later time.
-                  </div>
-                </div>
-              </td>
-            </tr>
-            <tr
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-4"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="0"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/42438801-c384-491a-943b-f5f621f0c882"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  YL-test-device-85
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="1"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Timeout
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="2"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 8px;"
-                  >
-                    <span
-                      class="pf-v5-c-icon"
-                    >
-                      <span
-                        class="pf-v5-c-icon__content pf-m-danger"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 512 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 16px;"
-                  >
-                    <span
-                      style="color: rgb(201, 25, 11);"
-                    >
-                      Alert
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  >
-                    Task failed to complete due to timing out. Retry this task at a later time.
-                  </div>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <div
-          class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
-          data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
-          data-ouia-component-type="RHI/TableToolbar"
-          data-ouia-safe="true"
-          id="pf-random-id-0"
-        >
-          <div
-            class="pf-v5-c-toolbar__content"
-          >
-            <div
-              class="pf-v5-c-toolbar__content-section"
-            >
+                    log4j task
+                  </li>
+                </ol>
+              </nav>
               <div
-                class="pf-v5-c-toolbar__item pf-m-align-self-center"
+                class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
               >
-                <div>
+                <div
+                  class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
+                >
                   <div
-                    style="display: contents;"
+                    class=""
                   >
+                    <h1
+                      class="pf-v5-c-title pf-m-2xl"
+                      data-ouia-component-id="OUIA-Generated-Title-1"
+                      data-ouia-component-type="PF5/Title"
+                      data-ouia-safe="true"
+                      widget-type="InsightsPageHeaderTitle"
+                    >
+                      log4j task
+                    </h1>
                     <div
                       class="pf-v5-c-content"
                     >
                       <small
                         class=""
-                        data-ouia-component-id="OUIA-Generated-Text-2"
+                        data-ouia-component-id="OUIA-Generated-Text-1"
                         data-ouia-component-type="PF5/Text"
                         data-ouia-safe="true"
                         data-pf-content="true"
                       >
-                        Last updated: All jobs completed
+                        Log4J Detection
                       </small>
+                    </div>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    <p>
+                      Uses the insights-client to determine if systems are affected by the LogShell vulnerability. Resource intensive scan
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex"
+                >
+                  <div
+                    class=""
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="log4j-run-task-button"
+                      class="pf-v5-c-button pf-m-secondary"
+                      data-ouia-component-id="OUIA-Generated-Button-secondary-1"
+                      data-ouia-component-type="PF5/Button"
+                      data-ouia-safe="true"
+                      type="button"
+                    >
+                      Run task again
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex"
+                >
+                  <div
+                    class=""
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-label="Task details menu toggle"
+                      class="pf-v5-c-menu-toggle pf-m-plain"
+                      id="executed-task-kebab"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 192 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section
+              class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
+            >
+              <div
+                class="pf-v5-c-card"
+                data-ouia-component-id="OUIA-Generated-Card-1"
+                data-ouia-component-type="PF5/Card"
+                data-ouia-safe="true"
+                id=""
+              >
+                <div
+                  class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
+                >
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Systems
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      3
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Run start
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      21 Apr 2022, 10:10 UTC
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Run end
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      25 Apr 2022, 10:10 UTC (5760 min)
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Initiated by
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      UserX
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Systems with alerts
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      2
                     </div>
                   </div>
                 </div>
               </div>
+              <br />
               <div
-                class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
+                class="pf-v5-c-card"
+                data-ouia-component-id="OUIA-Generated-Card-2"
+                data-ouia-component-type="PF5/Card"
+                data-ouia-safe="true"
+                id=""
               >
                 <div
-                  class="pf-v5-c-pagination pf-m-bottom"
-                  data-ouia-component-id="OUIA-Generated-Pagination-bottom-1"
-                  data-ouia-component-type="PF5/Pagination"
+                  class="pf-v5-c-toolbar  ins-c-primary-toolbar"
+                  data-ouia-component-id="PrimaryToolbar"
+                  data-ouia-component-type="PF5/Toolbar"
                   data-ouia-safe="true"
-                  id="options-menu-bottom-pagination"
-                  style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                  id="ins-primary-data-toolbar"
                 >
-                  <div>
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                      id="options-menu-bottom-toggle"
-                      type="button"
+                  <div
+                    class="pf-v5-c-toolbar__content"
+                  >
+                    <div
+                      class="pf-v5-c-toolbar__content-section"
                     >
-                      <span
-                        class="pf-v5-c-menu-toggle__text"
+                      <div
+                        class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
                       >
-                        <b>
-                          1 - 3
-                        </b>
-                         of 
-                        <b>
-                          3
-                        </b>
-                         
-                      </span>
-                      <span
-                        class="pf-v5-c-menu-toggle__controls"
+                        <div
+                          class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                        >
+                          <div
+                            class="pf-v5-l-split ins-c-conditional-filter"
+                          >
+                            <div
+                              class="pf-v5-l-split__item"
+                            >
+                              <button
+                                aria-expanded="false"
+                                aria-label="Conditional filter"
+                                class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
+                                type="button"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__text"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon pf-m-md"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    class="ins-c-conditional-filter__value-selector"
+                                  >
+                                    Name
+                                  </span>
+                                </span>
+                                <span
+                                  class="pf-v5-c-menu-toggle__controls"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-l-split__item pf-m-fill"
+                            >
+                              <span
+                                class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
+                              >
+                                <input
+                                  aria-invalid="false"
+                                  aria-label="text input"
+                                  data-ouia-component-id="ConditionalFilter"
+                                  data-ouia-component-type="PF5/TextInput"
+                                  data-ouia-safe="true"
+                                  placeholder="Filter by name"
+                                  type="text"
+                                  value=""
+                                  widget-type="InsightsInput"
+                                />
+                                <span
+                                  class="pf-v5-c-form-control__utilities"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control__icon"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon pf-m-md ins-c-search-icon"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__item pf-m-spacer-sm"
                       >
-                        <span
-                          class="pf-v5-c-menu-toggle__toggle-icon"
+                        <button
+                          aria-expanded="false"
+                          aria-label="Export"
+                          class="pf-v5-c-menu-toggle pf-m-plain"
+                          type="button"
                         >
                           <svg
                             aria-hidden="true"
@@ -3415,539 +2864,98 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                             fill="currentColor"
                             height="1em"
                             role="img"
-                            viewBox="0 0 320 512"
+                            viewBox="0 0 1024 1024"
                             width="1em"
                           >
                             <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
                             />
                           </svg>
-                        </span>
-                      </span>
-                    </button>
-                  </div>
-                  <nav
-                    aria-label="Pagination"
-                    class="pf-v5-c-pagination__nav"
-                  >
-                    <div
-                      class="pf-v5-c-pagination__nav-control pf-m-first"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to first page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="first"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
+                        </button>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 448 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to previous page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="previous"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-4"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-page-select"
-                    >
-                      <span
-                        class="pf-v5-c-form-control pf-m-disabled"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-label="Current page"
-                          data-ouia-component-id="OUIA-Generated-TextInputBase-2"
-                          data-ouia-component-type="PF5/TextInput"
+                        <div
+                          class="pf-v5-c-pagination pf-m-compact"
+                          data-ouia-component-id="CompactPagination"
+                          data-ouia-component-type="PF5/Pagination"
                           data-ouia-safe="true"
-                          disabled=""
-                          max="1"
-                          min="1"
-                          type="number"
-                          value="1"
-                        />
-                      </span>
-                      <span
-                        aria-hidden="true"
-                      >
-                        of 1
-                      </span>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to next page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="next"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-5"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
+                          id="options-menu-top-pagination"
+                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                         >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-control pf-m-last"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to last page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="last"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-6"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 448 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </nav>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="pf-v5-c-toolbar__content pf-m-hidden"
-            hidden=""
-          >
-            <div
-              class="pf-v5-c-toolbar__group"
-            />
-          </div>
-        </div>
-      </div>
-    </section>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
-<DocumentFragment>
-  <div>
-    <section
-      class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
-      widget-type="InsightsPageHeader"
-    >
-      <nav
-        aria-label="Breadcrumb"
-        class="pf-v5-c-breadcrumb"
-        data-ouia-component-id="completed-tasks-details-breadcrumb"
-        data-ouia-component-type="PF5/Breadcrumb"
-        data-ouia-safe="true"
-      >
-        <ol
-          class="pf-v5-c-breadcrumb__list"
-          role="list"
-        >
-          <li
-            class="pf-v5-c-breadcrumb__item"
-          >
-            <a
-              class="pf-v5-c-breadcrumb__link"
-              href="/insights/tasks/executed"
-            >
-              Tasks
-            </a>
-          </li>
-          <li
-            class="pf-v5-c-breadcrumb__item"
-          >
-            <span
-              class="pf-v5-c-breadcrumb__item-divider"
-            >
-              <svg
-                aria-hidden="true"
-                class="pf-v5-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 256 512"
-                width="1em"
-              >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </span>
-            leapp task
-          </li>
-        </ol>
-      </nav>
-      <div
-        class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
-      >
-        <div
-          class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
-        >
-          <div
-            class=""
-          >
-            <h1
-              class="pf-v5-c-title pf-m-2xl"
-              data-ouia-component-id="OUIA-Generated-Title-3"
-              data-ouia-component-type="PF5/Title"
-              data-ouia-safe="true"
-              widget-type="InsightsPageHeaderTitle"
-            >
-              leapp task
-            </h1>
-            <div
-              class="pf-v5-c-content"
-            >
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-5"
-                data-ouia-component-type="PF5/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                Upgrade RHEL version with LEAP tool
-              </small>
-            </div>
-          </div>
-          <div
-            class=""
-          >
-            <p>
-              Uses the insights-client to determine if RHEL version can be upgraded with LEAP tool. Resource intensive scan
-            </p>
-          </div>
-        </div>
-        <div
-          class="pf-v5-l-flex"
-        >
-          <div
-            class=""
-          >
-            <button
-              aria-disabled="false"
-              aria-label="leapp-preupgrade-run-task-button"
-              class="pf-v5-c-button pf-m-secondary"
-              data-ouia-component-id="OUIA-Generated-Button-secondary-3"
-              data-ouia-component-type="PF5/Button"
-              data-ouia-safe="true"
-              type="button"
-            >
-              Run task again
-            </button>
-          </div>
-        </div>
-        <div
-          class="pf-v5-l-flex"
-        >
-          <div
-            class=""
-          >
-            <button
-              aria-expanded="false"
-              aria-label="Task details menu toggle"
-              class="pf-v5-c-menu-toggle pf-m-plain"
-              id="executed-task-kebab"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="pf-v5-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 192 512"
-                width="1em"
-              >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section
-      class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
-    >
-      <div
-        class="pf-v5-c-card"
-        data-ouia-component-id="OUIA-Generated-Card-5"
-        data-ouia-component-type="PF5/Card"
-        data-ouia-safe="true"
-        id=""
-      >
-        <div
-          class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
-        >
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Systems
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              6
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Run start
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              21 Apr 2022, 10:10 UTC
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Run end
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              -
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Initiated by
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              Michael
-            </div>
-          </div>
-          <div
-            class="pf-v5-l-flex pf-m-column"
-          >
-            <div
-              class=""
-            >
-              <b>
-                Systems with alerts
-              </b>
-            </div>
-            <div
-              class=""
-            >
-              5
-            </div>
-          </div>
-        </div>
-      </div>
-      <br />
-      <div
-        class="pf-v5-c-card"
-        data-ouia-component-id="OUIA-Generated-Card-6"
-        data-ouia-component-type="PF5/Card"
-        data-ouia-safe="true"
-        id=""
-      >
-        <div
-          class="pf-v5-c-toolbar  ins-c-primary-toolbar"
-          data-ouia-component-id="PrimaryToolbar"
-          data-ouia-component-type="PF5/Toolbar"
-          data-ouia-safe="true"
-          id="ins-primary-data-toolbar"
-        >
-          <div
-            class="pf-v5-c-toolbar__content"
-          >
-            <div
-              class="pf-v5-c-toolbar__content-section"
-            >
-              <div
-                class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
-              >
-                <div
-                  class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
-                >
-                  <div
-                    class="pf-v5-l-split ins-c-conditional-filter"
-                  >
-                    <div
-                      class="pf-v5-l-split__item"
-                    >
-                      <button
-                        aria-expanded="false"
-                        aria-label="Conditional filter"
-                        class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
-                        type="button"
-                      >
-                        <span
-                          class="pf-v5-c-menu-toggle__text"
-                        >
-                          <span
-                            class="pf-v5-c-icon pf-m-md"
+                          <div
+                            class="pf-v5-c-pagination__total-items"
                           >
-                            <span
-                              class="pf-v5-c-icon__content"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 512 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
-                                />
-                              </svg>
-                            </span>
-                          </span>
-                          <span
-                            class="ins-c-conditional-filter__value-selector"
-                          >
-                            Name
-                          </span>
-                        </span>
-                        <span
-                          class="pf-v5-c-menu-toggle__controls"
-                        >
-                          <span
-                            class="pf-v5-c-menu-toggle__toggle-icon"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="pf-v5-svg"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 320 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              />
-                            </svg>
-                          </span>
-                        </span>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-l-split__item pf-m-fill"
-                    >
-                      <span
-                        class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-label="text input"
-                          data-ouia-component-id="ConditionalFilter"
-                          data-ouia-component-type="PF5/TextInput"
-                          data-ouia-safe="true"
-                          placeholder="Filter by name"
-                          type="text"
-                          value=""
-                          widget-type="InsightsInput"
-                        />
-                        <span
-                          class="pf-v5-c-form-control__utilities"
-                        >
-                          <span
-                            class="pf-v5-c-form-control__icon"
-                          >
-                            <span
-                              class="pf-v5-c-icon pf-m-md ins-c-search-icon"
+                            <b>
+                              1 - 3
+                            </b>
+                             of 
+                            <b>
+                              3
+                            </b>
+                             
+                          </div>
+                          <div>
+                            <button
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                              id="options-menu-top-toggle"
+                              type="button"
                             >
                               <span
-                                class="pf-v5-c-icon__content"
+                                class="pf-v5-c-menu-toggle__text"
+                              >
+                                <b>
+                                  1 - 3
+                                </b>
+                                 of 
+                                <b>
+                                  3
+                                </b>
+                                 
+                              </span>
+                              <span
+                                class="pf-v5-c-menu-toggle__controls"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                          <nav
+                            aria-label="Pagination"
+                            class="pf-v5-c-pagination__nav"
+                          >
+                            <div
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to previous page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="previous"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3955,750 +2963,97 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                   fill="currentColor"
                                   height="1em"
                                   role="img"
-                                  viewBox="0 0 512 512"
+                                  viewBox="0 0 256 512"
                                   width="1em"
                                 >
                                   <path
-                                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
                                   />
                                 </svg>
-                              </span>
-                            </span>
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="pf-v5-c-toolbar__item pf-m-spacer-sm"
-              >
-                <button
-                  aria-expanded="false"
-                  aria-label="Export"
-                  class="pf-v5-c-menu-toggle pf-m-plain"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v5-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 1024 1024"
-                    width="1em"
-                  >
-                    <path
-                      d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <div
-                class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
-              >
-                <div
-                  class="pf-v5-c-pagination pf-m-compact"
-                  data-ouia-component-id="CompactPagination"
-                  data-ouia-component-type="PF5/Pagination"
-                  data-ouia-safe="true"
-                  id="options-menu-top-pagination"
-                  style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-                >
-                  <div
-                    class="pf-v5-c-pagination__total-items"
-                  >
-                    <b>
-                      1 - 6
-                    </b>
-                     of 
-                    <b>
-                      6
-                    </b>
-                     
-                  </div>
-                  <div>
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                      id="options-menu-top-toggle"
-                      type="button"
-                    >
-                      <span
-                        class="pf-v5-c-menu-toggle__text"
-                      >
-                        <b>
-                          1 - 6
-                        </b>
-                         of 
-                        <b>
-                          6
-                        </b>
-                         
-                      </span>
-                      <span
-                        class="pf-v5-c-menu-toggle__controls"
-                      >
-                        <span
-                          class="pf-v5-c-menu-toggle__toggle-icon"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 320 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </button>
-                  </div>
-                  <nav
-                    aria-label="Pagination"
-                    class="pf-v5-c-pagination__nav"
-                  >
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to previous page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="previous"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-21"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to next page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="next"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-22"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </nav>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="pf-v5-c-toolbar__content pf-m-hidden"
-            hidden=""
-          >
-            <div
-              class="pf-v5-c-toolbar__group"
-            />
-          </div>
-        </div>
-        <table
-          aria-label="43-completed-jobs"
-          class="pf-v5-c-table pf-m-grid-md"
-          data-ouia-component-id="43-completed-jobs-table"
-          data-ouia-component-type="PF5/Table"
-          data-ouia-safe="true"
-          role="grid"
-        >
-          <thead
-            class="pf-v5-c-table__thead"
-          >
-            <tr
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-30"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <th
-                class="pf-v5-c-table__th"
-                data-key="0"
-                data-label=""
-                tabindex="-1"
-              />
-              <th
-                aria-sort="none"
-                class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
-                data-key="1"
-                data-label="System name"
-                scope="col"
-                tabindex="-1"
-              >
-                <button
-                  class="pf-v5-c-table__button"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__button-content"
-                  >
-                    <span
-                      class="pf-v5-c-table__text"
-                    >
-                      System name
-                    </span>
-                    <span
-                      class="pf-v5-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
-              </th>
-              <th
-                aria-sort="none"
-                class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
-                data-key="2"
-                data-label="Status"
-                scope="col"
-                tabindex="-1"
-              >
-                <button
-                  class="pf-v5-c-table__button"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__button-content"
-                  >
-                    <span
-                      class="pf-v5-c-table__text"
-                    >
-                      Status
-                    </span>
-                    <span
-                      class="pf-v5-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
-              </th>
-              <th
-                aria-sort="ascending"
-                class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
-                data-key="3"
-                data-label="Message"
-                scope="col"
-                tabindex="-1"
-              >
-                <button
-                  class="pf-v5-c-table__button"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__button-content"
-                  >
-                    <span
-                      class="pf-v5-c-table__text"
-                    >
-                      Message
-                    </span>
-                    <span
-                      class="pf-v5-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v5-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            class="pf-v5-c-table__tbody"
-            role="rowgroup"
-          >
-            <tr
-              aria-label=""
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-36"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td"
-                data-key="0"
-                tabindex="-1"
-              />
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="1"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/42438801-c384-491a-943b-f5f621f0c882"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  YL-test-device-85
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="2"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Timeout
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="3"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 8px;"
-                  >
-                    <span
-                      class="pf-v5-c-icon"
-                    >
-                      <span
-                        class="pf-v5-c-icon__content pf-m-danger"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 512 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 16px;"
-                  >
-                    <span
-                      style="color: rgb(201, 25, 11);"
-                    >
-                      Alert
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  >
-                    Task failed to complete due to timing out. Retry this task at a later time.
-                  </div>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-          <tbody
-            class="pf-v5-c-table__tbody"
-            role="rowgroup"
-          >
-            <tr
-              aria-label=""
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-37"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td"
-                data-key="0"
-                tabindex="-1"
-              />
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="1"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/3262b268-23ed-4c5a-a918-d8c4923fdfbf"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  MG-test-device
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="2"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Failure
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="3"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 8px;"
-                  >
-                    <span
-                      class="pf-v5-c-icon"
-                    >
-                      <span
-                        class="pf-v5-c-icon__content pf-m-danger"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 512 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 16px;"
-                  >
-                    <span
-                      style="color: rgb(201, 25, 11);"
-                    >
-                      Alert
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  >
-                    Task failed to complete for an unknown reason. Retry this task at a later time.
-                  </div>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-          <tbody
-            class="pf-v5-c-table__tbody"
-            role="rowgroup"
-          >
-            <tr
-              aria-label=""
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-38"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td"
-                data-key="0"
-                tabindex="-1"
-              />
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="1"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  dl-test-device-2
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="2"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Success
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="3"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  />
-                </div>
-              </td>
-            </tr>
-          </tbody>
-          <tbody
-            class="pf-v5-c-table__tbody"
-            role="rowgroup"
-          >
-            <tr
-              aria-label=""
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-39"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                data-key="0"
-                tabindex="-1"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-expanded="false"
-                  aria-label="Details"
-                  aria-labelledby="simple-node3 expandable-toggle3"
-                  class="pf-v5-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-23"
-                  data-ouia-component-type="PF5/Button"
-                  data-ouia-safe="true"
-                  id="expandable-toggle3"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__toggle-icon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="pf-v5-svg"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                      />
-                    </svg>
-                  </div>
-                </button>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="1"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cf29c99"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  dl-test-device-4
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="2"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Success
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="3"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 8px;"
-                  >
-                    <span
-                      class="pf-v5-c-icon"
-                    >
-                      <span
-                        class="pf-v5-c-icon__content pf-m-danger"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 512 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 16px;"
-                  >
-                    <span
-                      style="color: rgb(201, 25, 11);"
-                    >
-                      Alert
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  >
-                    Your system has 1 inhibitor out of 4 potential problems
-                  </div>
-                </div>
-              </td>
-            </tr>
-            <tr
-              aria-label=""
-              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-              data-ouia-component-id="OUIA-Generated-TableRow-40"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-              hidden=""
-            >
-              <td
-                class="pf-v5-c-table__td"
-                colspan="4"
-                data-key="0"
-                id="expanded-content4"
-                tabindex="-1"
-              >
-                <div>
-                  <table
-                    class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                    data-ouia-component-id="OUIA-Generated-Table-9"
-                    data-ouia-component-type="PF5/Table"
-                    data-ouia-safe="true"
-                    role="grid"
-                    style="margin-bottom: 30px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                  >
-                    <tbody
-                      class="pf-v5-c-table__tbody"
-                      role="rowgroup"
-                    >
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-41"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node0 expand-toggle0"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-24"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle0"
-                            type="button"
-                          >
+                              </button>
+                            </div>
                             <div
-                              class="pf-v5-c-table__toggle-icon"
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to next page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="next"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 256 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </nav>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-c-toolbar__content pf-m-hidden"
+                    hidden=""
+                  >
+                    <div
+                      class="pf-v5-c-toolbar__group"
+                    />
+                  </div>
+                </div>
+                <table
+                  aria-label="42-completed-jobs"
+                  class="pf-v5-c-table pf-m-grid-md"
+                  data-ouia-component-id="42-completed-jobs-table"
+                  data-ouia-component-type="PF5/Table"
+                  data-ouia-safe="true"
+                  role="grid"
+                >
+                  <thead
+                    class="pf-v5-c-table__thead"
+                  >
+                    <tr
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-1"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <th
+                        aria-sort="none"
+                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
+                        data-key="0"
+                        data-label="System name"
+                        scope="col"
+                        tabindex="-1"
+                      >
+                        <button
+                          class="pf-v5-c-table__button"
+                          type="button"
+                        >
+                          <div
+                            class="pf-v5-c-table__button-content"
+                          >
+                            <span
+                              class="pf-v5-c-table__text"
+                            >
+                              System name
+                            </span>
+                            <span
+                              class="pf-v5-c-table__sort-indicator"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4706,24 +3061,192 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 fill="currentColor"
                                 height="1em"
                                 role="img"
-                                viewBox="0 0 320 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                 />
                               </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
+                            </span>
+                          </div>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
+                        data-key="1"
+                        data-label="Status"
+                        scope="col"
+                        tabindex="-1"
+                      >
+                        <button
+                          class="pf-v5-c-table__button"
+                          type="button"
                         >
-                          <span>
+                          <div
+                            class="pf-v5-c-table__button-content"
+                          >
+                            <span
+                              class="pf-v5-c-table__text"
+                            >
+                              Status
+                            </span>
+                            <span
+                              class="pf-v5-c-table__sort-indicator"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-35"
+                        data-key="2"
+                        data-label="Message"
+                        scope="col"
+                        tabindex="-1"
+                      >
+                        <button
+                          class="pf-v5-c-table__button"
+                          type="button"
+                        >
+                          <div
+                            class="pf-v5-c-table__button-content"
+                          >
+                            <span
+                              class="pf-v5-c-table__text"
+                            >
+                              Message
+                            </span>
+                            <span
+                              class="pf-v5-c-table__sort-indicator"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </button>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="pf-v5-c-table__tbody"
+                    role="rowgroup"
+                  >
+                    <tr
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-2"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="0"
+                        data-label="System name"
+                        tabindex="-1"
+                      >
+                        <a
+                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          dl-test-device-2
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="1"
+                        data-label="Status"
+                        tabindex="-1"
+                      >
+                        Success
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="2"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
+                        >
+                          <div
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
+                          >
+                            This was a success.
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-3"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="0"
+                        data-label="System name"
+                        tabindex="-1"
+                      >
+                        <a
+                          href="/insights/inventory/3262b268-23ed-4c5a-a918-d8c4923fdfbf"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          MG-test-device
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="1"
+                        data-label="Status"
+                        tabindex="-1"
+                      >
+                        Failure
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="2"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
+                        >
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 8px;"
+                          >
                             <span
                               class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
                             >
                               <span
                                 class="pf-v5-c-icon__content pf-m-danger"
@@ -4743,572 +3266,72 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 </svg>
                               </span>
                             </span>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 16px;"
+                          >
                             <span
-                              style="color: rgb(163, 0, 0);"
+                              style="color: rgb(201, 25, 11);"
                             >
-                              <strong>
-                                Leapp could not identify where GRUB core is located
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-42"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-red pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 512 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  High risk
-                                </span>
-                              </span>
+                              Alert
                             </span>
                           </div>
                           <div
-                            class="entry-title"
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
                           >
-                            Leapp could not identify where GRUB core is located
+                            Task failed to complete for an unknown reason. Retry this task at a later time.
                           </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Remediation
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span
-                                    class="remediations-font-family"
-                                  >
-                                    [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                ca7a1a66906a7df3da890aa538562708d3ea6ecd
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-43"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-4"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="0"
+                        data-label="System name"
+                        tabindex="-1"
                       >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
+                        <a
+                          href="/insights/inventory/42438801-c384-491a-943b-f5f621f0c882"
+                          rel="noreferrer"
+                          target="_blank"
                         >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node1 expand-toggle1"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-25"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle1"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-warning"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 576 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(121, 80, 0);"
-                            >
-                              <strong>
-                                SElinux will be set to permissive mode
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-44"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
+                          YL-test-device-85
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="1"
+                        data-label="Status"
+                        tabindex="-1"
                       >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
+                        Timeout
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="2"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
                         >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-orange pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 576 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  Low risk
-                                </span>
-                              </span>
-                            </span>
-                          </div>
                           <div
-                            class="entry-title"
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 8px;"
                           >
-                            SElinux will be set to permissive mode
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Remediation
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span
-                                    class="remediations-font-family"
-                                  >
-                                    [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-45"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node2 expand-toggle2"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-26"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle2"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
                             <span
                               class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
                             >
                               <span
-                                class="pf-v5-c-icon__content pf-m-warning"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 576 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(121, 80, 0);"
-                            >
-                              <strong>
-                                The subscription-manager release is going to be set after the upgrade
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-46"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-orange pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 576 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  Low risk
-                                </span>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="entry-title"
-                          >
-                            The subscription-manager release is going to be set after the upgrade
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                After the upgrade has completed the release of the subscription-manager will be set to 9.0. This will ensure that you will receive and keep the version you choose to upgrade to.
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Remediation
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span
-                                    class="remediations-font-family"
-                                  >
-                                    [hint] If you wish to receive updates for the latest released version of the target system, run \`subscription-manager release --unset\` after the upgrade.
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                747a4ca25303eda17d1891bb85eeb226be14f252
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-47"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node3 expand-toggle3"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-27"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle3"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-info"
+                                class="pf-v5-c-icon__content pf-m-danger"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -5320,47 +3343,105 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                   width="1em"
                                 >
                                   <path
-                                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
                                   />
                                 </svg>
                               </span>
                             </span>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 16px;"
+                          >
                             <span
-                              style="color: rgb(0, 41, 82);"
+                              style="color: rgb(201, 25, 11);"
                             >
-                              <strong>
-                                SElinux relabeling will be scheduled
-                              </strong>
+                              Alert
                             </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-48"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
+                          >
+                            Task failed to complete due to timing out. Retry this task at a later time.
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div
+                  class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
+                  data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
+                  data-ouia-component-type="RHI/TableToolbar"
+                  data-ouia-safe="true"
+                  id="pf-random-id-1"
+                >
+                  <div
+                    class="pf-v5-c-toolbar__content"
+                  >
+                    <div
+                      class="pf-v5-c-toolbar__content-section"
+                    >
+                      <div
+                        class="pf-v5-c-toolbar__item pf-m-align-self-center"
                       >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
+                        <div>
+                          <div
+                            style="display: contents;"
+                          >
+                            <div
+                              class="pf-v5-c-content"
+                            >
+                              <small
+                                class=""
+                                data-ouia-component-id="OUIA-Generated-Text-2"
+                                data-ouia-component-type="PF5/Text"
+                                data-ouia-safe="true"
+                                data-pf-content="true"
+                              >
+                                Last updated: All jobs completed
+                              </small>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
+                      >
+                        <div
+                          class="pf-v5-c-pagination pf-m-bottom"
+                          data-ouia-component-id="OUIA-Generated-Pagination-bottom-1"
+                          data-ouia-component-type="PF5/Pagination"
+                          data-ouia-safe="true"
+                          id="options-menu-bottom-pagination"
+                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                         >
                           <div>
-                            <span
-                              class="pf-v5-c-label pf-m-blue pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
+                            <button
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                              id="options-menu-bottom-toggle"
+                              type="button"
                             >
                               <span
-                                class="pf-v5-c-label__content"
+                                class="pf-v5-c-menu-toggle__text"
+                              >
+                                <b>
+                                  1 - 3
+                                </b>
+                                 of 
+                                <b>
+                                  3
+                                </b>
+                                 
+                              </span>
+                              <span
+                                class="pf-v5-c-menu-toggle__controls"
                               >
                                 <span
-                                  class="pf-v5-c-label__icon"
+                                  class="pf-v5-c-menu-toggle__toggle-icon"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -5368,224 +3449,2199 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     fill="currentColor"
                                     height="1em"
                                     role="img"
-                                    viewBox="0 0 512 512"
+                                    viewBox="0 0 320 512"
                                     width="1em"
                                   >
                                     <path
-                                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
                                     />
                                   </svg>
                                 </span>
-                                <span
-                                  class="pf-v5-c-label__text"
+                              </span>
+                            </button>
+                          </div>
+                          <nav
+                            aria-label="Pagination"
+                            class="pf-v5-c-pagination__nav"
+                          >
+                            <div
+                              class="pf-v5-c-pagination__nav-control pf-m-first"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to first page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="first"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 448 512"
+                                  width="1em"
                                 >
-                                  Info
+                                  <path
+                                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to previous page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="previous"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 256 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-page-select"
+                            >
+                              <span
+                                class="pf-v5-c-form-control pf-m-disabled"
+                              >
+                                <input
+                                  aria-invalid="false"
+                                  aria-label="Current page"
+                                  data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+                                  data-ouia-component-type="PF5/TextInput"
+                                  data-ouia-safe="true"
+                                  disabled=""
+                                  max="1"
+                                  min="1"
+                                  type="number"
+                                  value="1"
+                                />
+                              </span>
+                              <span
+                                aria-hidden="true"
+                              >
+                                of 1
+                              </span>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to next page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="next"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 256 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-control pf-m-last"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to last page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="last"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 448 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </nav>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-c-toolbar__content pf-m-hidden"
+                    hidden=""
+                  >
+                    <div
+                      class="pf-v5-c-toolbar__group"
+                    />
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+        <div
+          class="pf-v5-c-drawer__panel pf-m-resizable"
+          hidden=""
+          id="end-resize-panel"
+          style="--pf-v5-c-drawer__panel--md--FlexBasis: 1000px; --pf-v5-c-drawer__panel--md--FlexBasis--min: 500px;"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="pf-v5-c-drawer"
+    >
+      <div
+        class="pf-v5-c-drawer__main"
+      >
+        <div
+          class="pf-v5-c-drawer__content"
+        >
+          <div
+            class="pf-v5-c-drawer__body"
+          >
+            <section
+              class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+              widget-type="InsightsPageHeader"
+            >
+              <nav
+                aria-label="Breadcrumb"
+                class="pf-v5-c-breadcrumb"
+                data-ouia-component-id="completed-tasks-details-breadcrumb"
+                data-ouia-component-type="PF5/Breadcrumb"
+                data-ouia-safe="true"
+              >
+                <ol
+                  class="pf-v5-c-breadcrumb__list"
+                  role="list"
+                >
+                  <li
+                    class="pf-v5-c-breadcrumb__item"
+                  >
+                    <a
+                      class="pf-v5-c-breadcrumb__link"
+                      href="/insights/tasks/executed"
+                    >
+                      Tasks
+                    </a>
+                  </li>
+                  <li
+                    class="pf-v5-c-breadcrumb__item"
+                  >
+                    <span
+                      class="pf-v5-c-breadcrumb__item-divider"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 256 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                        />
+                      </svg>
+                    </span>
+                    leapp task
+                  </li>
+                </ol>
+              </nav>
+              <div
+                class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
+              >
+                <div
+                  class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <h1
+                      class="pf-v5-c-title pf-m-2xl"
+                      data-ouia-component-id="OUIA-Generated-Title-3"
+                      data-ouia-component-type="PF5/Title"
+                      data-ouia-safe="true"
+                      widget-type="InsightsPageHeaderTitle"
+                    >
+                      leapp task
+                    </h1>
+                    <div
+                      class="pf-v5-c-content"
+                    >
+                      <small
+                        class=""
+                        data-ouia-component-id="OUIA-Generated-Text-5"
+                        data-ouia-component-type="PF5/Text"
+                        data-ouia-safe="true"
+                        data-pf-content="true"
+                      >
+                        Upgrade RHEL version with LEAP tool
+                      </small>
+                    </div>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    <p>
+                      Uses the insights-client to determine if RHEL version can be upgraded with LEAP tool. Resource intensive scan
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex"
+                >
+                  <div
+                    class=""
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="leapp-preupgrade-run-task-button"
+                      class="pf-v5-c-button pf-m-secondary"
+                      data-ouia-component-id="OUIA-Generated-Button-secondary-3"
+                      data-ouia-component-type="PF5/Button"
+                      data-ouia-safe="true"
+                      type="button"
+                    >
+                      Run task again
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex"
+                >
+                  <div
+                    class=""
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-label="Task details menu toggle"
+                      class="pf-v5-c-menu-toggle pf-m-plain"
+                      id="executed-task-kebab"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v5-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 192 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section
+              class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
+            >
+              <div
+                class="pf-v5-c-card"
+                data-ouia-component-id="OUIA-Generated-Card-5"
+                data-ouia-component-type="PF5/Card"
+                data-ouia-safe="true"
+                id=""
+              >
+                <div
+                  class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
+                >
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Systems
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      6
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Run start
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      21 Apr 2022, 10:10 UTC
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Run end
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      -
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Initiated by
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      Michael
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-flex pf-m-column"
+                  >
+                    <div
+                      class=""
+                    >
+                      <b>
+                        Systems with alerts
+                      </b>
+                    </div>
+                    <div
+                      class=""
+                    >
+                      5
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <br />
+              <div
+                class="pf-v5-c-card"
+                data-ouia-component-id="OUIA-Generated-Card-6"
+                data-ouia-component-type="PF5/Card"
+                data-ouia-safe="true"
+                id=""
+              >
+                <div
+                  class="pf-v5-c-toolbar  ins-c-primary-toolbar"
+                  data-ouia-component-id="PrimaryToolbar"
+                  data-ouia-component-type="PF5/Toolbar"
+                  data-ouia-safe="true"
+                  id="ins-primary-data-toolbar"
+                >
+                  <div
+                    class="pf-v5-c-toolbar__content"
+                  >
+                    <div
+                      class="pf-v5-c-toolbar__content-section"
+                    >
+                      <div
+                        class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+                      >
+                        <div
+                          class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                        >
+                          <div
+                            class="pf-v5-l-split ins-c-conditional-filter"
+                          >
+                            <div
+                              class="pf-v5-l-split__item"
+                            >
+                              <button
+                                aria-expanded="false"
+                                aria-label="Conditional filter"
+                                class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
+                                type="button"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__text"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon pf-m-md"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    class="ins-c-conditional-filter__value-selector"
+                                  >
+                                    Name
+                                  </span>
                                 </span>
+                                <span
+                                  class="pf-v5-c-menu-toggle__controls"
+                                >
+                                  <span
+                                    class="pf-v5-c-menu-toggle__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-l-split__item pf-m-fill"
+                            >
+                              <span
+                                class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
+                              >
+                                <input
+                                  aria-invalid="false"
+                                  aria-label="text input"
+                                  data-ouia-component-id="ConditionalFilter"
+                                  data-ouia-component-type="PF5/TextInput"
+                                  data-ouia-safe="true"
+                                  placeholder="Filter by name"
+                                  type="text"
+                                  value=""
+                                  widget-type="InsightsInput"
+                                />
+                                <span
+                                  class="pf-v5-c-form-control__utilities"
+                                >
+                                  <span
+                                    class="pf-v5-c-form-control__icon"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon pf-m-md ins-c-search-icon"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__item pf-m-spacer-sm"
+                      >
+                        <button
+                          aria-expanded="false"
+                          aria-label="Export"
+                          class="pf-v5-c-menu-toggle pf-m-plain"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 1024 1024"
+                            width="1em"
+                          >
+                            <path
+                              d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
+                      >
+                        <div
+                          class="pf-v5-c-pagination pf-m-compact"
+                          data-ouia-component-id="CompactPagination"
+                          data-ouia-component-type="PF5/Pagination"
+                          data-ouia-safe="true"
+                          id="options-menu-top-pagination"
+                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                        >
+                          <div
+                            class="pf-v5-c-pagination__total-items"
+                          >
+                            <b>
+                              1 - 6
+                            </b>
+                             of 
+                            <b>
+                              6
+                            </b>
+                             
+                          </div>
+                          <div>
+                            <button
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                              id="options-menu-top-toggle"
+                              type="button"
+                            >
+                              <span
+                                class="pf-v5-c-menu-toggle__text"
+                              >
+                                <b>
+                                  1 - 6
+                                </b>
+                                 of 
+                                <b>
+                                  6
+                                </b>
+                                 
+                              </span>
+                              <span
+                                class="pf-v5-c-menu-toggle__controls"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                          <nav
+                            aria-label="Pagination"
+                            class="pf-v5-c-pagination__nav"
+                          >
+                            <div
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to previous page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="previous"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-21"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 256 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to next page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="next"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-22"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 256 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </nav>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-c-toolbar__content pf-m-hidden"
+                    hidden=""
+                  >
+                    <div
+                      class="pf-v5-c-toolbar__group"
+                    />
+                  </div>
+                </div>
+                <table
+                  aria-label="43-completed-jobs"
+                  class="pf-v5-c-table pf-m-grid-md"
+                  data-ouia-component-id="43-completed-jobs-table"
+                  data-ouia-component-type="PF5/Table"
+                  data-ouia-safe="true"
+                  role="grid"
+                >
+                  <thead
+                    class="pf-v5-c-table__thead"
+                  >
+                    <tr
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-30"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <th
+                        class="pf-v5-c-table__th"
+                        data-key="0"
+                        data-label=""
+                        tabindex="-1"
+                      />
+                      <th
+                        aria-sort="none"
+                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
+                        data-key="1"
+                        data-label="System name"
+                        scope="col"
+                        tabindex="-1"
+                      >
+                        <button
+                          class="pf-v5-c-table__button"
+                          type="button"
+                        >
+                          <div
+                            class="pf-v5-c-table__button-content"
+                          >
+                            <span
+                              class="pf-v5-c-table__text"
+                            >
+                              System name
+                            </span>
+                            <span
+                              class="pf-v5-c-table__sort-indicator"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="none"
+                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
+                        data-key="2"
+                        data-label="Status"
+                        scope="col"
+                        tabindex="-1"
+                      >
+                        <button
+                          class="pf-v5-c-table__button"
+                          type="button"
+                        >
+                          <div
+                            class="pf-v5-c-table__button-content"
+                          >
+                            <span
+                              class="pf-v5-c-table__text"
+                            >
+                              Status
+                            </span>
+                            <span
+                              class="pf-v5-c-table__sort-indicator"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </button>
+                      </th>
+                      <th
+                        aria-sort="ascending"
+                        class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
+                        data-key="3"
+                        data-label="Message"
+                        scope="col"
+                        tabindex="-1"
+                      >
+                        <button
+                          class="pf-v5-c-table__button"
+                          type="button"
+                        >
+                          <div
+                            class="pf-v5-c-table__button-content"
+                          >
+                            <span
+                              class="pf-v5-c-table__text"
+                            >
+                              Message
+                            </span>
+                            <span
+                              class="pf-v5-c-table__sort-indicator"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </button>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="pf-v5-c-table__tbody"
+                    role="rowgroup"
+                  >
+                    <tr
+                      aria-label=""
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-36"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <td
+                        class="pf-v5-c-table__td"
+                        data-key="0"
+                        tabindex="-1"
+                      />
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="1"
+                        data-label="System name"
+                        tabindex="-1"
+                      >
+                        <a
+                          href="/insights/inventory/42438801-c384-491a-943b-f5f621f0c882"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          YL-test-device-85
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="2"
+                        data-label="Status"
+                        tabindex="-1"
+                      >
+                        Timeout
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="3"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
+                        >
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 8px;"
+                          >
+                            <span
+                              class="pf-v5-c-icon"
+                            >
+                              <span
+                                class="pf-v5-c-icon__content pf-m-danger"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 512 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                  />
+                                </svg>
                               </span>
                             </span>
                           </div>
                           <div
-                            class="entry-title"
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 16px;"
                           >
-                            SElinux relabeling will be scheduled
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                            <span
+                              style="color: rgb(201, 25, 11);"
                             >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                SElinux relabeling will be scheduled as the status is permissive/enforcing.
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                8fb81863f8413bd617c2a55b69b8e10ff03d7c72
-                              </div>
-                            </div>
+                              Alert
+                            </span>
                           </div>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-          <tbody
-            class="pf-v5-c-table__tbody"
-            role="rowgroup"
-          >
-            <tr
-              aria-label=""
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-49"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                data-key="0"
-                tabindex="-1"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-expanded="false"
-                  aria-label="Details"
-                  aria-labelledby="simple-node5 expandable-toggle5"
-                  class="pf-v5-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-28"
-                  data-ouia-component-type="PF5/Button"
-                  data-ouia-safe="true"
-                  id="expandable-toggle5"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__toggle-icon"
+                          <div
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
+                          >
+                            Task failed to complete due to timing out. Retry this task at a later time.
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                  <tbody
+                    class="pf-v5-c-table__tbody"
+                    role="rowgroup"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="pf-v5-svg"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 320 512"
-                      width="1em"
+                    <tr
+                      aria-label=""
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-37"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
                     >
-                      <path
-                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                      <td
+                        class="pf-v5-c-table__td"
+                        data-key="0"
+                        tabindex="-1"
                       />
-                    </svg>
-                  </div>
-                </button>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="1"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cf29c91"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  dl-test-device-5
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="2"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Success
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="3"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 8px;"
-                  >
-                    <span
-                      class="pf-v5-c-icon"
-                    >
-                      <span
-                        class="pf-v5-c-icon__content pf-m-danger"
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="1"
+                        data-label="System name"
+                        tabindex="-1"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 512 512"
-                          width="1em"
+                        <a
+                          href="/insights/inventory/3262b268-23ed-4c5a-a918-d8c4923fdfbf"
+                          rel="noreferrer"
+                          target="_blank"
                         >
-                          <path
-                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                          MG-test-device
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="2"
+                        data-label="Status"
+                        tabindex="-1"
+                      >
+                        Failure
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="3"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
+                        >
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 8px;"
+                          >
+                            <span
+                              class="pf-v5-c-icon"
+                            >
+                              <span
+                                class="pf-v5-c-icon__content pf-m-danger"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 512 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                  />
+                                </svg>
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 16px;"
+                          >
+                            <span
+                              style="color: rgb(201, 25, 11);"
+                            >
+                              Alert
+                            </span>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
+                          >
+                            Task failed to complete for an unknown reason. Retry this task at a later time.
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                  <tbody
+                    class="pf-v5-c-table__tbody"
+                    role="rowgroup"
+                  >
+                    <tr
+                      aria-label=""
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-38"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <td
+                        class="pf-v5-c-table__td"
+                        data-key="0"
+                        tabindex="-1"
+                      />
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="1"
+                        data-label="System name"
+                        tabindex="-1"
+                      >
+                        <a
+                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc6e2f2"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          dl-test-device-2
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="2"
+                        data-label="Status"
+                        tabindex="-1"
+                      >
+                        Success
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="3"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
+                        >
+                          <div
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
                           />
-                        </svg>
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 16px;"
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                  <tbody
+                    class="pf-v5-c-table__tbody"
+                    role="rowgroup"
                   >
-                    <span
-                      style="color: rgb(201, 25, 11);"
+                    <tr
+                      aria-label=""
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-39"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
                     >
-                      Alert
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  >
-                    Your system has 1 inhibitor out of 4 potential problems
-                  </div>
-                </div>
-              </td>
-            </tr>
-            <tr
-              aria-label=""
-              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-              data-ouia-component-id="OUIA-Generated-TableRow-50"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-              hidden=""
-            >
-              <td
-                class="pf-v5-c-table__td"
-                colspan="4"
-                data-key="0"
-                id="expanded-content6"
-                tabindex="-1"
-              >
-                <div>
-                  <div
-                    class="pf-v5-c-code-block"
-                    style="--pf-v5-c-code-block__header--BorderBottomColor: [object Object]; background-color: rgb(255, 255, 255);"
-                  >
-                    <div
-                      class="pf-v5-c-code-block__content"
-                    >
-                      <pre
-                        class="pf-v5-c-code-block__pre"
+                      <td
+                        class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                        data-key="0"
+                        tabindex="-1"
                       >
-                        <code
-                          class="pf-v5-c-code-block__code"
+                        <button
+                          aria-disabled="false"
+                          aria-expanded="false"
+                          aria-label="Details"
+                          aria-labelledby="simple-node3 expandable-toggle3"
+                          class="pf-v5-c-button pf-m-plain"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-23"
+                          data-ouia-component-type="PF5/Button"
+                          data-ouia-safe="true"
+                          id="expandable-toggle3"
+                          type="button"
                         >
-                          Risk Factor: high
+                          <div
+                            class="pf-v5-c-table__toggle-icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                              />
+                            </svg>
+                          </div>
+                        </button>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="1"
+                        data-label="System name"
+                        tabindex="-1"
+                      >
+                        <a
+                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cf29c99"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          dl-test-device-4
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="2"
+                        data-label="Status"
+                        tabindex="-1"
+                      >
+                        Success
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="3"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
+                        >
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 8px;"
+                          >
+                            <span
+                              class="pf-v5-c-icon"
+                            >
+                              <span
+                                class="pf-v5-c-icon__content pf-m-danger"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 512 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                  />
+                                </svg>
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 16px;"
+                          >
+                            <span
+                              style="color: rgb(201, 25, 11);"
+                            >
+                              Alert
+                            </span>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
+                          >
+                            Your system has 1 inhibitor out of 4 potential problems
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      aria-label=""
+                      class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                      data-ouia-component-id="OUIA-Generated-TableRow-40"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                      hidden=""
+                    >
+                      <td
+                        class="pf-v5-c-table__td"
+                        colspan="4"
+                        data-key="0"
+                        id="expanded-content4"
+                        tabindex="-1"
+                      >
+                        <div>
+                          <table
+                            class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                            data-ouia-component-id="OUIA-Generated-Table-9"
+                            data-ouia-component-type="PF5/Table"
+                            data-ouia-safe="true"
+                            role="grid"
+                            style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                          >
+                            <tbody
+                              class="pf-v5-c-table__tbody"
+                              role="rowgroup"
+                            >
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-41"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node0 expand-toggle0"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-24"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle0"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-danger"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(163, 0, 0);"
+                                    >
+                                      <strong>
+                                        Leapp could not identify where GRUB core is located
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-42"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-red pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          High risk
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    Leapp could not identify where GRUB core is located
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Remediation
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        ca7a1a66906a7df3da890aa538562708d3ea6ecd
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-43"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node1 expand-toggle1"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-25"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle1"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-warning"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 576 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(121, 80, 0);"
+                                    >
+                                      <strong>
+                                        SElinux will be set to permissive mode
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-44"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 576 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          Low risk
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    SElinux will be set to permissive mode
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Remediation
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-45"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node2 expand-toggle2"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-26"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle2"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-warning"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 576 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(121, 80, 0);"
+                                    >
+                                      <strong>
+                                        The subscription-manager release is going to be set after the upgrade
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-46"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 576 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          Low risk
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    The subscription-manager release is going to be set after the upgrade
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        After the upgrade has completed the release of the subscription-manager will be set to 9.0. This will ensure that you will receive and keep the version you choose to upgrade to.
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Remediation
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            [hint] If you wish to receive updates for the latest released version of the target system, run \`subscription-manager release --unset\` after the upgrade.
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        747a4ca25303eda17d1891bb85eeb226be14f252
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-47"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node3 expand-toggle3"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-27"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle3"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-info"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(0, 41, 82);"
+                                    >
+                                      <strong>
+                                        SElinux relabeling will be scheduled
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-48"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-blue pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          Info
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    SElinux relabeling will be scheduled
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        SElinux relabeling will be scheduled as the status is permissive/enforcing.
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        8fb81863f8413bd617c2a55b69b8e10ff03d7c72
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                  <tbody
+                    class="pf-v5-c-table__tbody"
+                    role="rowgroup"
+                  >
+                    <tr
+                      aria-label=""
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-49"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <td
+                        class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                        data-key="0"
+                        tabindex="-1"
+                      >
+                        <button
+                          aria-disabled="false"
+                          aria-expanded="false"
+                          aria-label="Details"
+                          aria-labelledby="simple-node5 expandable-toggle5"
+                          class="pf-v5-c-button pf-m-plain"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-28"
+                          data-ouia-component-type="PF5/Button"
+                          data-ouia-safe="true"
+                          id="expandable-toggle5"
+                          type="button"
+                        >
+                          <div
+                            class="pf-v5-c-table__toggle-icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                              />
+                            </svg>
+                          </div>
+                        </button>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="1"
+                        data-label="System name"
+                        tabindex="-1"
+                      >
+                        <a
+                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cf29c91"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          dl-test-device-5
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="2"
+                        data-label="Status"
+                        tabindex="-1"
+                      >
+                        Success
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="3"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
+                        >
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 8px;"
+                          >
+                            <span
+                              class="pf-v5-c-icon"
+                            >
+                              <span
+                                class="pf-v5-c-icon__content pf-m-danger"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 512 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                  />
+                                </svg>
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 16px;"
+                          >
+                            <span
+                              style="color: rgb(201, 25, 11);"
+                            >
+                              Alert
+                            </span>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
+                          >
+                            Your system has 1 inhibitor out of 4 potential problems
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      aria-label=""
+                      class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                      data-ouia-component-id="OUIA-Generated-TableRow-50"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                      hidden=""
+                    >
+                      <td
+                        class="pf-v5-c-table__td"
+                        colspan="4"
+                        data-key="0"
+                        id="expanded-content6"
+                        tabindex="-1"
+                      >
+                        <div>
+                          <div
+                            class="pf-v5-c-code-block"
+                            style="--pf-v5-c-code-block__header--BorderBottomColor: [object Object]; background-color: rgb(255, 255, 255);"
+                          >
+                            <div
+                              class="pf-v5-c-code-block__content"
+                            >
+                              <pre
+                                class="pf-v5-c-code-block__pre"
+                              >
+                                <code
+                                  class="pf-v5-c-code-block__code"
+                                >
+                                  Risk Factor: high
 Title: Leapp could not identify where GRUB core is located
 Summary: We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
 Remediation: [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
@@ -5609,1393 +5665,1403 @@ Summary: SElinux relabeling will be scheduled as the status is permissive/enforc
 Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
 ----------------------------------------
 
-                        </code>
-                      </pre>
-                    </div>
-                  </div>
-                  <table
-                    class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                    data-ouia-component-id="OUIA-Generated-Table-10"
-                    data-ouia-component-type="PF5/Table"
-                    data-ouia-safe="true"
-                    role="grid"
-                    style="margin-bottom: 30px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                  >
-                    <tbody
-                      class="pf-v5-c-table__tbody"
-                      role="rowgroup"
-                    />
-                  </table>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-          <tbody
-            class="pf-v5-c-table__tbody"
-            role="rowgroup"
-          >
-            <tr
-              aria-label=""
-              class="pf-v5-c-table__tr"
-              data-ouia-component-id="OUIA-Generated-TableRow-51"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-            >
-              <td
-                class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                data-key="0"
-                tabindex="-1"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-expanded="false"
-                  aria-label="Details"
-                  aria-labelledby="simple-node7 expandable-toggle7"
-                  class="pf-v5-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-29"
-                  data-ouia-component-type="PF5/Button"
-                  data-ouia-safe="true"
-                  id="expandable-toggle7"
-                  type="button"
-                >
-                  <div
-                    class="pf-v5-c-table__toggle-icon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="pf-v5-svg"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                      />
-                    </svg>
-                  </div>
-                </button>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-30"
-                data-key="1"
-                data-label="System name"
-                tabindex="-1"
-              >
-                <a
-                  href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc53bee"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  dl-test-device-3
-                </a>
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-10"
-                data-key="2"
-                data-label="Status"
-                tabindex="-1"
-              >
-                Success
-              </td>
-              <td
-                class="pf-v5-c-table__td pf-m-width-35"
-                data-key="3"
-                data-label="Message"
-                tabindex="-1"
-              >
-                <div
-                  class="pf-v5-l-split"
-                >
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 8px;"
-                  >
-                    <span
-                      class="pf-v5-c-icon"
-                    >
-                      <span
-                        class="pf-v5-c-icon__content pf-m-danger"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 512 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    style="padding-right: 16px;"
-                  >
-                    <span
-                      style="color: rgb(201, 25, 11);"
-                    >
-                      Alert
-                    </span>
-                  </div>
-                  <div
-                    class="pf-v5-l-split__item"
-                    color="#A30000"
-                  >
-                    Your system has 3 inhibitors out of 5 potential problems.
-                  </div>
-                </div>
-              </td>
-            </tr>
-            <tr
-              aria-label=""
-              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-              data-ouia-component-id="OUIA-Generated-TableRow-52"
-              data-ouia-component-type="PF5/TableRow"
-              data-ouia-safe="true"
-              hidden=""
-            >
-              <td
-                class="pf-v5-c-table__td"
-                colspan="4"
-                data-key="0"
-                id="expanded-content8"
-                tabindex="-1"
-              >
-                <div>
-                  <table
-                    class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                    data-ouia-component-id="OUIA-Generated-Table-11"
-                    data-ouia-component-type="PF5/Table"
-                    data-ouia-safe="true"
-                    role="grid"
-                    style="margin-bottom: 30px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                  >
-                    <tbody
-                      class="pf-v5-c-table__tbody"
-                      role="rowgroup"
-                    >
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-53"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node0 expand-toggle0"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-30"
-                            data-ouia-component-type="PF5/Button"
+                                </code>
+                              </pre>
+                            </div>
+                          </div>
+                          <table
+                            class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                            data-ouia-component-id="OUIA-Generated-Table-10"
+                            data-ouia-component-type="PF5/Table"
                             data-ouia-safe="true"
-                            id="expand-toggle0"
-                            type="button"
+                            role="grid"
+                            style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
                           >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(163, 0, 0);"
-                            >
-                              <strong>
-                                Leapp could not identify where GRUB core is located
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-54"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-red pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 512 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  High risk
-                                </span>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="entry-title"
-                          >
-                            Leapp could not identify where GRUB core is located
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Remediation
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span
-                                    class="remediations-font-family"
-                                  >
-                                    [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                ca7a1a66906a7df3da890aa538562708d3ea6ecd
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-55"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node1 expand-toggle1"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-31"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle1"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(163, 0, 0);"
-                            >
-                              <strong>
-                                Firewalld Configuration AllowZoneDrifting Is Unsupported
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-56"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-red pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 512 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  High risk
-                                </span>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="entry-title"
-                          >
-                            Firewalld Configuration AllowZoneDrifting Is Unsupported
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                Firewalld has enabled configuration option "AllowZoneDrifiting" which has been removed in RHEL-9. New behavior is as if "AllowZoneDrifiting" was set to "no".
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Remediation
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span
-                                    class="remediations-font-family"
-                                  >
-                                    [hint] Set AllowZoneDrifting=no in /etc/firewalld/firewalld.conf
-                                  </span>
-                                </div>
-                                <div>
-                                  <span>
-                                    <br />
-                                  </span>
-                                  <span
-                                    class="remediations-font-family"
-                                  >
-                                    [command] sed -i "s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/" /etc/firewalld/firewalld.conf
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                5b1cf050e1a877b0358b6e8c612277c591d40c13
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-57"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node2 expand-toggle2"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-32"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle2"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-danger"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(163, 0, 0);"
-                            >
-                              <strong>
-                                VDO devices migration to LVM management
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-58"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-red pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 512 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  High risk
-                                </span>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="entry-title"
-                          >
-                            VDO devices migration to LVM management
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                VDO devices 'vda, vda1, vda2' require migration to LVM management.After performing the upgrade VDO devices can only be managed via LVM. Any VDO device not currently managed by LVM must be converted to LVM management before upgrading. The data on any VDO device not converted to LVM management will be inaccessible after upgrading.
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Remediation
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span
-                                    class="remediations-font-family"
-                                  >
-                                    [hint] Consult the VDO to LVM conversion process documentation for how to perform the conversion.
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                f7c335398cc449f5d7baf4e73255d44c34ad2620
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-59"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node3 expand-toggle3"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-33"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle3"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-warning"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 576 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(121, 80, 0);"
-                            >
-                              <strong>
-                                SElinux will be set to permissive mode
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-60"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-orange pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 576 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  Low risk
-                                </span>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="entry-title"
-                          >
-                            SElinux will be set to permissive mode
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Remediation
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                <div>
-                                  <span
-                                    class="remediations-font-family"
-                                  >
-                                    [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr"
-                        data-ouia-component-id="OUIA-Generated-TableRow-61"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                      >
-                        <td
-                          class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                          tabindex="-1"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-expanded="false"
-                            aria-label="Details"
-                            aria-labelledby="simple-node4 expand-toggle4"
-                            class="pf-v5-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Button-plain-34"
-                            data-ouia-component-type="PF5/Button"
-                            data-ouia-safe="true"
-                            id="expand-toggle4"
-                            type="button"
-                          >
-                            <div
-                              class="pf-v5-c-table__toggle-icon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 320 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                />
-                              </svg>
-                            </div>
-                          </button>
-                        </td>
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <span>
-                            <span
-                              class="pf-v5-c-icon"
-                              style="margin-right: 8px;"
-                            >
-                              <span
-                                class="pf-v5-c-icon__content pf-m-info"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                  />
-                                </svg>
-                              </span>
-                            </span>
-                            <span
-                              style="color: rgb(0, 41, 82);"
-                            >
-                              <strong>
-                                SElinux relabeling will be scheduled
-                              </strong>
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        aria-label=""
-                        class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                        data-ouia-component-id="OUIA-Generated-TableRow-62"
-                        data-ouia-component-type="PF5/TableRow"
-                        data-ouia-safe="true"
-                        hidden=""
-                      >
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        />
-                        <td
-                          class="pf-v5-c-table__td"
-                          tabindex="-1"
-                        >
-                          <div>
-                            <span
-                              class="pf-v5-c-label pf-m-blue pf-m-compact"
-                              style="margin-top: 16px; margin-bottom: 4px;"
-                            >
-                              <span
-                                class="pf-v5-c-label__content"
-                              >
-                                <span
-                                  class="pf-v5-c-label__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 512 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                    />
-                                  </svg>
-                                </span>
-                                <span
-                                  class="pf-v5-c-label__text"
-                                >
-                                  Info
-                                </span>
-                              </span>
-                            </span>
-                          </div>
-                          <div
-                            class="entry-title"
-                          >
-                            SElinux relabeling will be scheduled
-                          </div>
-                          <div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Summary
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                SElinux relabeling will be scheduled as the status is permissive/enforcing.
-                              </div>
-                            </div>
-                            <div
-                              class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                            >
-                              <div
-                                class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                              >
-                                Key
-                              </div>
-                              <div
-                                class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                l="6"
-                                m="7"
-                                style="white-space: pre-line;"
-                              >
-                                8fb81863f8413bd617c2a55b69b8e10ff03d7c72
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <div
-          class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
-          data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-3"
-          data-ouia-component-type="RHI/TableToolbar"
-          data-ouia-safe="true"
-          id="pf-random-id-2"
-        >
-          <div
-            class="pf-v5-c-toolbar__content"
-          >
-            <div
-              class="pf-v5-c-toolbar__content-section"
-            >
-              <div
-                class="pf-v5-c-toolbar__item pf-m-align-self-center"
-              >
-                <div>
-                  <div
-                    style="display: contents;"
-                  >
-                    <div
-                      class="pf-v5-c-content"
-                    >
-                      <small
-                        class=""
-                        data-ouia-component-id="OUIA-Generated-Text-6"
-                        data-ouia-component-type="PF5/Text"
-                        data-ouia-safe="true"
-                        data-pf-content="true"
-                      >
-                        Last updated: All jobs completed
-                      </small>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
-              >
-                <div
-                  class="pf-v5-c-pagination pf-m-bottom"
-                  data-ouia-component-id="OUIA-Generated-Pagination-bottom-3"
-                  data-ouia-component-type="PF5/Pagination"
-                  data-ouia-safe="true"
-                  id="options-menu-bottom-pagination"
-                  style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-                >
-                  <div>
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                      id="options-menu-bottom-toggle"
-                      type="button"
-                    >
-                      <span
-                        class="pf-v5-c-menu-toggle__text"
-                      >
-                        <b>
-                          1 - 6
-                        </b>
-                         of 
-                        <b>
-                          6
-                        </b>
-                         
-                      </span>
-                      <span
-                        class="pf-v5-c-menu-toggle__controls"
-                      >
-                        <span
-                          class="pf-v5-c-menu-toggle__toggle-icon"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 320 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            <tbody
+                              class="pf-v5-c-table__tbody"
+                              role="rowgroup"
                             />
-                          </svg>
-                        </span>
-                      </span>
-                    </button>
-                  </div>
-                  <nav
-                    aria-label="Pagination"
-                    class="pf-v5-c-pagination__nav"
+                          </table>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                  <tbody
+                    class="pf-v5-c-table__tbody"
+                    role="rowgroup"
+                  >
+                    <tr
+                      aria-label=""
+                      class="pf-v5-c-table__tr"
+                      data-ouia-component-id="OUIA-Generated-TableRow-51"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                    >
+                      <td
+                        class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                        data-key="0"
+                        tabindex="-1"
+                      >
+                        <button
+                          aria-disabled="false"
+                          aria-expanded="false"
+                          aria-label="Details"
+                          aria-labelledby="simple-node7 expandable-toggle7"
+                          class="pf-v5-c-button pf-m-plain"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-29"
+                          data-ouia-component-type="PF5/Button"
+                          data-ouia-safe="true"
+                          id="expandable-toggle7"
+                          type="button"
+                        >
+                          <div
+                            class="pf-v5-c-table__toggle-icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                              />
+                            </svg>
+                          </div>
+                        </button>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-30"
+                        data-key="1"
+                        data-label="System name"
+                        tabindex="-1"
+                      >
+                        <a
+                          href="/insights/inventory/f1356a99-754d-4219-9g25-fccb2cc53bee"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          dl-test-device-3
+                        </a>
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-10"
+                        data-key="2"
+                        data-label="Status"
+                        tabindex="-1"
+                      >
+                        Success
+                      </td>
+                      <td
+                        class="pf-v5-c-table__td pf-m-width-35"
+                        data-key="3"
+                        data-label="Message"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="pf-v5-l-split"
+                        >
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 8px;"
+                          >
+                            <span
+                              class="pf-v5-c-icon"
+                            >
+                              <span
+                                class="pf-v5-c-icon__content pf-m-danger"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 512 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                  />
+                                </svg>
+                              </span>
+                            </span>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item"
+                            style="padding-right: 16px;"
+                          >
+                            <span
+                              style="color: rgb(201, 25, 11);"
+                            >
+                              Alert
+                            </span>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item"
+                            color="#A30000"
+                          >
+                            Your system has 3 inhibitors out of 5 potential problems.
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      aria-label=""
+                      class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                      data-ouia-component-id="OUIA-Generated-TableRow-52"
+                      data-ouia-component-type="PF5/TableRow"
+                      data-ouia-safe="true"
+                      hidden=""
+                    >
+                      <td
+                        class="pf-v5-c-table__td"
+                        colspan="4"
+                        data-key="0"
+                        id="expanded-content8"
+                        tabindex="-1"
+                      >
+                        <div>
+                          <table
+                            class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                            data-ouia-component-id="OUIA-Generated-Table-11"
+                            data-ouia-component-type="PF5/Table"
+                            data-ouia-safe="true"
+                            role="grid"
+                            style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                          >
+                            <tbody
+                              class="pf-v5-c-table__tbody"
+                              role="rowgroup"
+                            >
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-53"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node0 expand-toggle0"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-30"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle0"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-danger"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(163, 0, 0);"
+                                    >
+                                      <strong>
+                                        Leapp could not identify where GRUB core is located
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-54"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-red pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          High risk
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    Leapp could not identify where GRUB core is located
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Remediation
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        ca7a1a66906a7df3da890aa538562708d3ea6ecd
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-55"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node1 expand-toggle1"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-31"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle1"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-danger"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(163, 0, 0);"
+                                    >
+                                      <strong>
+                                        Firewalld Configuration AllowZoneDrifting Is Unsupported
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-56"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-red pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          High risk
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    Firewalld Configuration AllowZoneDrifting Is Unsupported
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        Firewalld has enabled configuration option "AllowZoneDrifiting" which has been removed in RHEL-9. New behavior is as if "AllowZoneDrifiting" was set to "no".
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Remediation
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            [hint] Set AllowZoneDrifting=no in /etc/firewalld/firewalld.conf
+                                          </span>
+                                        </div>
+                                        <div>
+                                          <span>
+                                            <br />
+                                          </span>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            [command] sed -i "s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/" /etc/firewalld/firewalld.conf
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        5b1cf050e1a877b0358b6e8c612277c591d40c13
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-57"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node2 expand-toggle2"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-32"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle2"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-danger"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(163, 0, 0);"
+                                    >
+                                      <strong>
+                                        VDO devices migration to LVM management
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-58"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-red pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          High risk
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    VDO devices migration to LVM management
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        VDO devices 'vda, vda1, vda2' require migration to LVM management.After performing the upgrade VDO devices can only be managed via LVM. Any VDO device not currently managed by LVM must be converted to LVM management before upgrading. The data on any VDO device not converted to LVM management will be inaccessible after upgrading.
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Remediation
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            [hint] Consult the VDO to LVM conversion process documentation for how to perform the conversion.
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        f7c335398cc449f5d7baf4e73255d44c34ad2620
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-59"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node3 expand-toggle3"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-33"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle3"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-warning"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 576 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(121, 80, 0);"
+                                    >
+                                      <strong>
+                                        SElinux will be set to permissive mode
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-60"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 576 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          Low risk
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    SElinux will be set to permissive mode
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Remediation
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        <div>
+                                          <span
+                                            class="remediations-font-family"
+                                          >
+                                            [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr"
+                                data-ouia-component-id="OUIA-Generated-TableRow-61"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                              >
+                                <td
+                                  class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                  tabindex="-1"
+                                >
+                                  <button
+                                    aria-disabled="false"
+                                    aria-expanded="false"
+                                    aria-label="Details"
+                                    aria-labelledby="simple-node4 expand-toggle4"
+                                    class="pf-v5-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-34"
+                                    data-ouia-component-type="PF5/Button"
+                                    data-ouia-safe="true"
+                                    id="expand-toggle4"
+                                    type="button"
+                                  >
+                                    <div
+                                      class="pf-v5-c-table__toggle-icon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </button>
+                                </td>
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <span>
+                                    <span
+                                      class="pf-v5-c-icon"
+                                      style="margin-right: 8px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-icon__content pf-m-info"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span
+                                      style="color: rgb(0, 41, 82);"
+                                    >
+                                      <strong>
+                                        SElinux relabeling will be scheduled
+                                      </strong>
+                                    </span>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr
+                                aria-label=""
+                                class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                                data-ouia-component-id="OUIA-Generated-TableRow-62"
+                                data-ouia-component-type="PF5/TableRow"
+                                data-ouia-safe="true"
+                                hidden=""
+                              >
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                />
+                                <td
+                                  class="pf-v5-c-table__td"
+                                  tabindex="-1"
+                                >
+                                  <div>
+                                    <span
+                                      class="pf-v5-c-label pf-m-blue pf-m-compact"
+                                      style="margin-top: 16px; margin-bottom: 4px;"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__content"
+                                      >
+                                        <span
+                                          class="pf-v5-c-label__icon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="pf-v5-svg"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            viewBox="0 0 512 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          class="pf-v5-c-label__text"
+                                        >
+                                          Info
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="entry-title"
+                                  >
+                                    SElinux relabeling will be scheduled
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Summary
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        SElinux relabeling will be scheduled as the status is permissive/enforcing.
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                    >
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                      >
+                                        Key
+                                      </div>
+                                      <div
+                                        class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                        l="6"
+                                        m="7"
+                                        style="white-space: pre-line;"
+                                      >
+                                        8fb81863f8413bd617c2a55b69b8e10ff03d7c72
+                                      </div>
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div
+                  class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
+                  data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-3"
+                  data-ouia-component-type="RHI/TableToolbar"
+                  data-ouia-safe="true"
+                  id="pf-random-id-5"
+                >
+                  <div
+                    class="pf-v5-c-toolbar__content"
                   >
                     <div
-                      class="pf-v5-c-pagination__nav-control pf-m-first"
+                      class="pf-v5-c-toolbar__content-section"
                     >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to first page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="first"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-35"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
+                      <div
+                        class="pf-v5-c-toolbar__item pf-m-align-self-center"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 448 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to previous page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="previous"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-36"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
+                        <div>
+                          <div
+                            style="display: contents;"
+                          >
+                            <div
+                              class="pf-v5-c-content"
+                            >
+                              <small
+                                class=""
+                                data-ouia-component-id="OUIA-Generated-Text-6"
+                                data-ouia-component-type="PF5/Text"
+                                data-ouia-safe="true"
+                                data-pf-content="true"
+                              >
+                                Last updated: All jobs completed
+                              </small>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-page-select"
-                    >
-                      <span
-                        class="pf-v5-c-form-control pf-m-disabled"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-label="Current page"
-                          data-ouia-component-id="OUIA-Generated-TextInputBase-6"
-                          data-ouia-component-type="PF5/TextInput"
+                        <div
+                          class="pf-v5-c-pagination pf-m-bottom"
+                          data-ouia-component-id="OUIA-Generated-Pagination-bottom-3"
+                          data-ouia-component-type="PF5/Pagination"
                           data-ouia-safe="true"
-                          disabled=""
-                          max="1"
-                          min="1"
-                          type="number"
-                          value="1"
-                        />
-                      </span>
-                      <span
-                        aria-hidden="true"
-                      >
-                        of 1
-                      </span>
-                    </div>
-                    <div
-                      class="pf-v5-c-pagination__nav-control"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to next page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="next"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-37"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 256 512"
-                          width="1em"
+                          id="options-menu-bottom-pagination"
+                          style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                         >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </button>
+                          <div>
+                            <button
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                              id="options-menu-bottom-toggle"
+                              type="button"
+                            >
+                              <span
+                                class="pf-v5-c-menu-toggle__text"
+                              >
+                                <b>
+                                  1 - 6
+                                </b>
+                                 of 
+                                <b>
+                                  6
+                                </b>
+                                 
+                              </span>
+                              <span
+                                class="pf-v5-c-menu-toggle__controls"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                          <nav
+                            aria-label="Pagination"
+                            class="pf-v5-c-pagination__nav"
+                          >
+                            <div
+                              class="pf-v5-c-pagination__nav-control pf-m-first"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to first page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="first"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-35"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 448 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to previous page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="previous"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-36"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 256 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-page-select"
+                            >
+                              <span
+                                class="pf-v5-c-form-control pf-m-disabled"
+                              >
+                                <input
+                                  aria-invalid="false"
+                                  aria-label="Current page"
+                                  data-ouia-component-id="OUIA-Generated-TextInputBase-6"
+                                  data-ouia-component-type="PF5/TextInput"
+                                  data-ouia-safe="true"
+                                  disabled=""
+                                  max="1"
+                                  min="1"
+                                  type="number"
+                                  value="1"
+                                />
+                              </span>
+                              <span
+                                aria-hidden="true"
+                              >
+                                of 1
+                              </span>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-control"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to next page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="next"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-37"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 256 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <div
+                              class="pf-v5-c-pagination__nav-control pf-m-last"
+                            >
+                              <button
+                                aria-disabled="true"
+                                aria-label="Go to last page"
+                                class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                                data-action="last"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-38"
+                                data-ouia-component-type="PF5/Button"
+                                data-ouia-safe="true"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 448 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </nav>
+                        </div>
+                      </div>
                     </div>
+                  </div>
+                  <div
+                    class="pf-v5-c-toolbar__content pf-m-hidden"
+                    hidden=""
+                  >
                     <div
-                      class="pf-v5-c-pagination__nav-control pf-m-last"
-                    >
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to last page"
-                        class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                        data-action="last"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-38"
-                        data-ouia-component-type="PF5/Button"
-                        data-ouia-safe="true"
-                        disabled=""
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v5-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 448 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </nav>
+                      class="pf-v5-c-toolbar__group"
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-          </div>
-          <div
-            class="pf-v5-c-toolbar__content pf-m-hidden"
-            hidden=""
-          >
-            <div
-              class="pf-v5-c-toolbar__group"
-            />
+            </section>
           </div>
         </div>
+        <div
+          class="pf-v5-c-drawer__panel pf-m-resizable"
+          hidden=""
+          id="end-resize-panel"
+          style="--pf-v5-c-drawer__panel--md--FlexBasis: 1000px; --pf-v5-c-drawer__panel--md--FlexBasis--min: 500px;"
+        />
       </div>
-    </section>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,6 +25,8 @@ export const TASKS_API_ROOT = '/api/tasks/v1';
 export const AVAILABLE_TASKS_ROOT = '/task';
 export const EXECUTED_TASK_ROOT = '/executed_task';
 export const SYSTEMS_ROOT = '/system';
+export const JOB_ROOT = '/job';
+export const LOG_ROOT = '/stdout';
 export const INSIGHTS_DOCUMENTATION =
   'https://access.redhat.com/documentation/en-us/red_hat_insights/';
 export const DOC_VERSION = '1-latest/html/';


### PR DESCRIPTION
When a task has completed, that task may have a job or series of jobs that have logs. This PR adds the ability for a user to view these logs in the UI.

A "View logs" link should appear when a job (system) is expanded and that job has logs. When the link is clicked, a drawer with a log viewer component is displayed. That log viewer has the ability to search, export as a file, and open the log in a new tab.

For now, we are adding the "View log" link in the expanded details of the job. In the next iteration, we will be adding the "View logs" action to a kebab in the table next to the job. For now, let's test the link.

Finding a task with logs may be difficult, but if you run this on prod.foo and sign into the insights-qa account, you can go to `/insights/tasks/executed/10753` and view a task with logs.