### PR TITLE
fix(RHINENG-7780): Change alert title and text in SystemsSelect

### DIFF
--- a/src/SmartComponents/RunTaskModal/SystemsSelect.js
+++ b/src/SmartComponents/RunTaskModal/SystemsSelect.js
@@ -101,11 +101,10 @@ const SystemsSelect = ({
         <b>Systems to run tasks on</b>
       </div>
       {warningConstants[warningConstantMapper]}
-      <Alert
-        variant="info"
-        isInline
-        title={filterMessage || INFO_ALERT_SYSTEMS}
-      />
+      <Alert variant="info" isInline title="Only eligible systems are shown">
+        {filterMessage || INFO_ALERT_SYSTEMS}
+      </Alert>
+
       <SystemTable
         bulkSelectIds={bulkSelectIds}
         selectedIds={selectedIds}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-7780.

This adds an extra title to all tasks alerts that notify about the systems eligible for a specific task according to mocks.