### PR TITLE
fix(RHINENG-8314): Rename action buttons

### DIFF
--- a/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
+++ b/src/PresentationalComponents/ExecuteTaskButton/ExecuteTaskButton.js
@@ -40,7 +40,7 @@ const ExecuteTaskButton = ({
       onClick={() => submitTask()}
       isDisabled={isDisabled}
     >
-      Execute task
+      Run task
     </Button>
   );
 };

--- a/src/PresentationalComponents/ExecuteTaskButton/__tests__/__snapshots__/ExecuteTaskButton.tests.js.snap
+++ b/src/PresentationalComponents/ExecuteTaskButton/__tests__/__snapshots__/ExecuteTaskButton.tests.js.snap
@@ -11,7 +11,7 @@ exports[`ExecuteTaskButton should render correctly 1`] = `
     data-ouia-safe="true"
     type="button"
   >
-    Execute task
+    Run task
   </button>
 </DocumentFragment>
 `;

--- a/src/PresentationalComponents/RunTaskButton/RunTaskButton.js
+++ b/src/PresentationalComponents/RunTaskButton/RunTaskButton.js
@@ -16,7 +16,7 @@ const RunTaskButton = ({
       variant={variant}
       onClick={() => openTaskModal(true, slug)}
     >
-      {isFirst ? 'Run task' : 'Run task again'}
+      {isFirst ? 'Select systems' : 'Run task again'}
     </Button>
   );
 };

--- a/src/PresentationalComponents/RunTaskButton/__tests__/__snapshots__/RunTaskButton.tests.js.snap
+++ b/src/PresentationalComponents/RunTaskButton/__tests__/__snapshots__/RunTaskButton.tests.js.snap
@@ -27,7 +27,7 @@ exports[`RunTaskButton should render correctly 1`] = `
     data-ouia-safe="true"
     type="button"
   >
-    Run task
+    Select systems
   </button>
 </DocumentFragment>
 `;


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-8314.

A quick PR to slightly rename the button names. On the tasks list page, "Run tasks" -> "Select systems", in the select systems modal, "Execute task" -> "Run task".