### PR TITLE
feat(RHINENG-8308): Make task cards expandable

### DIFF
--- a/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
+++ b/src/SmartComponents/AvailableTasks/AvailableTasksTable.js
@@ -1,32 +1,15 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import {
-  Card,
-  CardBody,
-  CardFooter,
-  CardTitle,
-  Flex,
-  FlexItem,
-} from '@patternfly/react-core';
-import RunTaskButton from '../../PresentationalComponents/RunTaskButton/RunTaskButton';
 import EmptyStateDisplay from '../../PresentationalComponents/EmptyStateDisplay/EmptyStateDisplay';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import {
-  AVAILABLE_TASKS_ROOT,
-  CONVERSION_SLUG,
   EMPTY_TASKS_MESSAGE,
   EMPTY_TASKS_TITLE,
-  TASKS_API_ROOT,
   TASKS_ERROR,
 } from '../../constants';
-import ReactMarkdown from 'react-markdown';
-import { QuickstartButton, SLUG_TO_QUICKSTART } from './QuickstartButton';
+import { TaskCard } from './TaskCard';
 
 const AvailableTasksTable = ({ availableTasks, error, openTaskModal }) => {
-  const scriptOrPlaybook = (slug) => {
-    return slug.includes(CONVERSION_SLUG) ? 'script' : 'playbook';
-  };
-
   return (
     <div aria-label="available-tasks-table">
       {error ? (
@@ -43,43 +26,9 @@ const AvailableTasksTable = ({ availableTasks, error, openTaskModal }) => {
           text={EMPTY_TASKS_MESSAGE}
         />
       ) : (
-        availableTasks?.map((task) => {
-          return (
-            <div aria-label={task.title} key={task.title}>
-              <Card>
-                <CardTitle>{task.title}</CardTitle>
-                <CardBody className="card-task-description">
-                  <Flex direction={{ default: 'column' }}>
-                    <FlexItem>
-                      <ReactMarkdown>{task.description}</ReactMarkdown>
-                    </FlexItem>
-                    <FlexItem>
-                      <a
-                        href={`${TASKS_API_ROOT}${AVAILABLE_TASKS_ROOT}/${task.slug}/playbook`}
-                      >
-                        {`Download preview of ${scriptOrPlaybook(task.slug)}`}
-                      </a>
-                    </FlexItem>
-                  </Flex>
-                </CardBody>
-                <CardFooter>
-                  <Flex>
-                    <RunTaskButton
-                      slug={task.slug}
-                      isFirst
-                      variant="primary"
-                      openTaskModal={openTaskModal}
-                    />
-                    {Object.keys(SLUG_TO_QUICKSTART).includes(task.slug) && (
-                      <QuickstartButton slug={task.slug} />
-                    )}
-                  </Flex>
-                </CardFooter>
-              </Card>
-              <br />
-            </div>
-          );
-        })
+        availableTasks?.map((task, index) => (
+          <TaskCard task={task} key={index} openTaskModal={openTaskModal} />
+        ))
       )}
     </div>
   );

--- a/src/SmartComponents/AvailableTasks/TaskCard.js
+++ b/src/SmartComponents/AvailableTasks/TaskCard.js
@@ -1,0 +1,86 @@
+import {
+  Card,
+  CardBody,
+  CardExpandableContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import React, { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import {
+  AVAILABLE_TASKS_ROOT,
+  CONVERSION_SLUG,
+  TASKS_API_ROOT,
+} from '../../constants';
+import RunTaskButton from '../../PresentationalComponents/RunTaskButton/RunTaskButton';
+import { QuickstartButton, SLUG_TO_QUICKSTART } from './QuickstartButton';
+import PropTypes from 'prop-types';
+
+const scriptOrPlaybook = (slug) => {
+  return slug.includes(CONVERSION_SLUG) ? 'script' : 'playbook';
+};
+
+const TaskCard = ({ task, openTaskModal }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div aria-label={task.title} key={task.title}>
+      <Card isExpanded={isExpanded}>
+        <CardHeader
+          onExpand={() => setIsExpanded(!isExpanded)}
+          toggleButtonProps={{
+            'data-ouia-component-id': `Expand ${task.title} description`,
+            'aria-label': `Expand ${task.title} description`,
+            'aria-expanded': isExpanded,
+          }}
+        >
+          <CardTitle>{task.title}</CardTitle>
+        </CardHeader>
+        <CardExpandableContent>
+          <CardBody className="card-task-description">
+            <Flex direction={{ default: 'column' }}>
+              <FlexItem>
+                <ReactMarkdown>{task.description}</ReactMarkdown>
+              </FlexItem>
+              <FlexItem>
+                <a
+                  href={`${TASKS_API_ROOT}${AVAILABLE_TASKS_ROOT}/${task.slug}/playbook`}
+                >
+                  {`Download preview of ${scriptOrPlaybook(task.slug)}`}
+                </a>
+              </FlexItem>
+            </Flex>
+          </CardBody>
+        </CardExpandableContent>
+        <CardFooter>
+          <Flex>
+            <RunTaskButton
+              slug={task.slug}
+              isFirst
+              variant="primary"
+              openTaskModal={openTaskModal}
+            />
+            {Object.keys(SLUG_TO_QUICKSTART).includes(task.slug) && (
+              <QuickstartButton slug={task.slug} />
+            )}
+          </Flex>
+        </CardFooter>
+      </Card>
+      <br />
+    </div>
+  );
+};
+
+TaskCard.propTypes = {
+  task: PropTypes.shape({
+    slug: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+  }).isRequired,
+  openTaskModal: PropTypes.func.isRequired,
+};
+
+export { TaskCard };

--- a/src/SmartComponents/AvailableTasks/__tests__/AvailableTasks.tests.js
+++ b/src/SmartComponents/AvailableTasks/__tests__/AvailableTasks.tests.js
@@ -37,7 +37,9 @@ describe('AvailableTasks', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByLabelText('available-tasks')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText('available-tasks')).toBeInTheDocument();
+    });
   });
 
   it('should fetch api data and build table', async () => {

--- a/src/SmartComponents/AvailableTasks/__tests__/AvailableTasksTable.tests.js
+++ b/src/SmartComponents/AvailableTasks/__tests__/AvailableTasksTable.tests.js
@@ -34,8 +34,8 @@ describe('AvailableTasksTable', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByLabelText('available-tasks-table')).toBeInTheDocument();
-    expect(screen.getByLabelText('empty-state')).toBeInTheDocument();
+    expect(screen.getByLabelText('available-tasks-table')).toBeVisible();
+    expect(screen.getByLabelText('empty-state')).toBeVisible();
   });
 
   it('should build table', () => {
@@ -47,8 +47,8 @@ describe('AvailableTasksTable', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByLabelText('available-tasks-table')).toBeInTheDocument();
-    expect(screen.getByLabelText('taska-run-task-button')).toBeInTheDocument();
+    expect(screen.getByLabelText('available-tasks-table')).toBeVisible();
+    expect(screen.getByLabelText('taska-run-task-button')).toBeVisible();
   });
 
   it('should show quickstart button for known slug', () => {
@@ -80,6 +80,6 @@ describe('AvailableTasksTable', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByLabelText('error-empty-state')).toBeInTheDocument();
+    expect(screen.getByLabelText('error-empty-state')).toBeVisible();
   });
 });

--- a/src/SmartComponents/AvailableTasks/__tests__/TaskCard.test.js
+++ b/src/SmartComponents/AvailableTasks/__tests__/TaskCard.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { TaskCard } from '../TaskCard';
+import userEvent from '@testing-library/user-event';
+
+describe('TaskCard', () => {
+  const mockedTask = {
+    title: 'Task title',
+    slug: 'foo-bar-task',
+    description: 'Task description',
+  };
+  const openTaskModalMocked = jest.fn();
+
+  it('renders simple task', () => {
+    render(<TaskCard task={mockedTask} openTaskModal={openTaskModalMocked} />);
+
+    expect(screen.getByText(/task title/i)).toBeVisible();
+    expect(
+      screen.getByRole('button', {
+        name: /foo-bar-task-run-task-button/i,
+      })
+    ).toBeVisible();
+    expect(screen.queryByText(/task description/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
+        name: /download preview of playbook/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('can expand the card', async () => {
+    render(<TaskCard task={mockedTask} openTaskModal={openTaskModalMocked} />);
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /expand task title description/i,
+      })
+    );
+
+    expect(screen.getByText(/task description/i)).toBeVisible();
+    expect(
+      screen.getByRole('link', {
+        name: /download preview of playbook/i,
+      })
+    ).toBeVisible();
+  });
+
+  it('calls select systems callback', async () => {
+    render(<TaskCard task={mockedTask} openTaskModal={openTaskModalMocked} />);
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /foo-bar-task-run-task-button/i,
+      })
+    );
+
+    await waitFor(() => {
+      expect(openTaskModalMocked).toBeCalled();
+    });
+  });
+});


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-8308.

This makes the task cards on the main page expandable hiding description and playbook download link by default. This also slightly improves the tests for the related components.

## How to test

Go to the available tasks list and make sure the cards are expandable.

## Screenshots

<img width="1287" alt="Screenshot 2024-03-25 at 13 18 49" src="https://github.com/RedHatInsights/tasks-frontend/assets/31385370/59995d7c-df30-4e26-ab95-0bace8654c19">
