### PR TITLE
feat(RHINENG-8945): Add new empty state for conversion tasks

### DIFF
--- a/src/PresentationalComponents/EmptyStateDisplay/EmptyStateDisplay.js
+++ b/src/PresentationalComponents/EmptyStateDisplay/EmptyStateDisplay.js
@@ -17,11 +17,13 @@ export const EmptyStateDisplay = ({
   isSmall,
   text,
   title,
+  ouiaId,
 }) => {
   return (
     <EmptyState
       variant={isSmall ? EmptyStateVariant.sm : EmptyStateVariant.lg}
       aria-label={error ? 'error-empty-state' : 'empty-state'}
+      {...(ouiaId !== undefined ? { 'data-ouia-component-id': ouiaId } : {})}
     >
       {icon ? (
         <EmptyStateIcon
@@ -30,7 +32,6 @@ export const EmptyStateDisplay = ({
           className={isSmall ? 'small-empty-state-icon' : null}
         />
       ) : null}
-      <br></br>
       <EmptyStateHeader
         titleText={title}
         headingLevel={isSmall ? 'h5' : 'h1'}
@@ -59,6 +60,7 @@ EmptyStateDisplay.propTypes = {
   isSmall: PropTypes.bool,
   text: PropTypes.array,
   title: PropTypes.string,
+  ouiaId: PropTypes.string,
 };
 
 export default EmptyStateDisplay;

--- a/src/SmartComponents/AvailableTasks/QuickstartButton.js
+++ b/src/SmartComponents/AvailableTasks/QuickstartButton.js
@@ -14,6 +14,13 @@ export const SLUG_TO_QUICKSTART = {
   'leapp-preupgrade': 'leapp-quickstart',
 };
 
+export const CENTOS_CONVERSION_SLUGS = [
+  'convert-to-rhel-preanalysis-stage',
+  'convert-to-rhel-preanalysis',
+  'convert-to-rhel-conversion-stage',
+  'convert-to-rhel-conversion',
+];
+
 export const QUICKSTART_TO_FEATURE_FLAG = {
   'pre-conversion-quickstart':
     'tasks-frontend_pre-conversion-quickstart-active',

--- a/src/SmartComponents/SystemTable/NoCentOsEmptyState.js
+++ b/src/SmartComponents/SystemTable/NoCentOsEmptyState.js
@@ -1,0 +1,62 @@
+import { Button, EmptyStateActions } from '@patternfly/react-core';
+import { AddCircleOIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import PropTypes from 'prop-types';
+import React from 'react';
+import EmptyStateDisplay from '../../PresentationalComponents/EmptyStateDisplay/EmptyStateDisplay';
+import useFeatureFlag from '../../Utilities/useFeatureFlag';
+import {
+  QUICKSTART_TO_FEATURE_FLAG,
+  SLUG_TO_QUICKSTART,
+} from '../AvailableTasks/QuickstartButton';
+
+const NoCentOsEmptyState = ({ slug }) => {
+  const quickstartName = SLUG_TO_QUICKSTART[slug];
+  const featureFlagName = QUICKSTART_TO_FEATURE_FLAG[quickstartName];
+
+  const { quickStarts } = useChrome();
+  const quickStartEnabled = useFeatureFlag(featureFlagName);
+
+  return (
+    <EmptyStateDisplay
+      icon={AddCircleOIcon}
+      title="No CentOS systems found"
+      ouiaId="NoCentOSEmptyState"
+      text={[
+        'You currently have no CentOS systems registered to this account. Get started by installing the client tools on your CentOS machines to view them in Insights',
+      ]}
+      button={
+        <>
+          {quickStartEnabled ? (
+            <EmptyStateActions>
+              <Button
+                variant="primary"
+                onClick={() => quickStarts.activateQuickstart(quickstartName)}
+              >
+                Help me get started
+              </Button>
+            </EmptyStateActions>
+          ) : null}
+          <EmptyStateActions>
+            <Button
+              variant="link"
+              icon={<ExternalLinkAltIcon />}
+              iconPosition="end"
+              component="a"
+              href="https://access.redhat.com/documentation/en-us/red_hat_insights/1-latest/html/converting_from_an_rpm-based_linux_distribution_to_rhel_using_red_hat_insights/proc_preparing-for-a-rhel-conversion-using-insights_converting-from-a-linux-distribution-to-rhel-in-insights"
+              target="_blank"
+            >
+              Learn more about connecting CentOS systems to Insights
+            </Button>
+          </EmptyStateActions>
+        </>
+      }
+    />
+  );
+};
+
+NoCentOsEmptyState.propTypes = {
+  slug: PropTypes.string.isRequired,
+};
+
+export { NoCentOsEmptyState };

--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -19,6 +19,8 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { generateFilter } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import usePromiseQueue from '../../Utilities/hooks/usePromiseQueue';
+import { NoCentOsEmptyState } from './NoCentOsEmptyState';
+import { CENTOS_CONVERSION_SLUGS } from '../AvailableTasks/QuickstartButton';
 
 const SystemTable = ({
   bulkSelectIds,
@@ -213,6 +215,9 @@ const SystemTable = ({
       showCentosVersions={true}
       filterConfig={{ items: [eligibilityFilter] }}
       activeFiltersConfig={activeFiltersConfig}
+      {...(CENTOS_CONVERSION_SLUGS.includes(slug)
+        ? { noSystemsTable: <NoCentOsEmptyState slug={slug} /> }
+        : {})}
     />
   );
 };

--- a/src/SmartComponents/SystemTable/__tests__/SystemTable.tests.js
+++ b/src/SmartComponents/SystemTable/__tests__/SystemTable.tests.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 
 import SystemTable from '../SystemTable';
+import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 
 jest.mock('../hooks', () => {
   const systemsMock = [
@@ -37,22 +37,63 @@ jest.mock('../hooks', () => {
 
 describe('SystemTable', () => {
   let mockStore = configureStore();
-  let props;
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('should render correctly', () => {
-    const store = mockStore(props);
     const { asFragment } = render(
-      <MemoryRouter keyLength={0}>
-        <Provider store={store}>
-          <SystemTable selectedIds={[]} />
-        </Provider>
-      </MemoryRouter>
+      <Provider store={mockStore()}>
+        <SystemTable selectedIds={[]} />
+      </Provider>
     );
 
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should replace empty state for conversion task', () => {
+    render(
+      <Provider store={mockStore()}>
+        <SystemTable selectedIds={[]} slug="convert-to-rhel-conversion" />
+      </Provider>
+    );
+
+    expect(InventoryTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        noSystemsTable: expect.anything(),
+      }),
+      expect.anything() // ref
+    );
+  });
+
+  it('should replace empty state for pre-conversion task', () => {
+    render(
+      <Provider store={mockStore()}>
+        <SystemTable selectedIds={[]} slug="convert-to-rhel-preanalysis" />
+      </Provider>
+    );
+
+    expect(InventoryTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        noSystemsTable: expect.anything(),
+      }),
+      expect.anything() // ref
+    );
+  });
+
+  it('should render default empty state for other tasks', () => {
+    render(
+      <Provider store={mockStore()}>
+        <SystemTable selectedIds={[]} slug="abc" />
+      </Provider>
+    );
+
+    expect(InventoryTable).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        noSystemsTable: expect.anything(),
+      }),
+      expect.anything() // ref
+    );
   });
 });


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-8945.

This adds special empty state for conversion and pre-conversion tasks explicitly telling that there are no CentOS systems registered in account. Other tasks must not be affected.

The primary button must open a quickstart content. If the content (= feature flag for this quickstart is off) is not available, the button is hidden. The secondary link opens a documentation page.

## How to test

Log into account without any CentOS systems registered. Navigate to conversion or pre-conversion task. Make sure you see the updated empty state.

## Screenshots

<img width="1276" alt="Screenshot 2024-03-27 at 13 23 07" src="https://github.com/RedHatInsights/tasks-frontend/assets/31385370/d011b8f7-b08a-446a-b39d-7903c03b06d5">
