### PR TITLE
fix(RHINENG-9145): Display empty state banner if task has no jobs

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -30,6 +30,8 @@ import {
   LOADING_JOBS_TABLE,
   TASK_ERROR,
   TASKS_TABLE_DEFAULTS,
+  EMPTY_EXECUTED_TASK_JOBS_TITLE,
+  EMPTY_EXECUTED_TASK_JOBS_MESSAGE,
 } from '../../constants';
 import FlexibleFlex from '../../PresentationalComponents/FlexibleFlex/FlexibleFlex';
 import EmptyStateDisplay from '../../PresentationalComponents/EmptyStateDisplay/EmptyStateDisplay';
@@ -96,9 +98,9 @@ const CompletedTaskDetails = () => {
         } else {
           setIsRunning(false);
         }
-        await setCompletedTaskDetails(fetchedTaskDetails);
-        await setCompletedTaskJobs(fetchedTaskJobs);
       }
+      await setCompletedTaskDetails(fetchedTaskDetails);
+      await setCompletedTaskJobs(fetchedTaskJobs);
     }
     setTableLoading(false);
   };
@@ -284,38 +286,47 @@ const CompletedTaskDetails = () => {
             <br />
             <Card>
               {!isLoading && hasAccess ? (
-                <TasksTables
-                  label={`${completedTaskDetails.id}-completed-jobs`}
-                  ouiaId={`${completedTaskDetails.id}-completed-jobs-table`}
-                  columns={isConversionTask() ? conversionColumns : columns}
-                  items={completedTaskJobs}
-                  filters={buildFilterConfig()}
-                  options={{
-                    ...TASKS_TABLE_DEFAULTS,
-                    exportable: {
-                      ...TASKS_TABLE_DEFAULTS.exportable,
-                      columns: isConversionTask()
-                        ? conversionColumns
-                        : exportableColumns,
-                    },
-                    detailsComponent: completedTaskJobs.some((job) =>
-                      hasDetails(job)
-                    )
-                      ? JobResultsRow
-                      : undefined,
-                    actionResolver,
-                  }}
-                  emptyRows={emptyRows('jobs')}
-                  isStickyHeader
-                  isTableLoading={tableLoading}
-                  footerContent={
-                    <RefreshFooterContent
-                      date={lastUpdated}
-                      isRunning={isRunning}
-                      type="jobs"
-                    />
-                  }
-                />
+                completedTaskJobs?.length === 0 ? (
+                  <EmptyStateDisplay
+                    icon={ExclamationCircleIcon}
+                    color="#a30000"
+                    title={EMPTY_EXECUTED_TASK_JOBS_TITLE}
+                    text={EMPTY_EXECUTED_TASK_JOBS_MESSAGE}
+                  />
+                ) : (
+                  <TasksTables
+                    label={`${completedTaskDetails.id}-completed-jobs`}
+                    ouiaId={`${completedTaskDetails.id}-completed-jobs-table`}
+                    columns={isConversionTask() ? conversionColumns : columns}
+                    items={completedTaskJobs}
+                    filters={buildFilterConfig()}
+                    options={{
+                      ...TASKS_TABLE_DEFAULTS,
+                      exportable: {
+                        ...TASKS_TABLE_DEFAULTS.exportable,
+                        columns: isConversionTask()
+                          ? conversionColumns
+                          : exportableColumns,
+                      },
+                      detailsComponent: completedTaskJobs.some((job) =>
+                        hasDetails(job)
+                      )
+                        ? JobResultsRow
+                        : undefined,
+                      actionResolver,
+                    }}
+                    emptyRows={emptyRows('jobs')}
+                    isStickyHeader
+                    isTableLoading={tableLoading}
+                    footerContent={
+                      <RefreshFooterContent
+                        date={lastUpdated}
+                        isRunning={isRunning}
+                        type="jobs"
+                      />
+                    }
+                  />
+                )
               ) : (
                 <NotAuthorized serviceName="Inventory" />
               )}

--- a/src/constants.js
+++ b/src/constants.js
@@ -60,6 +60,13 @@ export const EMPTY_COMPLETED_TASKS_MESSAGE = [
   '',
   'To use a task, navigate to the "Available tasks" tab and choose a task to run.',
 ];
+export const EMPTY_EXECUTED_TASK_JOBS_TITLE =
+  'No Jobs were created for this task';
+export const EMPTY_EXECUTED_TASK_JOBS_MESSAGE = [
+  'No jobs could run on the selected systems because they are no longer connected.',
+  '',
+  'Ensure the systems are connected and try the task again. If the problem persists, please contact Red Hat Support.',
+];
 export const INFO_ALERT_SYSTEMS =
   'Eligible systems include systems connected to console.redhat.com with rhc, or Satellite with Cloud Connector.';
 


### PR DESCRIPTION
Before this PR, if a task has no jobs (which shouldn't occur, but does occasionally) the tasks table appears to continually load forever:
![Screenshot from 2024-04-05 17-41-53](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/1489127a-2df2-4531-bc51-e6ed63491053)


After the PR, an empty state banner is displayed:
![Screenshot from 2024-04-05 17-11-03](https://github.com/RedHatInsights/tasks-frontend/assets/4008744/3cf480ea-b704-4be6-90b8-547f94c846cb)
