### PR TITLE
fix(RHINENG-3779): Prevent empty custom task name

### DIFF
--- a/src/SmartComponents/RunTaskModal/RunTaskModal.js
+++ b/src/SmartComponents/RunTaskModal/RunTaskModal.js
@@ -21,7 +21,7 @@ const RunTaskModal = ({
   filterMessage = '',
 }) => {
   const [selectedIds, setSelectedIds] = useState(selectedSystems);
-  const [taskName, setTaskName] = useState(name);
+  const [taskName, setTaskName] = useState(name ?? title);
   const [executeTaskResult, setExecuteTaskResult] = useState();
   const [createTaskError, setCreateTaskError] = useState({});
   const [areSystemsSelected, setAreSystemsSelected] = useState(false);
@@ -36,14 +36,6 @@ const RunTaskModal = ({
   useEffect(() => {
     setSelectedIds(selectedSystems);
   }, [selectedSystems]);
-
-  useEffect(() => {
-    if (name) {
-      setTaskName(name);
-    } else {
-      setTaskName(title);
-    }
-  }, [title, name]);
 
   useEffect(() => {
     if (parameters) {
@@ -90,7 +82,6 @@ const RunTaskModal = ({
 
   const cancelModal = () => {
     setSelectedIds([]);
-    setTaskName(name || title);
     setModalOpened(false);
   };
 

--- a/src/SmartComponents/RunTaskModal/SystemsSelect.js
+++ b/src/SmartComponents/RunTaskModal/SystemsSelect.js
@@ -58,6 +58,16 @@ const SystemsSelect = ({
     }
   }, [createTaskError]);
 
+  useEffect(() => {
+    if (taskName.trim().length === 0) {
+      setHelperText('Task name cannot be empty');
+      setValidated('error');
+    } else if (validated === 'error') {
+      setHelperText(null);
+      setValidated('default');
+    }
+  }, [taskName]);
+
   const { bulkSelectIds, selectIds } = useSystemBulkSelect(
     selectedIds,
     setSelectedIds,
@@ -98,6 +108,7 @@ const SystemsSelect = ({
             type="text"
             onChange={handleSetTaskName}
             aria-label="Edit task name text field"
+            validated={validated}
           />
           <FormHelperText>
             <HelperText>

--- a/src/SmartComponents/RunTaskModal/SystemsSelect.js
+++ b/src/SmartComponents/RunTaskModal/SystemsSelect.js
@@ -23,7 +23,7 @@ import {
 import ReactMarkdown from 'react-markdown';
 import warningConstants from '../warningConstants';
 import { useSystemBulkSelect } from './hooks/useBulkSystemSelect';
-import { DownloadIcon } from '@patternfly/react-icons';
+import { DownloadIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import {
   QuickstartButton,
   SLUG_TO_QUICKSTART,
@@ -112,7 +112,14 @@ const SystemsSelect = ({
           />
           <FormHelperText>
             <HelperText>
-              <HelperTextItem variant={validated}>{helperText}</HelperTextItem>
+              <HelperTextItem
+                variant={validated}
+                {...(validated === 'error' && {
+                  icon: <ExclamationCircleIcon />,
+                })}
+              >
+                {helperText}
+              </HelperTextItem>
             </HelperText>
           </FormHelperText>
         </FormGroup>

--- a/src/SmartComponents/RunTaskModal/__tests__/RunTaskModal.tests.js
+++ b/src/SmartComponents/RunTaskModal/__tests__/RunTaskModal.tests.js
@@ -71,7 +71,7 @@ describe('RunTaskModal', () => {
 
     expect(
       screen.getByRole('button', {
-        name: /taska\-submit\-task\-button/i,
+        name: /taska-submit-task-button/i,
       })
     ).toBeDisabled();
   });
@@ -95,7 +95,7 @@ describe('RunTaskModal', () => {
     await userEvent.type(input, 'Task A');
     expect(
       screen.getByRole('button', {
-        name: /taska\-submit\-task\-button/i,
+        name: /taska-submit-task-button/i,
       })
     ).toBeDisabled();
 
@@ -107,7 +107,7 @@ describe('RunTaskModal', () => {
     );
     expect(
       screen.getByRole('button', {
-        name: /taska\-submit\-task\-button/i,
+        name: /taska-submit-task-button/i,
       })
     ).toBeEnabled();
   });

--- a/src/SmartComponents/RunTaskModal/__tests__/RunTaskModal.tests.js
+++ b/src/SmartComponents/RunTaskModal/__tests__/RunTaskModal.tests.js
@@ -57,33 +57,85 @@ describe('RunTaskModal', () => {
     };
   });
 
-  it.skip('should render execute button disabled with no name or systems selected', async () => {
+  it('should render run task button first disabled', () => {
     fetchSystems.mockImplementation(async () => {
       return {
         response: systemsMock,
       };
     });
-
     render(
       <Provider store={store}>
         <RunTaskModal {...props} />
       </Provider>
     );
 
-    const executeButton = screen.getByLabelText('taska-submit-task-button');
-    expect(executeButton).toBeDisabled();
+    expect(
+      screen.getByRole('button', {
+        name: /taska\-submit\-task\-button/i,
+      })
+    ).toBeDisabled();
+  });
+
+  it('should enable run task button', async () => {
+    fetchSystems.mockImplementation(async () => {
+      return {
+        response: systemsMock,
+      };
+    });
+    const { rerender } = render(
+      <Provider store={store}>
+        <RunTaskModal {...props} />
+      </Provider>
+    );
 
     // add name, button should still be disabled
-    const input = screen.getByLabelText('task name');
-    await waitFor(() =>
-      fireEvent.change(input, { target: { value: 'Task A' } })
-    );
-    expect(executeButton).toBeDisabled();
+    const input = screen.getByRole('textbox', {
+      name: /edit task name text field/i,
+    });
+    await userEvent.type(input, 'Task A');
+    expect(
+      screen.getByRole('button', {
+        name: /taska\-submit\-task\-button/i,
+      })
+    ).toBeDisabled();
 
     // add selected Systems, button should be enabled
-    const checkbox = screen.getByLabelText('Select row 0');
-    await waitFor(() => userEvent.click(checkbox));
-    expect(executeButton).toBeEnabled();
+    rerender(
+      <Provider store={store}>
+        <RunTaskModal {...props} selectedSystems={['123']} />
+      </Provider>
+    );
+    expect(
+      screen.getByRole('button', {
+        name: /taska\-submit\-task\-button/i,
+      })
+    ).toBeEnabled();
+  });
+
+  it('should disable task on empty task name', async () => {
+    fetchSystems.mockImplementation(async () => {
+      return {
+        response: systemsMock,
+      };
+    });
+    render(
+      <Provider store={store}>
+        <RunTaskModal {...props} />
+      </Provider>
+    );
+
+    await userEvent.type(
+      screen.getByRole('textbox', {
+        name: /edit task name text field/i,
+      }),
+      ''
+    );
+    screen.getByText(/task name cannot be empty/i);
+    expect(
+      screen.getByRole('textbox', {
+        name: /edit task name text field/i,
+      })
+    ).toBeInvalid();
   });
 
   it('should close modal with "X" button', async () => {

--- a/src/SmartComponents/RunTaskModal/hooks/useModalActions.js
+++ b/src/SmartComponents/RunTaskModal/hooks/useModalActions.js
@@ -14,7 +14,7 @@ export const useModalActions = (
   definedParameters
 ) => {
   const checkForSystemsAndTaskName = () => {
-    return !selectedIds?.length || !taskName.length;
+    return !selectedIds?.length || !taskName.trim().length;
   };
 
   const nextButton = parameters?.length && !areSystemsSelected && (


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-3779.

This ensures users cannot run a task with an empty task name field.

## How to test

Go to /tasks/available, open any task. Empty the task name field or put any number of whitespace characters. The field should indicate invalid input and disable "Run task" button.

## Screenshots

<img width="756" alt="Screenshot 2024-05-13 at 11 01 04" src="https://github.com/RedHatInsights/tasks-frontend/assets/31385370/77f5106a-b5ed-4d9c-a927-543032895576">
