### PR TITLE
refactor: Refactor RunTaskModal children components

### DIFF
--- a/src/SmartComponents/RunTaskModal/RunTaskModalBody.js
+++ b/src/SmartComponents/RunTaskModal/RunTaskModalBody.js
@@ -3,8 +3,12 @@ import propTypes from 'prop-types';
 import SystemsSelect from './SystemsSelect';
 import InputParameters from './InputParameters';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { TASK_ERROR } from '../../constants';
+import { INFO_ALERT_SYSTEMS, TASK_ERROR } from '../../constants';
 import EmptyStateDisplay from '../../PresentationalComponents/EmptyStateDisplay/EmptyStateDisplay';
+import { TaskDescription } from './TaskDescription';
+import { TaskName } from './TaskName';
+import { Alert, Flex } from '@patternfly/react-core';
+import warningConstants from '../warningConstants';
 
 const RunTaskModalBody = ({
   areSystemsSelected,
@@ -20,6 +24,10 @@ const RunTaskModalBody = ({
   taskName,
   filterMessage,
 }) => {
+  const warningConstantMapper = `${slug
+    ?.toUpperCase()
+    .replace(/-/g, '_')}_WARNING`;
+
   return error ? (
     <EmptyStateDisplay
       icon={ExclamationCircleIcon}
@@ -29,16 +37,28 @@ const RunTaskModalBody = ({
       error={`Error ${error?.response?.status}: ${error?.message}`}
     />
   ) : !areSystemsSelected ? (
-    <SystemsSelect
-      createTaskError={createTaskError}
-      description={description}
-      selectedIds={selectedIds}
-      setSelectedIds={setSelectedIds}
-      setTaskName={setTaskName}
-      slug={slug}
-      taskName={taskName}
-      filterMessage={filterMessage}
-    />
+    <Flex
+      direction={{ default: 'column' }}
+      spaceItems={{ default: 'spaceItemsLg' }}
+    >
+      <TaskDescription slug={slug} description={description} />
+      <TaskName
+        taskName={taskName}
+        setTaskName={setTaskName}
+        createTaskError={createTaskError}
+      />
+      <div id="task-warnings-and-alerts" aria-label="Task warnings and alerts">
+        {warningConstants[warningConstantMapper]}
+        <Alert variant="info" isInline title="Only eligible systems are shown">
+          {filterMessage || INFO_ALERT_SYSTEMS}
+        </Alert>
+      </div>
+      <SystemsSelect
+        selectedIds={selectedIds}
+        setSelectedIds={setSelectedIds}
+        slug={slug}
+      />
+    </Flex>
   ) : (
     <InputParameters
       parameters={parameters}

--- a/src/SmartComponents/RunTaskModal/SystemsSelect.js
+++ b/src/SmartComponents/RunTaskModal/SystemsSelect.js
@@ -1,72 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import { Title } from '@patternfly/react-core';
 import propTypes from 'prop-types';
-import {
-  Alert,
-  Button,
-  Flex,
-  Form,
-  FormGroup,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
-  Text,
-  TextContent,
-  TextInput,
-  Title,
-} from '@patternfly/react-core';
+import React, { useState } from 'react';
 import SystemTable from '../SystemTable/SystemTable';
-import {
-  AVAILABLE_TASKS_ROOT,
-  INFO_ALERT_SYSTEMS,
-  TASKS_API_ROOT,
-} from '../../constants';
-import ReactMarkdown from 'react-markdown';
-import warningConstants from '../warningConstants';
 import { useSystemBulkSelect } from './hooks/useBulkSystemSelect';
-import { DownloadIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
-import {
-  QuickstartButton,
-  SLUG_TO_QUICKSTART,
-} from '../AvailableTasks/QuickstartButton';
 
-const SystemsSelect = ({
-  createTaskError,
-  description,
-  selectedIds,
-  setSelectedIds,
-  setTaskName,
-  slug,
-  taskName,
-  filterMessage,
-}) => {
-  const warningConstantMapper = `${slug
-    ?.toUpperCase()
-    .replace(/-/g, '_')}_WARNING`;
-
+const SystemsSelect = ({ selectedIds, setSelectedIds, slug }) => {
   const [filterSortString, setFilterSortString] = useState('');
-  const [validated, setValidated] = useState('default');
-  const [helperText, setHelperText] = useState(null);
-
-  const handleSetTaskName = (_event, name) => {
-    setTaskName(name);
-  };
-
-  useEffect(() => {
-    if (createTaskError.status) {
-      setHelperText(createTaskError.statusText);
-      setValidated('error');
-    }
-  }, [createTaskError]);
-
-  useEffect(() => {
-    if (taskName.trim().length === 0) {
-      setHelperText('Task name cannot be empty');
-      setValidated('error');
-    } else if (validated === 'error') {
-      setHelperText(null);
-      setValidated('default');
-    }
-  }, [taskName]);
 
   const { bulkSelectIds, selectIds } = useSystemBulkSelect(
     selectedIds,
@@ -76,60 +15,7 @@ const SystemsSelect = ({
   );
 
   return (
-    <Flex
-      direction={{ default: 'column' }}
-      spaceItems={{ default: 'spaceItemsLg' }}
-    >
-      <TextContent>
-        <Text component="h4">Task description</Text>
-        <Text>
-          <ReactMarkdown>{description}</ReactMarkdown>
-        </Text>
-        <Text>
-          <Button
-            variant="link"
-            component="a"
-            href={`${TASKS_API_ROOT}${AVAILABLE_TASKS_ROOT}/${slug}/playbook`}
-            icon={<DownloadIcon />}
-            iconPosition="end"
-            isInline
-          >
-            Download preview of playbook
-          </Button>
-          {Object.keys(SLUG_TO_QUICKSTART).includes(slug) && (
-            <QuickstartButton slug={slug} />
-          )}
-        </Text>
-      </TextContent>
-      <Form>
-        <FormGroup label="Task name" isRequired type="text" fieldId="name">
-          <TextInput
-            value={taskName}
-            type="text"
-            onChange={handleSetTaskName}
-            aria-label="Edit task name text field"
-            validated={validated}
-          />
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem
-                variant={validated}
-                {...(validated === 'error' && {
-                  icon: <ExclamationCircleIcon />,
-                })}
-              >
-                {helperText}
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        </FormGroup>
-      </Form>
-      <div id="task-warnings-and-alerts" aria-label="Task warnings and alerts">
-        {warningConstants[warningConstantMapper]}
-        <Alert variant="info" isInline title="Only eligible systems are shown">
-          {filterMessage || INFO_ALERT_SYSTEMS}
-        </Alert>
-      </div>
+    <>
       <Title headingLevel="h4">Systems to run tasks on</Title>
       <SystemTable
         bulkSelectIds={bulkSelectIds}
@@ -138,19 +24,14 @@ const SystemsSelect = ({
         setFilterSortString={setFilterSortString}
         slug={slug}
       />
-    </Flex>
+    </>
   );
 };
 
 SystemsSelect.propTypes = {
-  createTaskError: propTypes.object,
-  description: propTypes.any,
   selectedIds: propTypes.array,
   setSelectedIds: propTypes.func,
-  setTaskName: propTypes.func,
   slug: propTypes.string,
-  taskName: propTypes.string,
-  filterMessage: propTypes.string,
 };
 
 export default SystemsSelect;

--- a/src/SmartComponents/RunTaskModal/TaskDescription.js
+++ b/src/SmartComponents/RunTaskModal/TaskDescription.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Button, Text, TextContent } from '@patternfly/react-core';
+import ReactMarkdown from 'react-markdown';
+import { AVAILABLE_TASKS_ROOT, TASKS_API_ROOT } from '../../constants';
+import { DownloadIcon } from '@patternfly/react-icons';
+import {
+  QuickstartButton,
+  SLUG_TO_QUICKSTART,
+} from '../AvailableTasks/QuickstartButton';
+
+const TaskDescription = ({ description, slug }) => {
+  return (
+    <TextContent>
+      <Text component="h4">Task description</Text>
+      <Text>
+        <ReactMarkdown>{description}</ReactMarkdown>
+      </Text>
+      <Text>
+        <Button
+          variant="link"
+          component="a"
+          href={`${TASKS_API_ROOT}${AVAILABLE_TASKS_ROOT}/${slug}/playbook`}
+          icon={<DownloadIcon />}
+          iconPosition="end"
+          isInline
+        >
+          Download preview of playbook
+        </Button>
+        {Object.keys(SLUG_TO_QUICKSTART).includes(slug) && (
+          <QuickstartButton slug={slug} />
+        )}
+      </Text>
+    </TextContent>
+  );
+};
+
+TaskDescription.propTypes = {
+  description: propTypes.string,
+  slug: propTypes.string,
+};
+
+export { TaskDescription };

--- a/src/SmartComponents/RunTaskModal/TaskName.js
+++ b/src/SmartComponents/RunTaskModal/TaskName.js
@@ -1,0 +1,74 @@
+import {
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import propTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+
+const TaskName = ({ taskName, setTaskName, createTaskError }) => {
+  const [validated, setValidated] = useState('default');
+  const [helperText, setHelperText] = useState(null);
+
+  const handleSetTaskName = (_event, name) => {
+    setTaskName(name);
+  };
+
+  useEffect(() => {
+    if (createTaskError.status) {
+      setHelperText(createTaskError.statusText);
+      setValidated('error');
+    }
+  }, [createTaskError]);
+
+  useEffect(() => {
+    if (taskName.trim().length === 0) {
+      setHelperText('Task name cannot be empty');
+      setValidated('error');
+    } else if (validated === 'error') {
+      setValidated('default');
+      setHelperText(null);
+    }
+  }, [taskName]);
+
+  return (
+    <Form>
+      <FormGroup label="Task name" isRequired type="text" fieldId="name">
+        <TextInput
+          value={taskName}
+          type="text"
+          onChange={handleSetTaskName}
+          aria-label="Edit task name text field"
+          validated={validated}
+        />
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem
+              variant={validated}
+              {...(validated === 'error' && {
+                icon: <ExclamationCircleIcon />,
+              })}
+            >
+              {helperText}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+    </Form>
+  );
+};
+
+TaskName.propTypes = {
+  createTaskError: propTypes.shape({
+    status: propTypes.any,
+    statusText: propTypes.string,
+  }),
+  taskName: propTypes.string,
+  setTaskName: propTypes.func,
+};
+
+export { TaskName };

--- a/src/SmartComponents/RunTaskModal/__tests__/TaskDescription.test.js
+++ b/src/SmartComponents/RunTaskModal/__tests__/TaskDescription.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TaskDescription } from '../TaskDescription';
+
+jest.mock('../../../Utilities/useFeatureFlag', () => () => true);
+
+describe('TaskDescription', () => {
+  it('renders description', () => {
+    render(
+      <TaskDescription
+        description="Test description"
+        slug="convert-to-rhel-conversion"
+      />
+    );
+
+    screen.getByText(/test description/i);
+  });
+
+  it('shows quickstart button for known slug', () => {
+    render(
+      <TaskDescription
+        description="Test description"
+        slug="convert-to-rhel-conversion"
+      />
+    );
+
+    screen.getByRole('button', {
+      name: /help me get started/i,
+    });
+  });
+
+  it('does not show quickstart button for other slugs', () => {
+    render(<TaskDescription description="Test description" slug="123" />);
+
+    expect(
+      screen.queryByRole('button', {
+        name: /help me get started/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows playbook preview download button', () => {
+    render(<TaskDescription description="Test description" slug="123" />);
+
+    expect(
+      screen.getByRole('link', {
+        name: /download preview of playbook/i,
+      })
+    ).toHaveAttribute('href', '/api/tasks/v1/task/123/playbook');
+  });
+});

--- a/src/SmartComponents/RunTaskModal/__tests__/TaskName.test.js
+++ b/src/SmartComponents/RunTaskModal/__tests__/TaskName.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { TaskName } from '../TaskName';
+
+describe('TaskName', () => {
+  it('renders initial task name', () => {
+    render(<TaskName taskName="Initial task name" createTaskError={{}} />);
+
+    expect(
+      screen.getByRole('textbox', {
+        name: /edit task name text field/i,
+      })
+    ).toHaveValue('Initial task name');
+  });
+
+  it('calls callback on name change', async () => {
+    const setTaskNameMock = jest.fn();
+
+    render(
+      <TaskName
+        taskName="Initial task name"
+        setTaskName={setTaskNameMock}
+        createTaskError={{}}
+      />
+    );
+
+    await userEvent.type(
+      screen.getByRole('textbox', {
+        name: /edit task name text field/i,
+      }),
+      'A'
+    );
+
+    expect(setTaskNameMock).toBeCalledWith('Initial task nameA');
+  });
+
+  it('shows alert on empty name', () => {
+    render(<TaskName taskName="" createTaskError={{}} />);
+
+    screen.getByText(/task name cannot be empty/i);
+  });
+});


### PR DESCRIPTION
No jira.

This aims to split SystemsSelect component into smaller components (TaskName, TaskDescription), that would have their own separated state and business logic.

## How to test

The modal should work as before the PR. The tests must pass.