### PR TITLE
feat(RHINENG-3781): Include report and report_json in the extended CSV/JSON report

### DIFF
--- a/src/SmartComponents/ActivityTable/__tests__/ActivityTable.tests.js
+++ b/src/SmartComponents/ActivityTable/__tests__/ActivityTable.tests.js
@@ -68,6 +68,8 @@ describe('ActivityTable', () => {
   });
 
   it('should export', async () => {
+    global.URL.createObjectURL = jest.fn();
+
     fetchExecutedTasks.mockImplementation(async () => {
       return activityTableItems;
     });
@@ -87,6 +89,8 @@ describe('ActivityTable', () => {
     await waitFor(() => userEvent.click(screen.getByLabelText('Export')));
     await waitFor(() => userEvent.click(screen.getByText('Export to CSV')));
     expect(notification).toHaveBeenCalled();
+
+    global.URL.createObjectURL.mockRestore();
   });
 
   it('should add name filter', async () => {

--- a/src/SmartComponents/CompletedTaskDetails/Columns.js
+++ b/src/SmartComponents/CompletedTaskDetails/Columns.js
@@ -108,8 +108,7 @@ export const conversionColumns = [
   ConversionStatusColumn,
   MessageColumn,
 ];
-export const reportColumns = [
-  ReportColumn,
+export const extendedReportColumns = [
   IssueTitleColumn,
   IssueSeverityColumn,
   IssueKeyColumn,

--- a/src/SmartComponents/CompletedTaskDetails/Columns.js
+++ b/src/SmartComponents/CompletedTaskDetails/Columns.js
@@ -63,42 +63,42 @@ export const MessageColumn = {
 
 export const ReportColumn = {
   title: 'Report',
-  renderExport: (job) => job?.results?.report || '',
+  renderExport: (job) => job.results?.report || '',
 };
 
 export const IssueTitleColumn = {
   title: 'Issue title',
-  renderExport: (job) => job?.issue_parsed?.title || '',
+  renderExport: (job) => job.issue_parsed.title,
 };
 
 export const IssueSeverityColumn = {
   title: 'Issue severity',
-  renderExport: (job) => job?.issue_parsed?.severity || '',
+  renderExport: (job) => job.issue_parsed.severity,
 };
 
 export const IssueKeyColumn = {
   title: 'Issue key',
-  renderExport: (job) => job?.issue_parsed?.key || '',
+  renderExport: (job) => job.issue_parsed.key,
 };
 
 export const IssueSummaryColumn = {
   title: 'Issue summary',
-  renderExport: (job) => job?.issue_parsed?.summary || '',
+  renderExport: (job) => job.issue_parsed.summary,
 };
 
 export const IssueDiagnosisColumn = {
   title: 'Issue diagnosis',
-  renderExport: (job) => job?.issue_parsed?.diagnosis || '',
+  renderExport: (job) => job.issue_parsed.diagnosis,
 };
 
 export const IssueRemediationTypeColumn = {
   title: 'Issue remediation type',
-  renderExport: (job) => job?.issue_parsed?.remediationType || '',
+  renderExport: (job) => job.issue_parsed.remediationType,
 };
 
 export const IssueRemediationColumn = {
   title: 'Issue remediation',
-  renderExport: (job) => job?.issue_parsed?.remediationContext || '',
+  renderExport: (job) => job.issue_parsed.remediationContext,
 };
 
 export const exportableColumns = [SystemColumn, StatusColumn, MessageColumn];

--- a/src/SmartComponents/CompletedTaskDetails/Columns.js
+++ b/src/SmartComponents/CompletedTaskDetails/Columns.js
@@ -69,37 +69,37 @@ export const ReportColumn = {
 
 export const IssueTitleColumn = {
   title: 'Issue title',
-  renderExport: (job) => get(job, 'issue_parsed[0]', ''),
+  renderExport: (job) => get(job, 'issue_parsed.title', ''),
 };
 
 export const IssueSeverityColumn = {
   title: 'Issue severity',
-  renderExport: (job) => get(job, 'issue_parsed[1]', ''),
+  renderExport: (job) => get(job, 'issue_parsed.severity', ''),
 };
 
 export const IssueKeyColumn = {
   title: 'Issue key',
-  renderExport: (job) => get(job, 'issue_parsed[2]', ''),
+  renderExport: (job) => get(job, 'issue_parsed.key', ''),
 };
 
 export const IssueSummaryColumn = {
   title: 'Issue summary',
-  renderExport: (job) => get(job, 'issue_parsed[3]', ''),
+  renderExport: (job) => get(job, 'issue_parsed.summary', ''),
 };
 
 export const IssueDiagnosisColumn = {
   title: 'Issue diagnosis',
-  renderExport: (job) => get(job, 'issue_parsed[4]', ''),
+  renderExport: (job) => get(job, 'issue_parsed.diagnosis', ''),
 };
 
 export const IssueRemediationTypeColumn = {
   title: 'Issue remediation type',
-  renderExport: (job) => get(job, 'issue_parsed[5]', ''),
+  renderExport: (job) => get(job, 'issue_parsed.remediationType', ''),
 };
 
 export const IssueRemediationColumn = {
   title: 'Issue remediation',
-  renderExport: (job) => get(job, 'issue_parsed[6]', ''),
+  renderExport: (job) => get(job, 'issue_parsed.remediationContext', ''),
 };
 
 export const exportableColumns = [SystemColumn, StatusColumn, MessageColumn];

--- a/src/SmartComponents/CompletedTaskDetails/Columns.js
+++ b/src/SmartComponents/CompletedTaskDetails/Columns.js
@@ -2,7 +2,6 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { renderColumnComponent } from '../../Utilities/helpers';
 import SplitMessages from '../../PresentationalComponents/SplitMessages/SplitMessages';
-import get from 'lodash/get';
 
 const SystemNameCell = ({ display_name }) => {
   if (display_name) {
@@ -64,42 +63,42 @@ export const MessageColumn = {
 
 export const ReportColumn = {
   title: 'Report',
-  renderExport: (job) => get(job, 'results.report', ''),
+  renderExport: (job) => job?.results?.report || '',
 };
 
 export const IssueTitleColumn = {
   title: 'Issue title',
-  renderExport: (job) => get(job, 'issue_parsed.title', ''),
+  renderExport: (job) => job?.issue_parsed?.title || '',
 };
 
 export const IssueSeverityColumn = {
   title: 'Issue severity',
-  renderExport: (job) => get(job, 'issue_parsed.severity', ''),
+  renderExport: (job) => job?.issue_parsed?.severity || '',
 };
 
 export const IssueKeyColumn = {
   title: 'Issue key',
-  renderExport: (job) => get(job, 'issue_parsed.key', ''),
+  renderExport: (job) => job?.issue_parsed?.key || '',
 };
 
 export const IssueSummaryColumn = {
   title: 'Issue summary',
-  renderExport: (job) => get(job, 'issue_parsed.summary', ''),
+  renderExport: (job) => job?.issue_parsed?.summary || '',
 };
 
 export const IssueDiagnosisColumn = {
   title: 'Issue diagnosis',
-  renderExport: (job) => get(job, 'issue_parsed.diagnosis', ''),
+  renderExport: (job) => job?.issue_parsed?.diagnosis || '',
 };
 
 export const IssueRemediationTypeColumn = {
   title: 'Issue remediation type',
-  renderExport: (job) => get(job, 'issue_parsed.remediationType', ''),
+  renderExport: (job) => job?.issue_parsed?.remediationType || '',
 };
 
 export const IssueRemediationColumn = {
   title: 'Issue remediation',
-  renderExport: (job) => get(job, 'issue_parsed.remediationContext', ''),
+  renderExport: (job) => job?.issue_parsed?.remediationContext || '',
 };
 
 export const exportableColumns = [SystemColumn, StatusColumn, MessageColumn];

--- a/src/SmartComponents/CompletedTaskDetails/Columns.js
+++ b/src/SmartComponents/CompletedTaskDetails/Columns.js
@@ -2,6 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { renderColumnComponent } from '../../Utilities/helpers';
 import SplitMessages from '../../PresentationalComponents/SplitMessages/SplitMessages';
+import get from 'lodash/get';
 
 const SystemNameCell = ({ display_name }) => {
   if (display_name) {
@@ -61,11 +62,61 @@ export const MessageColumn = {
   ),
 };
 
+export const ReportColumn = {
+  title: 'Report',
+  renderExport: (job) => get(job, 'results.report', ''),
+};
+
+export const IssueTitleColumn = {
+  title: 'Issue title',
+  renderExport: (job) => get(job, 'issue_parsed[0]', ''),
+};
+
+export const IssueSeverityColumn = {
+  title: 'Issue severity',
+  renderExport: (job) => get(job, 'issue_parsed[1]', ''),
+};
+
+export const IssueKeyColumn = {
+  title: 'Issue key',
+  renderExport: (job) => get(job, 'issue_parsed[2]', ''),
+};
+
+export const IssueSummaryColumn = {
+  title: 'Issue summary',
+  renderExport: (job) => get(job, 'issue_parsed[3]', ''),
+};
+
+export const IssueDiagnosisColumn = {
+  title: 'Issue diagnosis',
+  renderExport: (job) => get(job, 'issue_parsed[4]', ''),
+};
+
+export const IssueRemediationTypeColumn = {
+  title: 'Issue remediation type',
+  renderExport: (job) => get(job, 'issue_parsed[5]', ''),
+};
+
+export const IssueRemediationColumn = {
+  title: 'Issue remediation',
+  renderExport: (job) => get(job, 'issue_parsed[6]', ''),
+};
+
 export const exportableColumns = [SystemColumn, StatusColumn, MessageColumn];
 export const conversionColumns = [
   SystemColumn,
   ConversionStatusColumn,
   MessageColumn,
+];
+export const reportColumns = [
+  ReportColumn,
+  IssueTitleColumn,
+  IssueSeverityColumn,
+  IssueKeyColumn,
+  IssueSummaryColumn,
+  IssueDiagnosisColumn,
+  IssueRemediationTypeColumn,
+  IssueRemediationColumn,
 ];
 
 export default [SystemColumn, StatusColumn, MessageColumn];

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -18,7 +18,11 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import columns, { conversionColumns, exportableColumns } from './Columns';
+import columns, {
+  conversionColumns,
+  exportableColumns,
+  reportColumns,
+} from './Columns';
 import { buildStatusFilter, systemFilter } from './Filters';
 import {
   COMPLETED_INFO_PANEL,
@@ -56,6 +60,7 @@ import { useInterval } from '../../Utilities/hooks/useTableTools/useInterval';
 import ParameterDetails from './ParameterDetails';
 import JobLogDrawer from './JobResultsDetails/JobLogDrawer';
 import useActionResolver from './hooks/useActionResolver';
+import { prepareItems } from '../../Utilities/hooks/useTableTools/reportParser';
 
 const CompletedTaskDetails = () => {
   const { id } = useParams();
@@ -159,6 +164,15 @@ const CompletedTaskDetails = () => {
         );
       },
     [completedTaskJobs]
+  );
+
+  const hasReportJson = useMemo(
+    () =>
+      !tableLoading &&
+      completedTaskJobs.some(
+        (job) => job.results?.report_json?.entries !== undefined
+      ),
+    [completedTaskJobs, tableLoading]
   );
 
   const isConversionTask = () => {
@@ -307,6 +321,9 @@ const CompletedTaskDetails = () => {
                         columns: isConversionTask()
                           ? conversionColumns
                           : exportableColumns,
+                        ...(hasReportJson
+                          ? { prepareItems, extraExportColumns: reportColumns }
+                          : {}),
                       },
                       detailsComponent: completedTaskJobs.some((job) =>
                         hasDetails(job)

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -21,7 +21,8 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import columns, {
   conversionColumns,
   exportableColumns,
-  reportColumns,
+  ReportColumn,
+  extendedReportColumns,
 } from './Columns';
 import { buildStatusFilter, systemFilter } from './Filters';
 import {
@@ -175,6 +176,13 @@ const CompletedTaskDetails = () => {
     [completedTaskJobs, tableLoading]
   );
 
+  const hasPlainReport = useMemo(
+    () =>
+      !tableLoading &&
+      completedTaskJobs.some((job) => job.results?.report !== undefined),
+    [completedTaskJobs, tableLoading]
+  );
+
   const isConversionTask = () => {
     return (
       completedTaskDetails.task_slug ===
@@ -321,9 +329,11 @@ const CompletedTaskDetails = () => {
                         columns: isConversionTask()
                           ? conversionColumns
                           : exportableColumns,
-                        ...(hasReportJson
-                          ? { prepareItems, extraExportColumns: reportColumns }
-                          : {}),
+                        extraExportColumns: [
+                          ...(hasPlainReport ? [ReportColumn] : []),
+                          ...(hasReportJson ? extendedReportColumns : []),
+                        ],
+                        ...(hasReportJson ? { prepareItems } : {}), // report json can generate more records for one item
                       },
                       detailsComponent: completedTaskJobs.some((job) =>
                         hasDetails(job)

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/CompletedTaskDetails.tests.js
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/CompletedTaskDetails.tests.js
@@ -259,6 +259,8 @@ describe('CompletedTaskDetails', () => {
   });
 
   it('should export as CSV', async () => {
+    global.URL.createObjectURL = jest.fn();
+
     fetchExecutedTask.mockImplementation(async () => {
       return log4j_task;
     });
@@ -284,6 +286,8 @@ describe('CompletedTaskDetails', () => {
       await waitFor(() => userEvent.click(screen.getByText('Export to CSV')));
       expect(notification).toHaveBeenCalled();
     });
+
+    global.URL.createObjectURL.mockRestore();
   });
 
   it('should open log drawer', async () => {

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -4609,6 +4609,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         role="rowgroup"
                       >
                         <tr
+                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-37"
                           data-ouia-component-type="PF5/TableRow"
@@ -4722,6 +4723,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         role="rowgroup"
                       >
                         <tr
+                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-38"
                           data-ouia-component-type="PF5/TableRow"
@@ -4835,6 +4837,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         role="rowgroup"
                       >
                         <tr
+                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-39"
                           data-ouia-component-type="PF5/TableRow"
@@ -4910,6 +4913,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         role="rowgroup"
                       >
                         <tr
+                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-40"
                           data-ouia-component-type="PF5/TableRow"
@@ -5013,6 +5017,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                           </td>
                         </tr>
                         <tr
+                          aria-label=""
                           class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                           data-ouia-component-id="OUIA-Generated-TableRow-41"
                           data-ouia-component-type="PF5/TableRow"
@@ -5040,6 +5045,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                   role="rowgroup"
                                 >
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-42"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5118,6 +5124,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-43"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5232,6 +5239,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-44"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5310,6 +5318,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-45"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5424,6 +5433,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-46"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5502,6 +5512,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-47"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5616,6 +5627,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-48"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5694,6 +5706,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-49"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5801,6 +5814,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         role="rowgroup"
                       >
                         <tr
+                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-50"
                           data-ouia-component-type="PF5/TableRow"
@@ -5904,6 +5918,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                           </td>
                         </tr>
                         <tr
+                          aria-label=""
                           class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                           data-ouia-component-id="OUIA-Generated-TableRow-51"
                           data-ouia-component-type="PF5/TableRow"
@@ -5987,6 +6002,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                         role="rowgroup"
                       >
                         <tr
+                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-52"
                           data-ouia-component-type="PF5/TableRow"
@@ -6090,6 +6106,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                           </td>
                         </tr>
                         <tr
+                          aria-label=""
                           class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                           data-ouia-component-id="OUIA-Generated-TableRow-53"
                           data-ouia-component-type="PF5/TableRow"
@@ -6117,6 +6134,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                   role="rowgroup"
                                 >
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-54"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6195,6 +6213,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-55"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6309,6 +6328,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-56"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6387,6 +6407,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-57"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6511,6 +6532,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-58"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6589,6 +6611,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-59"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6703,6 +6726,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-60"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6781,6 +6805,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-61"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6895,6 +6920,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-62"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6973,6 +6999,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
+                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-63"
                                     data-ouia-component-type="PF5/TableRow"

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -4609,7 +4609,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         role="rowgroup"
                       >
                         <tr
-                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-37"
                           data-ouia-component-type="PF5/TableRow"
@@ -4723,7 +4722,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         role="rowgroup"
                       >
                         <tr
-                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-38"
                           data-ouia-component-type="PF5/TableRow"
@@ -4837,7 +4835,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         role="rowgroup"
                       >
                         <tr
-                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-39"
                           data-ouia-component-type="PF5/TableRow"
@@ -4913,7 +4910,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         role="rowgroup"
                       >
                         <tr
-                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-40"
                           data-ouia-component-type="PF5/TableRow"
@@ -5017,7 +5013,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                           </td>
                         </tr>
                         <tr
-                          aria-label=""
                           class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                           data-ouia-component-id="OUIA-Generated-TableRow-41"
                           data-ouia-component-type="PF5/TableRow"
@@ -5045,7 +5040,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                   role="rowgroup"
                                 >
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-42"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5124,7 +5118,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-43"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5239,7 +5232,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-44"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5318,7 +5310,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-45"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5433,7 +5424,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-46"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5512,7 +5502,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-47"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5627,7 +5616,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-48"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5706,7 +5694,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-49"
                                     data-ouia-component-type="PF5/TableRow"
@@ -5814,7 +5801,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                         role="rowgroup"
                       >
                         <tr
-                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-50"
                           data-ouia-component-type="PF5/TableRow"
@@ -5918,7 +5904,6 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                           </td>
                         </tr>
                         <tr
-                          aria-label=""
                           class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                           data-ouia-component-id="OUIA-Generated-TableRow-51"
                           data-ouia-component-type="PF5/TableRow"
@@ -6002,7 +5987,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                         role="rowgroup"
                       >
                         <tr
-                          aria-label=""
                           class="pf-v5-c-table__tr"
                           data-ouia-component-id="OUIA-Generated-TableRow-52"
                           data-ouia-component-type="PF5/TableRow"
@@ -6106,7 +6090,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                           </td>
                         </tr>
                         <tr
-                          aria-label=""
                           class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                           data-ouia-component-id="OUIA-Generated-TableRow-53"
                           data-ouia-component-type="PF5/TableRow"
@@ -6134,7 +6117,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                   role="rowgroup"
                                 >
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-54"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6213,7 +6195,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-55"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6328,7 +6309,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-56"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6407,7 +6387,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-57"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6532,7 +6511,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-58"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6611,7 +6589,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-59"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6726,7 +6703,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-60"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6805,7 +6781,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-61"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6920,7 +6895,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr"
                                     data-ouia-component-id="OUIA-Generated-TableRow-62"
                                     data-ouia-component-type="PF5/TableRow"
@@ -6999,7 +6973,6 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                     </td>
                                   </tr>
                                   <tr
-                                    aria-label=""
                                     class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
                                     data-ouia-component-id="OUIA-Generated-TableRow-63"
                                     data-ouia-component-type="PF5/TableRow"

--- a/src/Utilities/__tests__/__snapshots__/helpers.tests.js.snap
+++ b/src/Utilities/__tests__/__snapshots__/helpers.tests.js.snap
@@ -31,15 +31,11 @@ exports[`orderArrayByProp sorts an array by numbers asc 1`] = `
     "task_title": "taskB",
   },
   {
-    "end_time": "2022-04-28T11:10:00",
-    "id": 3,
-    "initiated_by": "Michael",
-    "run_date_time": "25 Apr 2022, 11:10 UTC",
-    "start_time": "2022-04-25T10:10:00",
-    "status": "Completed",
-    "systems_count": 3,
-    "task_slug": "taskc",
-    "task_title": "taskC",
+    "start_time": "2022-04
+57
+hehe","break!",
+    "systems_count": 42,
+    "task_title": "special one",
   },
 ]
 `;
@@ -69,15 +65,11 @@ exports[`orderArrayByProp sorts an array by numbers desc 1`] = `
     "task_title": "taskB",
   },
   {
-    "end_time": "2022-04-28T11:10:00",
-    "id": 3,
-    "initiated_by": "Michael",
-    "run_date_time": "25 Apr 2022, 11:10 UTC",
-    "start_time": "2022-04-25T10:10:00",
-    "status": "Completed",
-    "systems_count": 3,
-    "task_slug": "taskc",
-    "task_title": "taskC",
+    "start_time": "2022-04
+57
+hehe","break!",
+    "systems_count": 42,
+    "task_title": "special one",
   },
 ]
 `;
@@ -107,15 +99,11 @@ exports[`orderArrayByProp sorts an array by string asc 1`] = `
     "task_title": "taskB",
   },
   {
-    "end_time": "2022-04-28T11:10:00",
-    "id": 3,
-    "initiated_by": "Michael",
-    "run_date_time": "25 Apr 2022, 11:10 UTC",
-    "start_time": "2022-04-25T10:10:00",
-    "status": "Completed",
-    "systems_count": 3,
-    "task_slug": "taskc",
-    "task_title": "taskC",
+    "start_time": "2022-04
+57
+hehe","break!",
+    "systems_count": 42,
+    "task_title": "special one",
   },
 ]
 `;
@@ -145,15 +133,11 @@ exports[`orderArrayByProp sorts an array by string desc 1`] = `
     "task_title": "taskB",
   },
   {
-    "end_time": "2022-04-28T11:10:00",
-    "id": 3,
-    "initiated_by": "Michael",
-    "run_date_time": "25 Apr 2022, 11:10 UTC",
-    "start_time": "2022-04-25T10:10:00",
-    "status": "Completed",
-    "systems_count": 3,
-    "task_slug": "taskc",
-    "task_title": "taskC",
+    "start_time": "2022-04
+57
+hehe","break!",
+    "systems_count": 42,
+    "task_title": "special one",
   },
 ]
 `;

--- a/src/Utilities/__tests__/__snapshots__/helpers.tests.js.snap
+++ b/src/Utilities/__tests__/__snapshots__/helpers.tests.js.snap
@@ -37,6 +37,14 @@ hehe","break!",
     "systems_count": 42,
     "task_title": "special one",
   },
+  {
+    "start_time": [
+      42,
+      "abc",
+    ],
+    "systems_count": 10,
+    "task_title": "another one with unexpected array",
+  },
 ]
 `;
 
@@ -70,6 +78,14 @@ exports[`orderArrayByProp sorts an array by numbers desc 1`] = `
 hehe","break!",
     "systems_count": 42,
     "task_title": "special one",
+  },
+  {
+    "start_time": [
+      42,
+      "abc",
+    ],
+    "systems_count": 10,
+    "task_title": "another one with unexpected array",
   },
 ]
 `;
@@ -105,6 +121,14 @@ hehe","break!",
     "systems_count": 42,
     "task_title": "special one",
   },
+  {
+    "start_time": [
+      42,
+      "abc",
+    ],
+    "systems_count": 10,
+    "task_title": "another one with unexpected array",
+  },
 ]
 `;
 
@@ -138,6 +162,14 @@ exports[`orderArrayByProp sorts an array by string desc 1`] = `
 hehe","break!",
     "systems_count": 42,
     "task_title": "special one",
+  },
+  {
+    "start_time": [
+      42,
+      "abc",
+    ],
+    "systems_count": 10,
+    "task_title": "another one with unexpected array",
   },
 ]
 `;

--- a/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/columns.fixtures.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/columns.fixtures.js
@@ -1,10 +1,11 @@
-export default [
+export const taskColumnsFixtures = [
   {
     title: 'Task',
     props: {
       width: 35,
     },
     sortByProp: 'task_title',
+    renderExport: (item) => item.task_title,
   },
   {
     title: 'Systems',
@@ -12,7 +13,7 @@ export default [
       width: 20,
     },
     sortByProp: 'systems_count',
-    renderExport: (item) => item.system_count,
+    renderExport: (item) => item.systems_count,
   },
   {
     title: 'Run date/time',
@@ -20,5 +21,33 @@ export default [
       width: 20,
     },
     sortByProp: 'start_time',
+    renderExport: (item) => item.start_time,
+  },
+];
+
+export const jobCompleteColumnsFixtures = [
+  {
+    title: 'System name',
+    props: {
+      width: 30,
+    },
+    sortByProp: 'display_name',
+    renderExport: (job) => job.display_name || 'System deleted',
+  },
+  {
+    title: 'Status',
+    props: {
+      width: 10,
+    },
+    sortByProp: 'status',
+    renderExport: (job) => job.status,
+  },
+  {
+    title: 'Message',
+    props: {
+      width: 35,
+    },
+    renderExport: (job) =>
+      job.status === 'Success' ? 'Completed' : job.status,
   },
 ];

--- a/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/items.fixtures.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/items.fixtures.js
@@ -26,4 +26,9 @@ export default [
     start_time: '2022-04\n57\nhehe","break!',
     systems_count: 42,
   },
+  {
+    task_title: 'another one with unexpected array',
+    start_time: [42, 'abc'],
+    systems_count: 10,
+  },
 ];

--- a/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/items.fixtures.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/items.fixtures.js
@@ -22,14 +22,8 @@ export default [
     systems_count: 5,
   },
   {
-    task_title: 'taskC',
-    task_slug: 'taskc',
-    id: 3,
-    start_time: '2022-04-25T10:10:00',
-    end_time: '2022-04-28T11:10:00',
-    run_date_time: '25 Apr 2022, 11:10 UTC',
-    initiated_by: 'Michael',
-    status: 'Completed',
-    systems_count: 3,
+    task_title: 'special one',
+    start_time: '2022-04\n57\nhehe","break!',
+    systems_count: 42,
   },
 ];

--- a/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/jobResultsItems.fixtures.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/jobResultsItems.fixtures.js
@@ -1,0 +1,156 @@
+export const fixturesPlainReport = {
+  display_name: 'host_abc',
+  status: 'Success',
+  results: {
+    report:
+      'Lorem ipsum dolor sit amet, "consectetuer" adipiscing elit. Maecenas fermentum, sem in pharetra pellentesque, velit turpis > !volutpat ante, in pharetra metus odio a lectus. ',
+    message: 'Lorem ipsum dolor sit amet',
+  },
+};
+
+export const fixturesExtendedReport = {
+  system: 'd06577c7-0d21-4796-82c4-b03453d16918',
+  display_name: null,
+  status: 'Success',
+  results: {
+    report:
+      'Lorem ipsum dolor sit amet, "consectetuer" adipiscing elit.\nMaecenas fermentum, sem in pharetra pellentesque, velit turpis > !volutpat ante, in pharetra metus odio a lectus.',
+    message:
+      'The upgrade cannot proceed. Your system has 1 inhibitor out of 8 potential problems.',
+    report_json: {
+      entries: [
+        {
+          id: '516addaddb1d220e5ca442ff3e29293d7af992621eb831815bc28943fa5b1c',
+          key: '1b91322362ae7830e48eee7811be9527747de8',
+          title: 'Excluded target system repositories',
+          detail: {
+            remediations: [
+              {
+                type: 'hint',
+                context:
+                  'Lorem ipsum dolor sit amet, "consectetuer" adipiscing elit.',
+              },
+            ],
+          },
+          summary:
+            'The following repositories are not supported by Red Hat and are excluded from the list of repositories used during the upgrade.\n- codeready-builder-for-rhel-9-x86_64-eus-rpms\n- codeready-builder-for-rhel-9-aarch64-rpms\n- rhui-codeready-builder-for-rhel-9-aarch64-rhui-rpms\n- codeready-builder-for-rhel-9-s390x-eus-rpms\n- rhui-codeready-builder-for-rhel-9-x86_64-rhui-rpms\n- codeready-builder-for-rhel-9-aarch64-eus-rpms\n- codeready-builder-for-rhel-9-s390x-rpms\n- codeready-builder-beta-for-rhel-9-aarch64-rpms\n- codeready-builder-for-rhel-9-x86_64-rhui-rpms\n- codeready-builder-beta-for-rhel-9-s390x-rpms\n- codeready-builder-beta-for-rhel-9-x86_64-rpms\n- codeready-builder-for-rhel-9-ppc64le-eus-rpms\n- codeready-builder-for-rhel-9-ppc64le-rpms\n- codeready-builder-beta-for-rhel-9-ppc64le-rpms\n- codeready-builder-for-rhel-9-x86_64-rpms\n- codeready-builder-for-rhel-9-rhui-rpms',
+          hostname: 'iqe-vm-tasks-d52a0049-d6a3-49ca-a565-9896b79d0df4',
+          severity: 'info',
+        },
+        {
+          id: '4d6de2d4daff8c48b25bb7791ba2f94d30b8e37c2cf74f934f90435510306c',
+          key: '1c7a949a747ec9890f04bf4321de7280970715',
+          title:
+            'The installed OS version is not supported for the in-place upgrade to the target RHEL version',
+          detail: {
+            related_resources: [
+              {
+                title: '/etc/os-release',
+                scheme: 'file',
+              },
+            ],
+          },
+          summary:
+            'The supported OS releases for the upgrade process:\n RHEL 8.8\nRHEL 8.10\nRHEL-SAPHANA 8.8\nRHEL-SAPHANA 8.10',
+          hostname: 'iqe-vm-tasks-d52a0049-d6a3-49ca-a565-9896b79d0df4',
+          severity: 'inhibitor',
+        },
+        {
+          id: 'ce9c370a30ad1619aaf4664314f44e6bff1bf7c0da7b2542928018f4387697',
+          key: 'ac7030e05de248d34f08a9fa040b352bc410a3',
+          title: 'GRUB2 core will be automatically updated during the upgrade',
+          summary:
+            'On legacy (BIOS) systems, GRUB2 core (located in the gap between the MBR and the first partition) cannot be updated during the rpm transaction and Leapp has to initiate the update running "grub2-install" after the transaction. No action is needed before the upgrade. After the upgrade, it is recommended to check the GRUB configuration.',
+          hostname: 'iqe-vm-tasks-d52a0049-d6a3-49ca-a565-9896b79d0df4',
+          severity: 'high',
+        },
+        {
+          id: '81e94942da7980c45bc2e0f1cc95abbb961d63c63f62c7607021a390628ecb',
+          key: '8fb818f8413bd617c2a55b69b8e10ff03d7c72',
+          title: 'SElinux relabeling will be scheduled',
+          summary:
+            'SElinux relabeling will be scheduled as the status is permissive/enforcing.',
+          hostname: 'iqe-vm-tasks-d52a0049-d6a3-49ca-a565-9896b79d0df4',
+          severity: 'info',
+        },
+        {
+          id: '571dff1262ade361274ca8bee42f11744f200d88d61926b3fd8a4b69f6ab3',
+          key: '39d7183dafba79a4bbb1e70b0ef2bbe5b1772f',
+          title: 'SElinux will be set to permissive mode',
+          detail: {
+            remediations: [
+              {
+                type: 'hint',
+                context:
+                  'Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.',
+              },
+            ],
+          },
+          summary:
+            'SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.',
+          hostname: 'iqe-vm-tasks-d52a0049-d6a3-49ca-a565-9896b79d0df4',
+          severity: 'low',
+        },
+        {
+          id: '60fee68aa010bcc41ebe17c57a68ec9eb7661f854b45568f45c5fd85f46370',
+          key: 'e738f78bc8f3a84414210e3b609057139d1855',
+          title: 'Remote root logins globally allowed using password',
+          detail: {
+            remediations: [
+              {
+                type: 'hint',
+                context:
+                  'If you depend on remote root logins using passwords, consider setting up a different user for remote administration. Otherwise you can ignore this message.',
+              },
+            ],
+            related_resources: [
+              {
+                title: 'openssh-server',
+                scheme: 'package',
+              },
+              {
+                title: '/etc/ssh/sshd_config',
+                scheme: 'file',
+              },
+            ],
+          },
+          summary:
+            'RHEL9 no longer allows remote root logins, but the server configuration explicitly overrides this default. The configuration file will not be updated and root is still going to be allowed to login with password. This is not recommended and considered as a security risk.',
+          hostname: 'iqe-vm-tasks-d52a0049-d6a3-49ca-a565-9896b79d0df4',
+          severity: 'high',
+        },
+        {
+          id: '187efd769d50466674a1b72a35fa8c0d88afdb563c7833beef94bb38fbdbc',
+          key: '96da6937c25c6492e4f1228e46795989fd3718',
+          title:
+            'The upgrade will prepend the Include directive to OpenSSH sshd_config',
+          detail: {
+            related_resources: [
+              {
+                title: 'openssh-server',
+                scheme: 'package',
+              },
+              {
+                title: '/etc/ssh/sshd_config',
+                scheme: 'file',
+              },
+            ],
+          },
+          summary:
+            'OpenSSH server configuration needs to be modified to contain Include directive for the RHEL9 to work properly and integrate with the other parts of the OS. The following snippet will be added to the /etc/ssh/sshd_config during the ApplicationsPhase: `Include /etc/ssh/sshd_config.d/*.conf`',
+          hostname: 'iqe-vm-tasks-d52a0049-d6a3-49ca-a565-9896b79d0df4',
+          severity: 'info',
+        },
+        {
+          id: 'c42b5edcf36969727cee80a66dc5239fe4d69d4d324e7e6e698cb58b9d1a0',
+          key: '693963253195f41852045b6d630a1f4c7a193d',
+          title: 'Automatic registration into Red Hat Insights',
+          summary:
+            "After the upgrade, this system will be automatically registered into Red Hat Insights. To skip the automatic registration, use the '--no-insights-register' command line option or set the LEAPP_NO_INSIGHTS_REGISTER environment variable.",
+          hostname: 'iqe-vm-tasks-d52a49-d6a3-49ca-a565-9896b79d0df4',
+          severity: 'info',
+        },
+      ],
+    },
+  },
+};

--- a/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/jobResultsItems.fixtures.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/__fixtures__/jobResultsItems.fixtures.js
@@ -42,14 +42,7 @@ export const fixturesExtendedReport = {
           key: '1c7a949a747ec9890f04bf4321de7280970715',
           title:
             'The installed OS version is not supported for the in-place upgrade to the target RHEL version',
-          detail: {
-            related_resources: [
-              {
-                title: '/etc/os-release',
-                scheme: 'file',
-              },
-            ],
-          },
+          detail: {},
           summary:
             'The supported OS releases for the upgrade process:\n RHEL 8.8\nRHEL 8.10\nRHEL-SAPHANA 8.8\nRHEL-SAPHANA 8.10',
           hostname: 'iqe-vm-tasks-d52a0049-d6a3-49ca-a565-9896b79d0df4',
@@ -103,16 +96,6 @@ export const fixturesExtendedReport = {
                   'If you depend on remote root logins using passwords, consider setting up a different user for remote administration. Otherwise you can ignore this message.',
               },
             ],
-            related_resources: [
-              {
-                title: 'openssh-server',
-                scheme: 'package',
-              },
-              {
-                title: '/etc/ssh/sshd_config',
-                scheme: 'file',
-              },
-            ],
           },
           summary:
             'RHEL9 no longer allows remote root logins, but the server configuration explicitly overrides this default. The configuration file will not be updated and root is still going to be allowed to login with password. This is not recommended and considered as a security risk.',
@@ -124,18 +107,7 @@ export const fixturesExtendedReport = {
           key: '96da6937c25c6492e4f1228e46795989fd3718',
           title:
             'The upgrade will prepend the Include directive to OpenSSH sshd_config',
-          detail: {
-            related_resources: [
-              {
-                title: 'openssh-server',
-                scheme: 'package',
-              },
-              {
-                title: '/etc/ssh/sshd_config',
-                scheme: 'file',
-              },
-            ],
-          },
+          detail: {},
           summary:
             'OpenSSH server configuration needs to be modified to contain Include directive for the RHEL9 to work properly and integrate with the other parts of the OS. The following snippet will be added to the /etc/ssh/sshd_config during the ApplicationsPhase: `Include /etc/ssh/sshd_config.d/*.conf`',
           hostname: 'iqe-vm-tasks-d52a0049-d6a3-49ca-a565-9896b79d0df4',

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/reportParser.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/reportParser.test.js.snap
@@ -1,11 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`parseJobReport should parse a job with report_json 1`] = `
-[
-  "Excluded target system repositories",
-  "info",
-  "1b91322362ae7830e48eee7811be9527747de8",
-  "The following repositories are not supported by Red Hat and are excluded from the list of repositories used during the upgrade.
+{
+  "diagnosis": "",
+  "key": "1b91322362ae7830e48eee7811be9527747de8",
+  "remediationContext": "Lorem ipsum dolor sit amet, "consectetuer" adipiscing elit.",
+  "remediationType": "hint",
+  "severity": "info",
+  "summary": "The following repositories are not supported by Red Hat and are excluded from the list of repositories used during the upgrade.
 - codeready-builder-for-rhel-9-x86_64-eus-rpms
 - codeready-builder-for-rhel-9-aarch64-rpms
 - rhui-codeready-builder-for-rhel-9-aarch64-rhui-rpms
@@ -22,98 +24,96 @@ exports[`parseJobReport should parse a job with report_json 1`] = `
 - codeready-builder-beta-for-rhel-9-ppc64le-rpms
 - codeready-builder-for-rhel-9-x86_64-rpms
 - codeready-builder-for-rhel-9-rhui-rpms",
-  "",
-  "hint",
-  "Lorem ipsum dolor sit amet, "consectetuer" adipiscing elit.",
-]
+  "title": "Excluded target system repositories",
+}
 `;
 
 exports[`parseJobReport should parse a job with report_json 2`] = `
-[
-  "The installed OS version is not supported for the in-place upgrade to the target RHEL version",
-  "inhibitor",
-  "1c7a949a747ec9890f04bf4321de7280970715",
-  "The supported OS releases for the upgrade process:
+{
+  "diagnosis": "",
+  "key": "1c7a949a747ec9890f04bf4321de7280970715",
+  "remediationContext": "",
+  "remediationType": "",
+  "severity": "inhibitor",
+  "summary": "The supported OS releases for the upgrade process:
  RHEL 8.8
 RHEL 8.10
 RHEL-SAPHANA 8.8
 RHEL-SAPHANA 8.10",
-  "",
-  "",
-  "",
-]
+  "title": "The installed OS version is not supported for the in-place upgrade to the target RHEL version",
+}
 `;
 
 exports[`parseJobReport should parse a job with report_json 3`] = `
-[
-  "GRUB2 core will be automatically updated during the upgrade",
-  "high",
-  "ac7030e05de248d34f08a9fa040b352bc410a3",
-  "On legacy (BIOS) systems, GRUB2 core (located in the gap between the MBR and the first partition) cannot be updated during the rpm transaction and Leapp has to initiate the update running "grub2-install" after the transaction. No action is needed before the upgrade. After the upgrade, it is recommended to check the GRUB configuration.",
-  "",
-  "",
-  "",
-]
+{
+  "diagnosis": "",
+  "key": "ac7030e05de248d34f08a9fa040b352bc410a3",
+  "remediationContext": "",
+  "remediationType": "",
+  "severity": "high",
+  "summary": "On legacy (BIOS) systems, GRUB2 core (located in the gap between the MBR and the first partition) cannot be updated during the rpm transaction and Leapp has to initiate the update running "grub2-install" after the transaction. No action is needed before the upgrade. After the upgrade, it is recommended to check the GRUB configuration.",
+  "title": "GRUB2 core will be automatically updated during the upgrade",
+}
 `;
 
 exports[`parseJobReport should parse a job with report_json 4`] = `
-[
-  "SElinux relabeling will be scheduled",
-  "info",
-  "8fb818f8413bd617c2a55b69b8e10ff03d7c72",
-  "SElinux relabeling will be scheduled as the status is permissive/enforcing.",
-  "",
-  "",
-  "",
-]
+{
+  "diagnosis": "",
+  "key": "8fb818f8413bd617c2a55b69b8e10ff03d7c72",
+  "remediationContext": "",
+  "remediationType": "",
+  "severity": "info",
+  "summary": "SElinux relabeling will be scheduled as the status is permissive/enforcing.",
+  "title": "SElinux relabeling will be scheduled",
+}
 `;
 
 exports[`parseJobReport should parse a job with report_json 5`] = `
-[
-  "SElinux will be set to permissive mode",
-  "low",
-  "39d7183dafba79a4bbb1e70b0ef2bbe5b1772f",
-  "SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.",
-  "",
-  "hint",
-  "Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.",
-]
+{
+  "diagnosis": "",
+  "key": "39d7183dafba79a4bbb1e70b0ef2bbe5b1772f",
+  "remediationContext": "Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.",
+  "remediationType": "hint",
+  "severity": "low",
+  "summary": "SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.",
+  "title": "SElinux will be set to permissive mode",
+}
 `;
 
 exports[`parseJobReport should parse a job with report_json 6`] = `
-[
-  "Remote root logins globally allowed using password",
-  "high",
-  "e738f78bc8f3a84414210e3b609057139d1855",
-  "RHEL9 no longer allows remote root logins, but the server configuration explicitly overrides this default. The configuration file will not be updated and root is still going to be allowed to login with password. This is not recommended and considered as a security risk.",
-  "",
-  "hint",
-  "If you depend on remote root logins using passwords, consider setting up a different user for remote administration. Otherwise you can ignore this message.",
-]
+{
+  "diagnosis": "",
+  "key": "e738f78bc8f3a84414210e3b609057139d1855",
+  "remediationContext": "If you depend on remote root logins using passwords, consider setting up a different user for remote administration. Otherwise you can ignore this message.",
+  "remediationType": "hint",
+  "severity": "high",
+  "summary": "RHEL9 no longer allows remote root logins, but the server configuration explicitly overrides this default. The configuration file will not be updated and root is still going to be allowed to login with password. This is not recommended and considered as a security risk.",
+  "title": "Remote root logins globally allowed using password",
+}
 `;
 
 exports[`parseJobReport should parse a job with report_json 7`] = `
-[
-  "The upgrade will prepend the Include directive to OpenSSH sshd_config",
-  "info",
-  "96da6937c25c6492e4f1228e46795989fd3718",
-  "OpenSSH server configuration needs to be modified to contain Include directive for the RHEL9 to work properly and integrate with the other parts of the OS. The following snippet will be added to the /etc/ssh/sshd_config during the ApplicationsPhase: \`Include /etc/ssh/sshd_config.d/*.conf\`",
-  "",
-  "",
-  "",
-]
+{
+  "diagnosis": "",
+  "key": "96da6937c25c6492e4f1228e46795989fd3718",
+  "remediationContext": "",
+  "remediationType": "",
+  "severity": "info",
+  "summary": "OpenSSH server configuration needs to be modified to contain Include directive for the RHEL9 to work properly and integrate with the other parts of the OS. The following snippet will be added to the /etc/ssh/sshd_config during the ApplicationsPhase: \`Include /etc/ssh/sshd_config.d/*.conf\`",
+  "title": "The upgrade will prepend the Include directive to OpenSSH sshd_config",
+}
 `;
 
 exports[`parseJobReport should parse a job with report_json 8`] = `
-[
-  "Automatic registration into Red Hat Insights",
-  "info",
-  "693963253195f41852045b6d630a1f4c7a193d",
-  "After the upgrade, this system will be automatically registered into Red Hat Insights. To skip the automatic registration, use the '--no-insights-register' command line option or set the LEAPP_NO_INSIGHTS_REGISTER environment variable.",
-  "",
-  "",
-  "",
-]
+{
+  "diagnosis": "",
+  "key": "693963253195f41852045b6d630a1f4c7a193d",
+  "remediationContext": "",
+  "remediationType": "",
+  "severity": "info",
+  "summary": "After the upgrade, this system will be automatically registered into Red Hat Insights. To skip the automatic registration, use the '--no-insights-register' command line option or set the LEAPP_NO_INSIGHTS_REGISTER environment variable.",
+  "title": "Automatic registration into Red Hat Insights",
+}
 `;
 
 exports[`parseJobReport should parse a job without report 1`] = `

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/reportParser.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/reportParser.test.js.snap
@@ -1,0 +1,130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseJobReport should parse a job with report_json 1`] = `
+[
+  "Excluded target system repositories",
+  "info",
+  "1b91322362ae7830e48eee7811be9527747de8",
+  "The following repositories are not supported by Red Hat and are excluded from the list of repositories used during the upgrade.
+- codeready-builder-for-rhel-9-x86_64-eus-rpms
+- codeready-builder-for-rhel-9-aarch64-rpms
+- rhui-codeready-builder-for-rhel-9-aarch64-rhui-rpms
+- codeready-builder-for-rhel-9-s390x-eus-rpms
+- rhui-codeready-builder-for-rhel-9-x86_64-rhui-rpms
+- codeready-builder-for-rhel-9-aarch64-eus-rpms
+- codeready-builder-for-rhel-9-s390x-rpms
+- codeready-builder-beta-for-rhel-9-aarch64-rpms
+- codeready-builder-for-rhel-9-x86_64-rhui-rpms
+- codeready-builder-beta-for-rhel-9-s390x-rpms
+- codeready-builder-beta-for-rhel-9-x86_64-rpms
+- codeready-builder-for-rhel-9-ppc64le-eus-rpms
+- codeready-builder-for-rhel-9-ppc64le-rpms
+- codeready-builder-beta-for-rhel-9-ppc64le-rpms
+- codeready-builder-for-rhel-9-x86_64-rpms
+- codeready-builder-for-rhel-9-rhui-rpms",
+  "",
+  "hint",
+  "Lorem ipsum dolor sit amet, "consectetuer" adipiscing elit.",
+]
+`;
+
+exports[`parseJobReport should parse a job with report_json 2`] = `
+[
+  "The installed OS version is not supported for the in-place upgrade to the target RHEL version",
+  "inhibitor",
+  "1c7a949a747ec9890f04bf4321de7280970715",
+  "The supported OS releases for the upgrade process:
+ RHEL 8.8
+RHEL 8.10
+RHEL-SAPHANA 8.8
+RHEL-SAPHANA 8.10",
+  "",
+  "",
+  "",
+]
+`;
+
+exports[`parseJobReport should parse a job with report_json 3`] = `
+[
+  "GRUB2 core will be automatically updated during the upgrade",
+  "high",
+  "ac7030e05de248d34f08a9fa040b352bc410a3",
+  "On legacy (BIOS) systems, GRUB2 core (located in the gap between the MBR and the first partition) cannot be updated during the rpm transaction and Leapp has to initiate the update running "grub2-install" after the transaction. No action is needed before the upgrade. After the upgrade, it is recommended to check the GRUB configuration.",
+  "",
+  "",
+  "",
+]
+`;
+
+exports[`parseJobReport should parse a job with report_json 4`] = `
+[
+  "SElinux relabeling will be scheduled",
+  "info",
+  "8fb818f8413bd617c2a55b69b8e10ff03d7c72",
+  "SElinux relabeling will be scheduled as the status is permissive/enforcing.",
+  "",
+  "",
+  "",
+]
+`;
+
+exports[`parseJobReport should parse a job with report_json 5`] = `
+[
+  "SElinux will be set to permissive mode",
+  "low",
+  "39d7183dafba79a4bbb1e70b0ef2bbe5b1772f",
+  "SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.",
+  "",
+  "hint",
+  "Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.",
+]
+`;
+
+exports[`parseJobReport should parse a job with report_json 6`] = `
+[
+  "Remote root logins globally allowed using password",
+  "high",
+  "e738f78bc8f3a84414210e3b609057139d1855",
+  "RHEL9 no longer allows remote root logins, but the server configuration explicitly overrides this default. The configuration file will not be updated and root is still going to be allowed to login with password. This is not recommended and considered as a security risk.",
+  "",
+  "hint",
+  "If you depend on remote root logins using passwords, consider setting up a different user for remote administration. Otherwise you can ignore this message.",
+]
+`;
+
+exports[`parseJobReport should parse a job with report_json 7`] = `
+[
+  "The upgrade will prepend the Include directive to OpenSSH sshd_config",
+  "info",
+  "96da6937c25c6492e4f1228e46795989fd3718",
+  "OpenSSH server configuration needs to be modified to contain Include directive for the RHEL9 to work properly and integrate with the other parts of the OS. The following snippet will be added to the /etc/ssh/sshd_config during the ApplicationsPhase: \`Include /etc/ssh/sshd_config.d/*.conf\`",
+  "",
+  "",
+  "",
+]
+`;
+
+exports[`parseJobReport should parse a job with report_json 8`] = `
+[
+  "Automatic registration into Red Hat Insights",
+  "info",
+  "693963253195f41852045b6d630a1f4c7a193d",
+  "After the upgrade, this system will be automatically registered into Red Hat Insights. To skip the automatic registration, use the '--no-insights-register' command line option or set the LEAPP_NO_INSIGHTS_REGISTER environment variable.",
+  "",
+  "",
+  "",
+]
+`;
+
+exports[`parseJobReport should parse a job without report 1`] = `
+[
+  {
+    "display_name": "host_abc",
+    "results": {
+      "message": "Lorem ipsum dolor sit amet",
+      "report": "Lorem ipsum dolor sit amet, "consectetuer" adipiscing elit. Maecenas fermentum, sem in pharetra pellentesque, velit turpis > !volutpat ante, in pharetra metus odio a lectus. ",
+    },
+    "status": "Success",
+  },
+]
+`;

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/reportParser.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/reportParser.test.js.snap
@@ -1,13 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`parseJobReport should parse a job with report_json 1`] = `
-{
-  "diagnosis": "",
-  "key": "1b91322362ae7830e48eee7811be9527747de8",
-  "remediationContext": "Lorem ipsum dolor sit amet, "consectetuer" adipiscing elit.",
-  "remediationType": "hint",
-  "severity": "info",
-  "summary": "The following repositories are not supported by Red Hat and are excluded from the list of repositories used during the upgrade.
+exports[`parseJobReport should add issue_parsed 1`] = `
+[
+  {
+    "diagnosis": "",
+    "key": "1b91322362ae7830e48eee7811be9527747de8",
+    "remediationContext": "Lorem ipsum dolor sit amet, "consectetuer" adipiscing elit.",
+    "remediationType": "hint",
+    "severity": "info",
+    "summary": "The following repositories are not supported by Red Hat and are excluded from the list of repositories used during the upgrade.
 - codeready-builder-for-rhel-9-x86_64-eus-rpms
 - codeready-builder-for-rhel-9-aarch64-rpms
 - rhui-codeready-builder-for-rhel-9-aarch64-rhui-rpms
@@ -24,96 +25,76 @@ exports[`parseJobReport should parse a job with report_json 1`] = `
 - codeready-builder-beta-for-rhel-9-ppc64le-rpms
 - codeready-builder-for-rhel-9-x86_64-rpms
 - codeready-builder-for-rhel-9-rhui-rpms",
-  "title": "Excluded target system repositories",
-}
-`;
-
-exports[`parseJobReport should parse a job with report_json 2`] = `
-{
-  "diagnosis": "",
-  "key": "1c7a949a747ec9890f04bf4321de7280970715",
-  "remediationContext": "",
-  "remediationType": "",
-  "severity": "inhibitor",
-  "summary": "The supported OS releases for the upgrade process:
+    "title": "Excluded target system repositories",
+  },
+  {
+    "diagnosis": "",
+    "key": "1c7a949a747ec9890f04bf4321de7280970715",
+    "remediationContext": "",
+    "remediationType": "",
+    "severity": "inhibitor",
+    "summary": "The supported OS releases for the upgrade process:
  RHEL 8.8
 RHEL 8.10
 RHEL-SAPHANA 8.8
 RHEL-SAPHANA 8.10",
-  "title": "The installed OS version is not supported for the in-place upgrade to the target RHEL version",
-}
-`;
-
-exports[`parseJobReport should parse a job with report_json 3`] = `
-{
-  "diagnosis": "",
-  "key": "ac7030e05de248d34f08a9fa040b352bc410a3",
-  "remediationContext": "",
-  "remediationType": "",
-  "severity": "high",
-  "summary": "On legacy (BIOS) systems, GRUB2 core (located in the gap between the MBR and the first partition) cannot be updated during the rpm transaction and Leapp has to initiate the update running "grub2-install" after the transaction. No action is needed before the upgrade. After the upgrade, it is recommended to check the GRUB configuration.",
-  "title": "GRUB2 core will be automatically updated during the upgrade",
-}
-`;
-
-exports[`parseJobReport should parse a job with report_json 4`] = `
-{
-  "diagnosis": "",
-  "key": "8fb818f8413bd617c2a55b69b8e10ff03d7c72",
-  "remediationContext": "",
-  "remediationType": "",
-  "severity": "info",
-  "summary": "SElinux relabeling will be scheduled as the status is permissive/enforcing.",
-  "title": "SElinux relabeling will be scheduled",
-}
-`;
-
-exports[`parseJobReport should parse a job with report_json 5`] = `
-{
-  "diagnosis": "",
-  "key": "39d7183dafba79a4bbb1e70b0ef2bbe5b1772f",
-  "remediationContext": "Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.",
-  "remediationType": "hint",
-  "severity": "low",
-  "summary": "SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.",
-  "title": "SElinux will be set to permissive mode",
-}
-`;
-
-exports[`parseJobReport should parse a job with report_json 6`] = `
-{
-  "diagnosis": "",
-  "key": "e738f78bc8f3a84414210e3b609057139d1855",
-  "remediationContext": "If you depend on remote root logins using passwords, consider setting up a different user for remote administration. Otherwise you can ignore this message.",
-  "remediationType": "hint",
-  "severity": "high",
-  "summary": "RHEL9 no longer allows remote root logins, but the server configuration explicitly overrides this default. The configuration file will not be updated and root is still going to be allowed to login with password. This is not recommended and considered as a security risk.",
-  "title": "Remote root logins globally allowed using password",
-}
-`;
-
-exports[`parseJobReport should parse a job with report_json 7`] = `
-{
-  "diagnosis": "",
-  "key": "96da6937c25c6492e4f1228e46795989fd3718",
-  "remediationContext": "",
-  "remediationType": "",
-  "severity": "info",
-  "summary": "OpenSSH server configuration needs to be modified to contain Include directive for the RHEL9 to work properly and integrate with the other parts of the OS. The following snippet will be added to the /etc/ssh/sshd_config during the ApplicationsPhase: \`Include /etc/ssh/sshd_config.d/*.conf\`",
-  "title": "The upgrade will prepend the Include directive to OpenSSH sshd_config",
-}
-`;
-
-exports[`parseJobReport should parse a job with report_json 8`] = `
-{
-  "diagnosis": "",
-  "key": "693963253195f41852045b6d630a1f4c7a193d",
-  "remediationContext": "",
-  "remediationType": "",
-  "severity": "info",
-  "summary": "After the upgrade, this system will be automatically registered into Red Hat Insights. To skip the automatic registration, use the '--no-insights-register' command line option or set the LEAPP_NO_INSIGHTS_REGISTER environment variable.",
-  "title": "Automatic registration into Red Hat Insights",
-}
+    "title": "The installed OS version is not supported for the in-place upgrade to the target RHEL version",
+  },
+  {
+    "diagnosis": "",
+    "key": "ac7030e05de248d34f08a9fa040b352bc410a3",
+    "remediationContext": "",
+    "remediationType": "",
+    "severity": "high",
+    "summary": "On legacy (BIOS) systems, GRUB2 core (located in the gap between the MBR and the first partition) cannot be updated during the rpm transaction and Leapp has to initiate the update running "grub2-install" after the transaction. No action is needed before the upgrade. After the upgrade, it is recommended to check the GRUB configuration.",
+    "title": "GRUB2 core will be automatically updated during the upgrade",
+  },
+  {
+    "diagnosis": "",
+    "key": "8fb818f8413bd617c2a55b69b8e10ff03d7c72",
+    "remediationContext": "",
+    "remediationType": "",
+    "severity": "info",
+    "summary": "SElinux relabeling will be scheduled as the status is permissive/enforcing.",
+    "title": "SElinux relabeling will be scheduled",
+  },
+  {
+    "diagnosis": "",
+    "key": "39d7183dafba79a4bbb1e70b0ef2bbe5b1772f",
+    "remediationContext": "Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.",
+    "remediationType": "hint",
+    "severity": "low",
+    "summary": "SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.",
+    "title": "SElinux will be set to permissive mode",
+  },
+  {
+    "diagnosis": "",
+    "key": "e738f78bc8f3a84414210e3b609057139d1855",
+    "remediationContext": "If you depend on remote root logins using passwords, consider setting up a different user for remote administration. Otherwise you can ignore this message.",
+    "remediationType": "hint",
+    "severity": "high",
+    "summary": "RHEL9 no longer allows remote root logins, but the server configuration explicitly overrides this default. The configuration file will not be updated and root is still going to be allowed to login with password. This is not recommended and considered as a security risk.",
+    "title": "Remote root logins globally allowed using password",
+  },
+  {
+    "diagnosis": "",
+    "key": "96da6937c25c6492e4f1228e46795989fd3718",
+    "remediationContext": "",
+    "remediationType": "",
+    "severity": "info",
+    "summary": "OpenSSH server configuration needs to be modified to contain Include directive for the RHEL9 to work properly and integrate with the other parts of the OS. The following snippet will be added to the /etc/ssh/sshd_config during the ApplicationsPhase: \`Include /etc/ssh/sshd_config.d/*.conf\`",
+    "title": "The upgrade will prepend the Include directive to OpenSSH sshd_config",
+  },
+  {
+    "diagnosis": "",
+    "key": "693963253195f41852045b6d630a1f4c7a193d",
+    "remediationContext": "",
+    "remediationType": "",
+    "severity": "info",
+    "summary": "After the upgrade, this system will be automatically registered into Red Hat Insights. To skip the automatic registration, use the '--no-insights-register' command line option or set the LEAPP_NO_INSIGHTS_REGISTER environment variable.",
+    "title": "Automatic registration into Red Hat Insights",
+  },
+]
 `;
 
 exports[`parseJobReport should parse a job without report 1`] = `

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useExport.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useExport.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`csvForItems returns an csv export of items for complete job 1`] = `
-"data:text/csv;charset=utf-8,System name,Status,Message
+"System name,Status,Message
 "host_abc","Success","Completed""
 `;
 
 exports[`csvForItems returns some example csv export of items 1`] = `
-"data:text/csv;charset=utf-8,Task,Systems,Run date/time
+"Task,Systems,Run date/time
 "taskA",10,"2022-04-20T10:10:00"
 "taskB",5,"2022-04-21T10:10:00"
 "special one",42,"2022-04
@@ -15,7 +15,7 @@ hehe"",""break!"
 "another one with unexpected array",10,"42,"abc"""
 `;
 
-exports[`jsonForItems returns an json export of items 1`] = `"data:application/json;charset=utf-8,[{"Task":"taskA","Systems":10,"RunDateTime":"2022-04-20T10:10:00"},{"Task":"taskB","Systems":5,"RunDateTime":"2022-04-21T10:10:00"},{"Task":"special one","Systems":42,"RunDateTime":"2022-04\\n57\\nhehe\\",\\"break!"},{"Task":"another one with unexpected array","Systems":10,"RunDateTime":[42,"abc"]}]"`;
+exports[`jsonForItems returns an json export of items 1`] = `"[{"Task":"taskA","Systems":10,"RunDateTime":"2022-04-20T10:10:00"},{"Task":"taskB","Systems":5,"RunDateTime":"2022-04-21T10:10:00"},{"Task":"special one","Systems":42,"RunDateTime":"2022-04\\n57\\nhehe\\",\\"break!"},{"Task":"another one with unexpected array","Systems":10,"RunDateTime":[42,"abc"]}]"`;
 
 exports[`useExport returns an export config toolbar config 1`] = `
 {

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useExport.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useExport.test.js.snap
@@ -11,10 +11,11 @@ exports[`csvForItems returns some example csv export of items 1`] = `
 "taskB",5,"2022-04-21T10:10:00"
 "special one",42,"2022-04
 57
-hehe"",""break!""
+hehe"",""break!"
+"another one with unexpected array",10,"42,"abc"""
 `;
 
-exports[`jsonForItems returns an json export of items 1`] = `"data:application/json;charset=utf-8,%5B%7B%22Task%22:%22taskA%22,%22Systems%22:10,%22RunDateTime%22:%222022-04-20T10:10:00%22%7D,%7B%22Task%22:%22taskB%22,%22Systems%22:5,%22RunDateTime%22:%222022-04-21T10:10:00%22%7D,%7B%22Task%22:%22special%20one%22,%22Systems%22:42,%22RunDateTime%22:%222022-04%5Cn57%5Cnhehe%5C%22,%5C%22break!%22%7D%5D"`;
+exports[`jsonForItems returns an json export of items 1`] = `"data:application/json;charset=utf-8,[{"Task":"taskA","Systems":10,"RunDateTime":"2022-04-20T10:10:00"},{"Task":"taskB","Systems":5,"RunDateTime":"2022-04-21T10:10:00"},{"Task":"special one","Systems":42,"RunDateTime":"2022-04\\n57\\nhehe\\",\\"break!"},{"Task":"another one with unexpected array","Systems":10,"RunDateTime":[42,"abc"]}]"`;
 
 exports[`useExport returns an export config toolbar config 1`] = `
 {

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useExport.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useExport.test.js.snap
@@ -1,10 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csvForItems returns an csv export of items for complete job 1`] = `"data:text/csv;charset=utf-8,System%20name,Status,Message%0A%22host_abc%22,%22Success%22,%22Completed%22"`;
+exports[`csvForItems returns an csv export of items for complete job 1`] = `
+"data:text/csv;charset=utf-8,System name,Status,Message
+"host_abc","Success","Completed""
+`;
 
-exports[`csvForItems returns some example csv export of items 1`] = `"data:text/csv;charset=utf-8,Task,Systems,Run%20date/time%0A%22taskA%22,%2210%22,%222022-04-20T10:10:00%22%0A%22taskB%22,%225%22,%222022-04-21T10:10:00%22%0A%22taskC%22,%223%22,%222022-04-25T10:10:00%22"`;
+exports[`csvForItems returns some example csv export of items 1`] = `
+"data:text/csv;charset=utf-8,Task,Systems,Run date/time
+"taskA",10,"2022-04-20T10:10:00"
+"taskB",5,"2022-04-21T10:10:00"
+"special one",42,"2022-04
+57
+hehe"",""break!""
+`;
 
-exports[`jsonForItems returns an json export of items 1`] = `"data:application/json;charset=utf-8,%5B%7B%22Task%22:%22taskA%22,%22Systems%22:10,%22RunDateTime%22:%222022-04-20T10:10:00%22%7D,%7B%22Task%22:%22taskB%22,%22Systems%22:5,%22RunDateTime%22:%222022-04-21T10:10:00%22%7D,%7B%22Task%22:%22taskC%22,%22Systems%22:3,%22RunDateTime%22:%222022-04-25T10:10:00%22%7D%5D"`;
+exports[`jsonForItems returns an json export of items 1`] = `"data:application/json;charset=utf-8,%5B%7B%22Task%22:%22taskA%22,%22Systems%22:10,%22RunDateTime%22:%222022-04-20T10:10:00%22%7D,%7B%22Task%22:%22taskB%22,%22Systems%22:5,%22RunDateTime%22:%222022-04-21T10:10:00%22%7D,%7B%22Task%22:%22special%20one%22,%22Systems%22:42,%22RunDateTime%22:%222022-04%5Cn57%5Cnhehe%5C%22,%5C%22break!%22%7D%5D"`;
 
 exports[`useExport returns an export config toolbar config 1`] = `
 {

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useExport.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useExport.test.js.snap
@@ -1,29 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csvForItems returns an csv export of items 1`] = `"data:text/csv;charset=utf-8,Task,Systems,Run%20date/time%0A%22%5Bobject%20Object%5D%22,%22undefined%22,%22%5Bobject%20Object%5D%22%0A%22%5Bobject%20Object%5D%22,%22undefined%22,%22%5Bobject%20Object%5D%22%0A%22%5Bobject%20Object%5D%22,%22undefined%22,%22%5Bobject%20Object%5D%22"`;
+exports[`csvForItems returns an csv export of items for complete job 1`] = `"data:text/csv;charset=utf-8,System%20name,Status,Message%0A%22host_abc%22,%22Success%22,%22Completed%22"`;
 
-exports[`jsonForItems returns an json export of items 1`] = `"data:application/json;charset=utf-8,%5B%7B%22Task%22:%7B%22task_title%22:%22taskA%22,%22task_slug%22:%22taska%22,%22id%22:1,%22start_time%22:%222022-04-20T10:10:00%22,%22end_time%22:%222022-04-20T11:10:00%22,%22run_date_time%22:%2220%20Apr%202022,%2011:10%20UTC%22,%22initiated_by%22:%22Michael%22,%22status%22:%22Completed%22,%22systems_count%22:10%7D,%22RunDateTime%22:%7B%22task_title%22:%22taskA%22,%22task_slug%22:%22taska%22,%22id%22:1,%22start_time%22:%222022-04-20T10:10:00%22,%22end_time%22:%222022-04-20T11:10:00%22,%22run_date_time%22:%2220%20Apr%202022,%2011:10%20UTC%22,%22initiated_by%22:%22Michael%22,%22status%22:%22Completed%22,%22systems_count%22:10%7D%7D,%7B%22Task%22:%7B%22task_title%22:%22taskB%22,%22task_slug%22:%22taskb%22,%22id%22:2,%22start_time%22:%222022-04-21T10:10:00%22,%22end_time%22:%22null%22,%22run_date_time%22:%22Running%22,%22initiated_by%22:%22Michael%22,%22status%22:%22Running%22,%22systems_count%22:5%7D,%22RunDateTime%22:%7B%22task_title%22:%22taskB%22,%22task_slug%22:%22taskb%22,%22id%22:2,%22start_time%22:%222022-04-21T10:10:00%22,%22end_time%22:%22null%22,%22run_date_time%22:%22Running%22,%22initiated_by%22:%22Michael%22,%22status%22:%22Running%22,%22systems_count%22:5%7D%7D,%7B%22Task%22:%7B%22task_title%22:%22taskC%22,%22task_slug%22:%22taskc%22,%22id%22:3,%22start_time%22:%222022-04-25T10:10:00%22,%22end_time%22:%222022-04-28T11:10:00%22,%22run_date_time%22:%2225%20Apr%202022,%2011:10%20UTC%22,%22initiated_by%22:%22Michael%22,%22status%22:%22Completed%22,%22systems_count%22:3%7D,%22RunDateTime%22:%7B%22task_title%22:%22taskC%22,%22task_slug%22:%22taskc%22,%22id%22:3,%22start_time%22:%222022-04-25T10:10:00%22,%22end_time%22:%222022-04-28T11:10:00%22,%22run_date_time%22:%2225%20Apr%202022,%2011:10%20UTC%22,%22initiated_by%22:%22Michael%22,%22status%22:%22Completed%22,%22systems_count%22:3%7D%7D%5D"`;
+exports[`csvForItems returns some example csv export of items 1`] = `"data:text/csv;charset=utf-8,Task,Systems,Run%20date/time%0A%22taskA%22,%2210%22,%222022-04-20T10:10:00%22%0A%22taskB%22,%225%22,%222022-04-21T10:10:00%22%0A%22taskC%22,%223%22,%222022-04-25T10:10:00%22"`;
+
+exports[`jsonForItems returns an json export of items 1`] = `"data:application/json;charset=utf-8,%5B%7B%22Task%22:%22taskA%22,%22Systems%22:10,%22RunDateTime%22:%222022-04-20T10:10:00%22%7D,%7B%22Task%22:%22taskB%22,%22Systems%22:5,%22RunDateTime%22:%222022-04-21T10:10:00%22%7D,%7B%22Task%22:%22taskC%22,%22Systems%22:3,%22RunDateTime%22:%222022-04-25T10:10:00%22%7D%5D"`;
 
 exports[`useExport returns an export config toolbar config 1`] = `
 {
-  "all": [
-    {
-      "toolbarProps": {
-        "exportConfig": {
-          "isDisabled": false,
-          "onSelect": [Function],
-        },
-      },
-    },
-  ],
-  "current": {
-    "toolbarProps": {
-      "exportConfig": {
-        "isDisabled": false,
-        "onSelect": [Function],
-      },
+  "toolbarProps": {
+    "exportConfig": {
+      "isDisabled": false,
+      "onSelect": [Function],
     },
   },
-  "error": undefined,
 }
 `;

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/usePaginate.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/usePaginate.test.js.snap
@@ -57,15 +57,11 @@ exports[`usePaginate returns a paginate configuration 2`] = `
     "task_title": "taskB",
   },
   {
-    "end_time": "2022-04-28T11:10:00",
-    "id": 3,
-    "initiated_by": "Michael",
-    "run_date_time": "25 Apr 2022, 11:10 UTC",
-    "start_time": "2022-04-25T10:10:00",
-    "status": "Completed",
-    "systems_count": 3,
-    "task_slug": "taskc",
-    "task_title": "taskC",
+    "start_time": "2022-04
+57
+hehe","break!",
+    "systems_count": 42,
+    "task_title": "special one",
   },
 ]
 `;

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/usePaginate.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/usePaginate.test.js.snap
@@ -63,5 +63,13 @@ hehe","break!",
     "systems_count": 42,
     "task_title": "special one",
   },
+  {
+    "start_time": [
+      42,
+      "abc",
+    ],
+    "systems_count": 10,
+    "task_title": "another one with unexpected array",
+  },
 ]
 `;

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useRowsBuilder.tests.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useRowsBuilder.tests.js.snap
@@ -59,6 +59,26 @@ hehe","break!",
             "itemId": undefined,
             "jobId": undefined,
           },
+          {
+            "cells": [
+              {
+                "title": "another one with unexpected array",
+              },
+              {
+                "title": 10,
+              },
+              {
+                "title": [
+                  42,
+                  "abc",
+                ],
+              },
+            ],
+            "display_name": undefined,
+            "has_stdout": undefined,
+            "itemId": undefined,
+            "jobId": undefined,
+          },
         ],
       },
       "toolbarProps": {
@@ -115,6 +135,26 @@ hehe","break!",
               "title": "2022-04
 57
 hehe","break!",
+            },
+          ],
+          "display_name": undefined,
+          "has_stdout": undefined,
+          "itemId": undefined,
+          "jobId": undefined,
+        },
+        {
+          "cells": [
+            {
+              "title": "another one with unexpected array",
+            },
+            {
+              "title": 10,
+            },
+            {
+              "title": [
+                42,
+                "abc",
+              ],
             },
           ],
           "display_name": undefined,

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useRowsBuilder.tests.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useRowsBuilder.tests.js.snap
@@ -43,19 +43,21 @@ exports[`useRowsBuilder returns a rows configuration 1`] = `
           {
             "cells": [
               {
-                "title": "taskC",
+                "title": "special one",
               },
               {
-                "title": 3,
+                "title": 42,
               },
               {
-                "title": "2022-04-25T10:10:00",
+                "title": "2022-04
+57
+hehe","break!",
               },
             ],
             "display_name": undefined,
             "has_stdout": undefined,
             "itemId": undefined,
-            "jobId": 3,
+            "jobId": undefined,
           },
         ],
       },
@@ -104,19 +106,21 @@ exports[`useRowsBuilder returns a rows configuration 1`] = `
         {
           "cells": [
             {
-              "title": "taskC",
+              "title": "special one",
             },
             {
-              "title": 3,
+              "title": 42,
             },
             {
-              "title": "2022-04-25T10:10:00",
+              "title": "2022-04
+57
+hehe","break!",
             },
           ],
           "display_name": undefined,
           "has_stdout": undefined,
           "itemId": undefined,
-          "jobId": 3,
+          "jobId": undefined,
         },
       ],
     },

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableSort.test.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableSort.test.js.snap
@@ -11,6 +11,7 @@ exports[`useTableSort returns a table sort configuration 1`] = `
             "props": {
               "width": 35,
             },
+            "renderExport": [Function],
             "sortByProp": "task_title",
             "title": "Task",
             "transforms": [
@@ -32,6 +33,7 @@ exports[`useTableSort returns a table sort configuration 1`] = `
             "props": {
               "width": 20,
             },
+            "renderExport": [Function],
             "sortByProp": "start_time",
             "title": "Run date/time",
             "transforms": [
@@ -55,6 +57,7 @@ exports[`useTableSort returns a table sort configuration 1`] = `
           "props": {
             "width": 35,
           },
+          "renderExport": [Function],
           "sortByProp": "task_title",
           "title": "Task",
           "transforms": [
@@ -76,6 +79,7 @@ exports[`useTableSort returns a table sort configuration 1`] = `
           "props": {
             "width": 20,
           },
+          "renderExport": [Function],
           "sortByProp": "start_time",
           "title": "Run date/time",
           "transforms": [

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableTools.tests.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableTools.tests.js.snap
@@ -95,6 +95,26 @@ hehe","break!",
             "itemId": undefined,
             "jobId": undefined,
           },
+          {
+            "cells": [
+              {
+                "title": "another one with unexpected array",
+              },
+              {
+                "title": 10,
+              },
+              {
+                "title": [
+                  42,
+                  "abc",
+                ],
+              },
+            ],
+            "display_name": undefined,
+            "has_stdout": undefined,
+            "itemId": undefined,
+            "jobId": undefined,
+          },
         ],
         "sortBy": {
           "direction": "asc",
@@ -103,7 +123,7 @@ hehe","break!",
       },
       "toolbarProps": {
         "pagination": {
-          "itemCount": 3,
+          "itemCount": 4,
           "onPerPageSelect": [Function],
           "onSetPage": [Function],
           "page": 1,
@@ -203,6 +223,26 @@ hehe","break!",
             "itemId": undefined,
             "jobId": undefined,
           },
+          {
+            "cells": [
+              {
+                "title": "another one with unexpected array",
+              },
+              {
+                "title": 10,
+              },
+              {
+                "title": [
+                  42,
+                  "abc",
+                ],
+              },
+            ],
+            "display_name": undefined,
+            "has_stdout": undefined,
+            "itemId": undefined,
+            "jobId": undefined,
+          },
         ],
         "sortBy": {
           "direction": "asc",
@@ -211,7 +251,7 @@ hehe","break!",
       },
       "toolbarProps": {
         "pagination": {
-          "itemCount": 3,
+          "itemCount": 4,
           "onPerPageSelect": [Function],
           "onSetPage": [Function],
           "page": 1,
@@ -312,6 +352,26 @@ hehe","break!",
           "itemId": undefined,
           "jobId": undefined,
         },
+        {
+          "cells": [
+            {
+              "title": "another one with unexpected array",
+            },
+            {
+              "title": 10,
+            },
+            {
+              "title": [
+                42,
+                "abc",
+              ],
+            },
+          ],
+          "display_name": undefined,
+          "has_stdout": undefined,
+          "itemId": undefined,
+          "jobId": undefined,
+        },
       ],
       "sortBy": {
         "direction": "asc",
@@ -320,7 +380,7 @@ hehe","break!",
     },
     "toolbarProps": {
       "pagination": {
-        "itemCount": 3,
+        "itemCount": 4,
         "onPerPageSelect": [Function],
         "onSetPage": [Function],
         "page": 1,

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableTools.tests.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableTools.tests.js.snap
@@ -79,19 +79,21 @@ exports[`useTableTools returns tableProps 1`] = `
           {
             "cells": [
               {
-                "title": "taskC",
+                "title": "special one",
               },
               {
-                "title": 3,
+                "title": 42,
               },
               {
-                "title": "2022-04-25T10:10:00",
+                "title": "2022-04
+57
+hehe","break!",
               },
             ],
             "display_name": undefined,
             "has_stdout": undefined,
             "itemId": undefined,
-            "jobId": 3,
+            "jobId": undefined,
           },
         ],
         "sortBy": {
@@ -185,19 +187,21 @@ exports[`useTableTools returns tableProps 1`] = `
           {
             "cells": [
               {
-                "title": "taskC",
+                "title": "special one",
               },
               {
-                "title": 3,
+                "title": 42,
               },
               {
-                "title": "2022-04-25T10:10:00",
+                "title": "2022-04
+57
+hehe","break!",
               },
             ],
             "display_name": undefined,
             "has_stdout": undefined,
             "itemId": undefined,
-            "jobId": 3,
+            "jobId": undefined,
           },
         ],
         "sortBy": {
@@ -292,19 +296,21 @@ exports[`useTableTools returns tableProps 1`] = `
         {
           "cells": [
             {
-              "title": "taskC",
+              "title": "special one",
             },
             {
-              "title": 3,
+              "title": 42,
             },
             {
-              "title": "2022-04-25T10:10:00",
+              "title": "2022-04
+57
+hehe","break!",
             },
           ],
           "display_name": undefined,
           "has_stdout": undefined,
           "itemId": undefined,
-          "jobId": 3,
+          "jobId": undefined,
         },
       ],
       "sortBy": {

--- a/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableTools.tests.js.snap
+++ b/src/Utilities/hooks/useTableTools/__tests__/__snapshots__/useTableTools.tests.js.snap
@@ -10,6 +10,7 @@ exports[`useTableTools returns tableProps 1`] = `
             "props": {
               "width": 35,
             },
+            "renderExport": [Function],
             "sortByProp": "task_title",
             "title": "Task",
             "transforms": [
@@ -31,6 +32,7 @@ exports[`useTableTools returns tableProps 1`] = `
             "props": {
               "width": 20,
             },
+            "renderExport": [Function],
             "sortByProp": "start_time",
             "title": "Run date/time",
             "transforms": [
@@ -114,6 +116,7 @@ exports[`useTableTools returns tableProps 1`] = `
             "props": {
               "width": 35,
             },
+            "renderExport": [Function],
             "sortByProp": "task_title",
             "title": "Task",
             "transforms": [
@@ -135,6 +138,7 @@ exports[`useTableTools returns tableProps 1`] = `
             "props": {
               "width": 20,
             },
+            "renderExport": [Function],
             "sortByProp": "start_time",
             "title": "Run date/time",
             "transforms": [
@@ -219,6 +223,7 @@ exports[`useTableTools returns tableProps 1`] = `
           "props": {
             "width": 35,
           },
+          "renderExport": [Function],
           "sortByProp": "task_title",
           "title": "Task",
           "transforms": [
@@ -240,6 +245,7 @@ exports[`useTableTools returns tableProps 1`] = `
           "props": {
             "width": 20,
           },
+          "renderExport": [Function],
           "sortByProp": "start_time",
           "title": "Run date/time",
           "transforms": [

--- a/src/Utilities/hooks/useTableTools/__tests__/reportParser.test.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/reportParser.test.js
@@ -1,0 +1,68 @@
+import cloneDeep from 'lodash/cloneDeep';
+import { parseJobReport, prepareItems } from '../reportParser';
+import {
+  fixturesExtendedReport,
+  fixturesPlainReport,
+} from './__fixtures__/jobResultsItems.fixtures';
+
+describe('parseJobReport', () => {
+  it('should parse a job without report', () => {
+    const parsed = parseJobReport(fixturesPlainReport);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed).toMatchSnapshot();
+  });
+
+  it('should parse a job with report_json', () => {
+    const parsed = parseJobReport(fixturesExtendedReport);
+
+    expect(parsed).toHaveLength(8);
+    parsed.forEach(({ issue_parsed }) => {
+      expect(issue_parsed).toMatchSnapshot();
+    });
+  });
+
+  it('parses multiple remediatios for the extended report', () => {
+    const fixtures = cloneDeep(fixturesExtendedReport);
+    fixtures.results.report_json.entries[0].detail?.remediations?.push({
+      type: 'info',
+      context: 'Some info remediation.',
+    });
+    const result = parseJobReport(fixtures);
+
+    expect(result).toHaveLength(9);
+    expect(
+      result.some(
+        ({ issue_parsed }) => issue_parsed[6] === 'Some info remediation.'
+      )
+    ).toBeTruthy();
+  });
+
+  it('parses issue diagnosis for the extended report', () => {
+    const fixtures = cloneDeep(fixturesExtendedReport);
+    fixtures.results.report_json.entries[0].detail?.remediations?.push({
+      type: 'info',
+      context: 'Some info remediation.',
+    });
+    fixtures.results.report_json.entries[0].detail = {
+      ...fixtures.results.report_json.entries[0].detail,
+      diagnosis: { context: 'Test diagnosis text.' },
+    };
+    const result = parseJobReport(fixtures);
+
+    expect(result).toHaveLength(9);
+    expect(
+      result.filter(
+        ({ issue_parsed }) => issue_parsed[4] === 'Test diagnosis text.'
+      )
+    ).toHaveLength(2);
+  });
+});
+
+describe('prepareItems', () => {
+  it('should prepare items with report_json', () => {
+    const parsed = prepareItems([fixturesPlainReport, fixturesExtendedReport]);
+
+    expect(parsed).toHaveLength(9);
+  });
+});

--- a/src/Utilities/hooks/useTableTools/__tests__/reportParser.test.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/reportParser.test.js
@@ -13,13 +13,16 @@ describe('parseJobReport', () => {
     expect(parsed).toMatchSnapshot();
   });
 
-  it('should parse a job with report_json', () => {
+  it('should have correct length of parsed report_json', () => {
     const parsed = parseJobReport(fixturesExtendedReport);
 
     expect(parsed).toHaveLength(8);
-    parsed.forEach(({ issue_parsed }) => {
-      expect(issue_parsed).toMatchSnapshot();
-    });
+  });
+
+  it('should add issue_parsed', () => {
+    const parsed = parseJobReport(fixturesExtendedReport);
+
+    expect(parsed.map(({ issue_parsed }) => issue_parsed)).toMatchSnapshot();
   });
 
   it('parses multiple remediatios for the extended report', () => {

--- a/src/Utilities/hooks/useTableTools/__tests__/reportParser.test.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/reportParser.test.js
@@ -33,7 +33,8 @@ describe('parseJobReport', () => {
     expect(result).toHaveLength(9);
     expect(
       result.some(
-        ({ issue_parsed }) => issue_parsed[6] === 'Some info remediation.'
+        ({ issue_parsed }) =>
+          issue_parsed.remediationContext === 'Some info remediation.'
       )
     ).toBeTruthy();
   });
@@ -53,7 +54,7 @@ describe('parseJobReport', () => {
     expect(result).toHaveLength(9);
     expect(
       result.filter(
-        ({ issue_parsed }) => issue_parsed[4] === 'Test diagnosis text.'
+        ({ issue_parsed }) => issue_parsed.diagnosis === 'Test diagnosis text.'
       )
     ).toHaveLength(2);
   });

--- a/src/Utilities/hooks/useTableTools/__tests__/useExport.test.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/useExport.test.js
@@ -14,10 +14,10 @@ import {
   taskColumnsFixtures,
 } from './__fixtures__/columns.fixtures';
 import get from 'lodash/get';
-import { linkAndDownload } from '../useExportHelpers';
 import { waitFor } from '@testing-library/react';
+import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 
-jest.mock('../useExportHelpers');
+jest.mock('@redhat-cloud-services/frontend-components-utilities/helpers');
 
 describe('useExport', () => {
   let workingExporter = jest.fn(() => Promise.resolve(items));
@@ -120,24 +120,16 @@ describe('useExportWithItems', () => {
 
     result.current.toolbarProps.exportConfig.onSelect(undefined, 'csv');
     await waitFor(() => {
-      expect(linkAndDownload).toBeCalledWith(
-        'data:text/csv;charset=utf-8,System name,Status,Message,Test 1,Test 2\n"System deleted","Success","Completed","success",""some","array",1"',
-        expect.anything()
+      expect(downloadFile).toBeCalledWith(
+        'System name,Status,Message,Test 1,Test 2\n"System deleted","Success","Completed","success",""some","array",1"',
+        expect.anything(),
+        'csv'
       );
     });
   });
 });
 
 describe('csvForItems', () => {
-  it('contains encoding metadata', () => {
-    const result = csvForItems({
-      columns: taskColumnsFixtures,
-      items: items,
-    });
-
-    expect(result).toContain('data:text/csv;charset=utf-8');
-  });
-
   it('returns some example csv export of items', () => {
     const result = csvForItems({
       columns: taskColumnsFixtures,

--- a/src/Utilities/hooks/useTableTools/__tests__/useExport.test.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/useExport.test.js
@@ -121,7 +121,7 @@ describe('useExportWithItems', () => {
     result.current.toolbarProps.exportConfig.onSelect(undefined, 'csv');
     await waitFor(() => {
       expect(linkAndDownload).toBeCalledWith(
-        'data:text/csv;charset=utf-8,System name,Status,Message,Test 1,Test 2\n"System deleted","Success","Completed","success",some,array,1',
+        'data:text/csv;charset=utf-8,System name,Status,Message,Test 1,Test 2\n"System deleted","Success","Completed","success",""some","array",1"',
         expect.anything()
       );
     });
@@ -154,5 +154,23 @@ describe('csvForItems', () => {
     });
 
     expect(result).toMatchSnapshot();
+  });
+
+  it('adds extra double-quote if contained in cell', () => {
+    const result = csvForItems({
+      columns: taskColumnsFixtures,
+      items: items,
+    });
+
+    expect(result).toContain('hehe"",""break');
+  });
+
+  it('does not escape new line', () => {
+    const result = csvForItems({
+      columns: taskColumnsFixtures,
+      items,
+    });
+
+    expect(result).toContain('2022-04\n57\n');
   });
 });

--- a/src/Utilities/hooks/useTableTools/__tests__/useExport.test.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/useExport.test.js
@@ -121,7 +121,7 @@ describe('useExportWithItems', () => {
     result.current.toolbarProps.exportConfig.onSelect(undefined, 'csv');
     await waitFor(() => {
       expect(linkAndDownload).toBeCalledWith(
-        'data:text/csv;charset=utf-8,System%20name,Status,Message,Test%201,Test%202%0A%22System%2520deleted%22,%22Success%22,%22Completed%22,%22success%22,%22some,array,1%22',
+        'data:text/csv;charset=utf-8,System name,Status,Message,Test 1,Test 2\n"System deleted","Success","Completed","success",some,array,1',
         expect.anything()
       );
     });

--- a/src/Utilities/hooks/useTableTools/__tests__/usePaginate.test.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/usePaginate.test.js
@@ -28,7 +28,7 @@ describe('usePaginate', () => {
     const paginatedItems = result.current.paginator(items);
 
     expect(paginatedItems).toMatchSnapshot();
-    expect(paginatedItems.length).toBe(3);
+    expect(paginatedItems.length).toBe(4);
     expect(paginatedItems[1]).toBe(items[1]);
   });
 

--- a/src/Utilities/hooks/useTableTools/__tests__/useRowsBuilder.tests.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/useRowsBuilder.tests.js
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import items from './__fixtures__/items.fixtures';
-import columns from './__fixtures__/columns.fixtures';
+import { taskColumnsFixtures as columns } from './__fixtures__/columns.fixtures';
 import useRowsBuilder from '../useRowsBuilder';
 
 describe('useRowsBuilder', () => {

--- a/src/Utilities/hooks/useTableTools/__tests__/useTableSort.test.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/useTableSort.test.js
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import useTableSort, { useTableSortWithItems } from '../useTableSort';
-import columns from './__fixtures__/columns.fixtures';
+import { taskColumnsFixtures as columns } from './__fixtures__/columns.fixtures';
 
 describe('useTableSort', () => {
   it('returns a table sort configuration', () => {

--- a/src/Utilities/hooks/useTableTools/__tests__/useTableTools.tests.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/useTableTools.tests.js
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import useTableTools from '../useTableTools';
 import items from './__fixtures__/items.fixtures';
-import columns from './__fixtures__/columns.fixtures';
+import { taskColumnsFixtures as columns } from './__fixtures__/columns.fixtures';
 
 describe('useTableTools', () => {
   let options = {

--- a/src/Utilities/hooks/useTableTools/__tests__/useTableTools.tests.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/useTableTools.tests.js
@@ -13,7 +13,7 @@ describe('useTableTools', () => {
   it('returns tableProps', () => {
     const { result } = renderHook(() => useTableTools(items, columns, options));
     expect(result).toMatchSnapshot();
-    expect(result.current.tableProps.rows.length).toBe(3);
+    expect(result.current.tableProps.rows.length).toBe(4);
     expect(result.current.tableProps.cells.length).toBe(3);
   });
 

--- a/src/Utilities/hooks/useTableTools/reportParser.js
+++ b/src/Utilities/hooks/useTableTools/reportParser.js
@@ -1,7 +1,13 @@
 // extended utilities parse jobs with report_json available
 
-export const encodeCsvCell = (cell) =>
-  typeof cell === 'string' ? `"${cell.replaceAll('"', '""')}"` : cell;
+export const encodeCsvCell = (
+  cell // https://www.ietf.org/rfc/rfc4180.txt
+) =>
+  typeof cell === 'string'
+    ? `"${cell.replaceAll('"', '""')}"`
+    : Array.isArray(cell)
+    ? `"${cell.map(encodeCsvCell)}"`
+    : cell;
 
 const parseReportDiagnosis = (detail) => {
   const { diagnosis } = detail || {};

--- a/src/Utilities/hooks/useTableTools/reportParser.js
+++ b/src/Utilities/hooks/useTableTools/reportParser.js
@@ -12,14 +12,16 @@ const parseReportRemediations = (detail) => {
   const { remediations } = detail || {};
 
   if (Array.isArray(remediations)) {
-    return remediations.map(({ type, context }) => [type, context]);
+    return remediations.map(({ type, context }) => ({ type, context }));
   }
 
   if (typeof remediations === 'object') {
-    return [[remediations?.type ?? '', remediations?.context ?? '']];
+    return [
+      { type: remediations?.type ?? '', context: remediations?.context ?? '' },
+    ];
   }
 
-  return [['', '']];
+  return [{ type: '', context: '' }];
 };
 
 const parseReportJson = (report) => {
@@ -35,16 +37,27 @@ const parseReportJson = (report) => {
       const remediations = parseReportRemediations(detail);
 
       if (remediations.length > 0) {
-        return remediations.map((remediation) => [
+        return remediations.map((remediation) => ({
           title,
           severity,
           key,
           summary,
           diagnosis,
-          ...remediation,
-        ]);
+          remediationType: remediation.type,
+          remediationContext: remediation.context,
+        }));
       } else {
-        return [title, severity, key, summary, diagnosis];
+        return [
+          {
+            title,
+            severity,
+            key,
+            summary,
+            diagnosis,
+            remediationType: '',
+            remediationContext: '',
+          },
+        ];
       }
     })
     .flat();

--- a/src/Utilities/hooks/useTableTools/reportParser.js
+++ b/src/Utilities/hooks/useTableTools/reportParser.js
@@ -1,6 +1,7 @@
 // extended utilities parse jobs with report_json available
 
-export const encodeCsvString = (str) => `"${encodeURI(str)}"`;
+export const encodeCsvCell = (cell) =>
+  typeof cell === 'string' ? `"${cell.replaceAll('"', '""')}"` : cell;
 
 const parseReportDiagnosis = (detail) => {
   const { diagnosis } = detail || {};

--- a/src/Utilities/hooks/useTableTools/reportParser.js
+++ b/src/Utilities/hooks/useTableTools/reportParser.js
@@ -1,0 +1,70 @@
+// extended utilities parse jobs with report_json available
+
+export const encodeCsvString = (str) => `"${encodeURI(str)}"`;
+
+const parseReportDiagnosis = (detail) => {
+  const { diagnosis } = detail || {};
+
+  return diagnosis?.context ?? diagnosis?.[0]?.context ?? '';
+};
+
+const parseReportRemediations = (detail) => {
+  const { remediations } = detail || {};
+
+  if (Array.isArray(remediations)) {
+    return remediations.map(({ type, context }) => [type, context]);
+  }
+
+  if (typeof remediations === 'object') {
+    return [[remediations?.type ?? '', remediations?.context ?? '']];
+  }
+
+  return [['', '']];
+};
+
+const parseReportJson = (report) => {
+  const { entries } = report;
+
+  if (entries === undefined || entries === null) {
+    return [];
+  }
+
+  return entries
+    .map(({ title, severity, key, summary, detail }) => {
+      const diagnosis = parseReportDiagnosis(detail);
+      const remediations = parseReportRemediations(detail);
+
+      if (remediations.length > 0) {
+        return remediations.map((remediation) => [
+          title,
+          severity,
+          key,
+          summary,
+          diagnosis,
+          ...remediation,
+        ]);
+      } else {
+        return [title, severity, key, summary, diagnosis];
+      }
+    })
+    .flat();
+};
+
+export const parseJobReport = (job) => {
+  const { report_json } = job?.results || {};
+
+  if (report_json !== undefined && report_json !== null) {
+    const issues = parseReportJson(report_json);
+
+    if (issues.length === 0) {
+      return [job];
+    } else {
+      return issues.map((issue) => ({ ...job, issue_parsed: issue }));
+    }
+  }
+
+  return [job];
+};
+
+export const prepareItems = (items) =>
+  items.map((job) => parseJobReport(job)).flat();

--- a/src/Utilities/hooks/useTableTools/useExport.js
+++ b/src/Utilities/hooks/useTableTools/useExport.js
@@ -1,18 +1,11 @@
+import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { camelCase, getProperty } from '../../helpers';
 import { encodeCsvCell } from './reportParser';
-import { linkAndDownload } from './useExportHelpers';
 
 const CSV_FILE_PREFIX = 'tasks-export';
 const CSV_DELIMITER = ',';
-const ENCODINGS = {
-  csv: 'text/csv',
-  json: 'application/json',
-};
 
-const filename = (format) =>
-  CSV_FILE_PREFIX + '-' + new Date().toISOString() + '.' + format;
-
-const encoding = (format) => `data:${ENCODINGS[format]};charset=utf-8`;
+const filename = () => CSV_FILE_PREFIX + '-' + new Date().toISOString();
 
 const textForCell = (row, column) => {
   const { exportKey, renderExport } = column;
@@ -37,7 +30,7 @@ export const csvForItems = ({ items, columns }) => {
     ),
   ];
 
-  return `${encoding('csv')},${csvRows.join('\n')}`;
+  return csvRows.join('\n');
 };
 
 export const jsonForItems = ({ items, columns }) => {
@@ -51,7 +44,7 @@ export const jsonForItems = ({ items, columns }) => {
     }, {})
   );
 
-  return `${encoding('json')},${JSON.stringify(result)}`;
+  return JSON.stringify(result);
 };
 
 const callCallback = (callback, ...args) => callback && callback(...args);
@@ -80,16 +73,16 @@ const useExport = ({
     const formater = format === 'csv' ? csvForItems : jsonForItems;
 
     if (items) {
-      return linkAndDownload(
+      downloadFile(
         formater({
           items,
           columns: exportableColumns,
         }),
-        filename(format)
+        filename(),
+        format
       );
     } else {
       console.info('No items returned for export');
-      return;
     }
   };
 

--- a/src/Utilities/hooks/useTableTools/useExport.js
+++ b/src/Utilities/hooks/useTableTools/useExport.js
@@ -51,7 +51,7 @@ export const jsonForItems = ({ items, columns }) => {
     }, {})
   );
 
-  return encodeURI(`${encoding('json')},${JSON.stringify(result)}`);
+  return `${encoding('json')},${JSON.stringify(result)}`;
 };
 
 const callCallback = (callback, ...args) => callback && callback(...args);

--- a/src/Utilities/hooks/useTableTools/useExport.js
+++ b/src/Utilities/hooks/useTableTools/useExport.js
@@ -1,5 +1,5 @@
 import { camelCase, getProperty } from '../../helpers';
-import { encodeCsvString } from './reportParser';
+import { encodeCsvCell } from './reportParser';
 import { linkAndDownload } from './useExportHelpers';
 
 const CSV_FILE_PREFIX = 'tasks-export';
@@ -32,12 +32,12 @@ export const csvForItems = ({ items, columns }) => {
     header,
     ...items.map((row) =>
       columns
-        .map((column) => encodeCsvString(textForCell(row, column)))
+        .map((column) => encodeCsvCell(textForCell(row, column)))
         .join(CSV_DELIMITER)
     ),
   ];
 
-  return encodeURI(`${encoding('csv')},${csvRows.join('\n')}`);
+  return `${encoding('csv')},${csvRows.join('\n')}`;
 };
 
 export const jsonForItems = ({ items, columns }) => {

--- a/src/Utilities/hooks/useTableTools/useExportHelpers.js
+++ b/src/Utilities/hooks/useTableTools/useExportHelpers.js
@@ -1,6 +1,0 @@
-export const linkAndDownload = (data, filename) => {
-  const link = document.createElement('a');
-  link.href = data;
-  link.download = filename;
-  link.click();
-};

--- a/src/Utilities/hooks/useTableTools/useExportHelpers.js
+++ b/src/Utilities/hooks/useTableTools/useExportHelpers.js
@@ -1,0 +1,6 @@
+export const linkAndDownload = (data, filename) => {
+  const link = document.createElement('a');
+  link.href = data;
+  link.download = filename;
+  link.click();
+};


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-3781.

This improves the CSV and JSON export of the completed task report. In addition to System name, Status, Message columns, it now also includes further information about the executed job (from `report`, `report_json` fields).

- The `useExport` hook now supports `prepareItems` that allows to pre-process the items from the table before the CSV report is generated and `extraExportColumns` that extend the visible columns with the columns that will be added in the final CSV/JSON export.

## How to test

Go to /tasks/executed and find any executed job. Try to find the results with some findings (warnings, errors, info messages) or just with some plain report. Export the table as CSV/JSON structure and verify it's correct and up to the information present in the UI.