### PR TITLE
fix(RHINENG-10046): Rename Inhibitor back to Overridable

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
+++ b/src/SmartComponents/CompletedTaskDetails/TaskEntries.js
@@ -15,7 +15,7 @@ const converttorhelconversionSeverityMap = {
     severityLevel: 2500,
   },
   overridable: {
-    text: 'Inhibitor',
+    text: 'Overridable',
     icon: <ExclamationCircleIcon />,
     iconSeverityColor: 'danger',
     titleColor: '#A30000',
@@ -59,7 +59,7 @@ const converttorhelconversionstageSeverityMap = {
     severityLevel: 2500,
   },
   overridable: {
-    text: 'Inhibitor',
+    text: 'Overridable',
     icon: <ExclamationCircleIcon />,
     iconSeverityColor: 'danger',
     titleColor: '#A30000',
@@ -102,7 +102,7 @@ const converttorhelanalysisSeverityMap = {
     severityLevel: 2500,
   },
   overridable: {
-    text: 'Inhibitor',
+    text: 'Overridable',
     icon: <ExclamationCircleIcon />,
     iconSeverityColor: 'danger',
     titleColor: '#A30000',
@@ -146,7 +146,7 @@ const converttorhelanalysisstageSeverityMap = {
     severityLevel: 2500,
   },
   overridable: {
-    text: 'Inhibitor',
+    text: 'Overridable',
     icon: <ExclamationCircleIcon />,
     iconSeverityColor: 'danger',
     titleColor: '#A30000',

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -1050,7 +1050,7 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                             <span
                                               class="pf-v5-c-label__text"
                                             >
-                                              Inhibitor
+                                              Overridable
                                             </span>
                                           </span>
                                         </span>
@@ -2258,7 +2258,7 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                             <span
                                               class="pf-v5-c-label__text"
                                             >
-                                              Inhibitor
+                                              Overridable
                                             </span>
                                           </span>
                                         </span>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-10046.

Reverts https://github.com/RedHatInsights/tasks-frontend/commit/ccc7419249ca430a96a7c98f17ba7f10c411d7cb.

When we allow users' input in Tasks, it will be possible for a customer to override an inhibitor detected in a pre-conversion analysis report directly in the Insights UI. The goal of this ticket is to let customers visually know that an overridable inhibitor has been detected, and to document how to override it.

An "overridable" label is shown instead of the current "inhibitor" label when a detected conversion inhibitor is overridable
The "overridable" label was originally being displayed but it was replaced with "inhibitor" under [HMS-3139](https://issues.redhat.com/browse/HMS-3139) when we realized it's not possible to override an inhibitor.