### PR TITLE
fix(RHINENG-10944): Move Drawer out of Page component

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -12,7 +12,6 @@ import {
   Card,
   Flex,
   FlexItem,
-  Page,
   Text,
   TextContent,
   TextVariants,
@@ -198,17 +197,12 @@ const CompletedTaskDetails = () => {
   };
 
   return (
-    <Page
-      notificationDrawer={
-        <JobLogDrawer
-          isLogDrawerExpanded={isLogDrawerExpanded}
-          jobName={jobName}
-          jobId={jobId}
-          setIsLogDrawerExpanded={setIsLogDrawerExpanded}
-        />
-      }
-      isNotificationDrawerExpanded={isLogDrawerExpanded}
+    <JobLogDrawer
       className="my-app-modified-drawer-width"
+      isLogDrawerExpanded={isLogDrawerExpanded}
+      jobName={jobName}
+      jobId={jobId}
+      setIsLogDrawerExpanded={setIsLogDrawerExpanded}
     >
       {runTaskModalOpened && (
         <RunTaskModal
@@ -361,7 +355,7 @@ const CompletedTaskDetails = () => {
           </section>
         </React.Fragment>
       )}
-    </Page>
+    </JobLogDrawer>
   );
 };
 

--- a/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobLogDrawer.js
+++ b/src/SmartComponents/CompletedTaskDetails/JobResultsDetails/JobLogDrawer.js
@@ -22,6 +22,7 @@ const JobLogDrawer = ({
   jobName,
   jobId,
   setIsLogDrawerExpanded,
+  ...props
 }) => {
   const [stdout, setStdOut] = useState();
   useEffect(() => {
@@ -44,7 +45,7 @@ const JobLogDrawer = ({
   };
 
   const panelContent = (
-    <DrawerPanelContent id="log-drawer" defaultSize="100%">
+    <DrawerPanelContent id="log-drawer">
       <DrawerHead>
         <TextContent>
           <Text component={TextVariants.h1}>
@@ -64,7 +65,7 @@ const JobLogDrawer = ({
   );
 
   return (
-    <Drawer isExpanded={isLogDrawerExpanded} onExpand={onExpand}>
+    <Drawer isExpanded={isLogDrawerExpanded} onExpand={onExpand} {...props}>
       <DrawerContent panelContent={panelContent}>
         <DrawerContentBody>{children}</DrawerContentBody>
       </DrawerContent>

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -3,157 +3,417 @@
 exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-page my-app-modified-drawer-width"
+    class="pf-v5-c-drawer my-app-modified-drawer-width"
   >
     <div
-      class="pf-v5-c-page__drawer"
+      class="pf-v5-c-drawer__main"
     >
       <div
-        class="pf-v5-c-drawer"
+        class="pf-v5-c-drawer__content"
       >
         <div
-          class="pf-v5-c-drawer__main"
+          class="pf-v5-c-drawer__body"
         >
-          <div
-            class="pf-v5-c-drawer__content"
+          <section
+            class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+            data-ouia-component-id="OUIA-Generated-RHI/Header-true-3"
+            data-ouia-component-type="RHI/Header"
+            data-ouia-safe="true"
+            widget-type="InsightsPageHeader"
+          >
+            <nav
+              aria-label="Breadcrumb"
+              class="pf-v5-c-breadcrumb"
+              data-ouia-component-id="completed-tasks-details-breadcrumb"
+              data-ouia-component-type="PF5/Breadcrumb"
+              data-ouia-safe="true"
+            >
+              <ol
+                class="pf-v5-c-breadcrumb__list"
+                role="list"
+              >
+                <li
+                  class="pf-v5-c-breadcrumb__item"
+                >
+                  <a
+                    class="pf-v5-c-breadcrumb__link"
+                    href="/insights/tasks/executed"
+                  >
+                    Tasks
+                  </a>
+                </li>
+                <li
+                  class="pf-v5-c-breadcrumb__item"
+                >
+                  <span
+                    class="pf-v5-c-breadcrumb__item-divider"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                      />
+                    </svg>
+                  </span>
+                  convert-to-rhel-analysis task
+                </li>
+              </ol>
+            </nav>
+            <div
+              class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
+            >
+              <div
+                class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
+              >
+                <div
+                  class=""
+                >
+                  <div
+                    class="pf-v5-l-flex pf-m-justify-content-space-between"
+                  >
+                    <div
+                      class=""
+                    >
+                      <h1
+                        class="pf-v5-c-title pf-m-2xl"
+                        data-ouia-component-id="OUIA-Generated-RHI/Header-true-4"
+                        data-ouia-component-type="RHI/Header"
+                        data-ouia-safe="true"
+                        widget-type="InsightsPageHeaderTitle"
+                      >
+                        convert-to-rhel-analysis task
+                      </h1>
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-c-content"
+                  >
+                    <small
+                      class=""
+                      data-ouia-component-id="OUIA-Generated-Text-3"
+                      data-ouia-component-type="PF5/Text"
+                      data-ouia-safe="true"
+                      data-pf-content="true"
+                    >
+                      Convert to RHEL Analysis
+                    </small>
+                  </div>
+                </div>
+                <div
+                  class=""
+                >
+                  <p>
+                    For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="pf-v5-l-flex pf-m-align-right"
+              >
+                <div
+                  class=""
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="convert-to-rhel-analysis-run-task-button"
+                    class="pf-v5-c-button pf-m-secondary"
+                    data-ouia-component-id="OUIA-Generated-Button-secondary-2"
+                    data-ouia-component-type="PF5/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    Run task again
+                  </button>
+                </div>
+              </div>
+              <div
+                class="pf-v5-l-flex pf-m-align-right"
+              >
+                <div
+                  class=""
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-label="Task details menu toggle"
+                    class="pf-v5-c-menu-toggle pf-m-plain"
+                    id="executed-task-kebab"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 192 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section
+            class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
           >
             <div
-              class="pf-v5-c-drawer__body"
+              class="pf-v5-c-card"
+              data-ouia-component-id="OUIA-Generated-Card-3"
+              data-ouia-component-type="PF5/Card"
+              data-ouia-safe="true"
+              id=""
             >
-              <main
-                class="pf-v5-c-page__main"
-                tabindex="-1"
+              <div
+                class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
               >
-                <section
-                  class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
-                  data-ouia-component-id="OUIA-Generated-RHI/Header-true-3"
-                  data-ouia-component-type="RHI/Header"
-                  data-ouia-safe="true"
-                  widget-type="InsightsPageHeader"
+                <div
+                  class="pf-v5-l-flex pf-m-column"
                 >
-                  <nav
-                    aria-label="Breadcrumb"
-                    class="pf-v5-c-breadcrumb"
-                    data-ouia-component-id="completed-tasks-details-breadcrumb"
-                    data-ouia-component-type="PF5/Breadcrumb"
-                    data-ouia-safe="true"
-                  >
-                    <ol
-                      class="pf-v5-c-breadcrumb__list"
-                      role="list"
-                    >
-                      <li
-                        class="pf-v5-c-breadcrumb__item"
-                      >
-                        <a
-                          class="pf-v5-c-breadcrumb__link"
-                          href="/insights/tasks/executed"
-                        >
-                          Tasks
-                        </a>
-                      </li>
-                      <li
-                        class="pf-v5-c-breadcrumb__item"
-                      >
-                        <span
-                          class="pf-v5-c-breadcrumb__item-divider"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 256 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                            />
-                          </svg>
-                        </span>
-                        convert-to-rhel-analysis task
-                      </li>
-                    </ol>
-                  </nav>
                   <div
-                    class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
+                    class=""
+                  >
+                    <b>
+                      Systems
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    4
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Run start
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    01 Jun 2023, 19:58 UTC
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Run end
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    -
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Initiated by
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    insights-qa
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Systems with alerts
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    -
+                  </div>
+                </div>
+              </div>
+            </div>
+            <br />
+            <div
+              class="pf-v5-c-card"
+              data-ouia-component-id="OUIA-Generated-Card-4"
+              data-ouia-component-type="PF5/Card"
+              data-ouia-safe="true"
+              id=""
+            >
+              <div
+                class="pf-v5-c-toolbar  ins-c-primary-toolbar"
+                data-ouia-component-id="PrimaryToolbar"
+                data-ouia-component-type="PF5/Toolbar"
+                data-ouia-safe="true"
+                id="ins-primary-data-toolbar"
+              >
+                <div
+                  class="pf-v5-c-toolbar__content"
+                >
+                  <div
+                    class="pf-v5-c-toolbar__content-section"
                   >
                     <div
-                      class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
+                      class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
                     >
                       <div
-                        class=""
+                        class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
                       >
                         <div
-                          class="pf-v5-l-flex pf-m-justify-content-space-between"
+                          class="pf-v5-l-split ins-c-conditional-filter"
                         >
                           <div
-                            class=""
+                            class="pf-v5-l-split__item"
                           >
-                            <h1
-                              class="pf-v5-c-title pf-m-2xl"
-                              data-ouia-component-id="OUIA-Generated-RHI/Header-true-4"
-                              data-ouia-component-type="RHI/Header"
-                              data-ouia-safe="true"
-                              widget-type="InsightsPageHeaderTitle"
+                            <button
+                              aria-expanded="false"
+                              aria-label="Conditional filter toggle"
+                              class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
+                              data-ouia-component-id="ConditionalFilterToggle"
+                              type="button"
                             >
-                              convert-to-rhel-analysis task
-                            </h1>
+                              <span
+                                class="pf-v5-c-menu-toggle__text"
+                              >
+                                <span
+                                  class="pf-v5-c-icon pf-m-md"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon__content"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                                <span
+                                  class="ins-c-conditional-filter__value-selector"
+                                >
+                                  Name
+                                </span>
+                              </span>
+                              <span
+                                class="pf-v5-c-menu-toggle__controls"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item pf-m-fill"
+                            data-ouia-component-id="ConditionalFilter"
+                          >
+                            <span
+                              class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
+                            >
+                              <input
+                                aria-invalid="false"
+                                aria-label="text input"
+                                data-ouia-component-id="ConditionalFilter"
+                                data-ouia-component-type="PF5/TextInput"
+                                data-ouia-safe="true"
+                                placeholder="Filter by name"
+                                type="text"
+                                value=""
+                                widget-type="InsightsInput"
+                              />
+                              <span
+                                class="pf-v5-c-form-control__utilities"
+                              >
+                                <span
+                                  class="pf-v5-c-form-control__icon"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon pf-m-md ins-c-search-icon"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </span>
+                              </span>
+                            </span>
                           </div>
                         </div>
-                        <div
-                          class="pf-v5-c-content"
-                        >
-                          <small
-                            class=""
-                            data-ouia-component-id="OUIA-Generated-Text-3"
-                            data-ouia-component-type="PF5/Text"
-                            data-ouia-safe="true"
-                            data-pf-content="true"
-                          >
-                            Convert to RHEL Analysis
-                          </small>
-                        </div>
-                      </div>
-                      <div
-                        class=""
-                      >
-                        <p>
-                          For connected systems running distributions compatible with RHEL 7 or RHEL 8 (for example, CentOS 7), the RHEL preconversion analysis will predict potential conflicts before you convert. Run this task to understand the impact of a conversion on your fleet and make a remediation plan before your maintenance window begins.
-                        </p>
                       </div>
                     </div>
                     <div
-                      class="pf-v5-l-flex pf-m-align-right"
+                      class="pf-v5-c-toolbar__item pf-m-spacer-sm"
                     >
                       <div
-                        class=""
-                      >
-                        <button
-                          aria-disabled="false"
-                          aria-label="convert-to-rhel-analysis-run-task-button"
-                          class="pf-v5-c-button pf-m-secondary"
-                          data-ouia-component-id="OUIA-Generated-Button-secondary-2"
-                          data-ouia-component-type="PF5/Button"
-                          data-ouia-safe="true"
-                          type="button"
-                        >
-                          Run task again
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="pf-v5-l-flex pf-m-align-right"
-                    >
-                      <div
-                        class=""
+                        style="display: contents;"
                       >
                         <button
                           aria-expanded="false"
-                          aria-label="Task details menu toggle"
+                          aria-label="Export"
                           class="pf-v5-c-menu-toggle pf-m-plain"
-                          id="executed-task-kebab"
                           type="button"
                         >
                           <svg
@@ -162,188 +422,624 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                             fill="currentColor"
                             height="1em"
                             role="img"
-                            viewBox="0 0 192 512"
+                            viewBox="0 0 1024 1024"
                             width="1em"
                           >
                             <path
-                              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                              d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
                             />
                           </svg>
                         </button>
                       </div>
                     </div>
-                  </div>
-                </section>
-                <section
-                  class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
-                >
-                  <div
-                    class="pf-v5-c-card"
-                    data-ouia-component-id="OUIA-Generated-Card-3"
-                    data-ouia-component-type="PF5/Card"
-                    data-ouia-safe="true"
-                    id=""
-                  >
                     <div
-                      class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
+                      class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
                     >
                       <div
-                        class="pf-v5-l-flex pf-m-column"
+                        class="pf-v5-c-pagination pf-m-compact"
+                        data-ouia-component-id="CompactPagination"
+                        data-ouia-component-type="PF5/Pagination"
+                        data-ouia-safe="true"
+                        id="options-menu-top-pagination"
+                        style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                       >
                         <div
-                          class=""
+                          class="pf-v5-c-pagination__total-items"
                         >
                           <b>
-                            Systems
+                            1 - 4
                           </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          4
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
+                           of 
                           <b>
-                            Run start
+                            4
                           </b>
+                           
                         </div>
-                        <div
-                          class=""
+                        <div>
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                            id="options-menu-top-toggle"
+                            type="button"
+                          >
+                            <span
+                              class="pf-v5-c-menu-toggle__text"
+                            >
+                              <b>
+                                1 - 4
+                              </b>
+                               of 
+                              <b>
+                                4
+                              </b>
+                               
+                            </span>
+                            <span
+                              class="pf-v5-c-menu-toggle__controls"
+                            >
+                              <span
+                                class="pf-v5-c-menu-toggle__toggle-icon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 320 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  />
+                                </svg>
+                              </span>
+                            </span>
+                          </button>
+                        </div>
+                        <nav
+                          aria-label="Pagination"
+                          class="pf-v5-c-pagination__nav"
                         >
-                          01 Jun 2023, 19:58 UTC
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
-                          <b>
-                            Run end
-                          </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          -
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
-                          <b>
-                            Initiated by
-                          </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          insights-qa
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
-                          <b>
-                            Systems with alerts
-                          </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          -
-                        </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-control"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to previous page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="previous"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-control"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to next page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="next"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </nav>
                       </div>
                     </div>
                   </div>
-                  <br />
+                </div>
+                <div
+                  class="pf-v5-c-toolbar__content pf-m-hidden"
+                  hidden=""
+                >
                   <div
-                    class="pf-v5-c-card"
-                    data-ouia-component-id="OUIA-Generated-Card-4"
-                    data-ouia-component-type="PF5/Card"
+                    class="pf-v5-c-toolbar__group"
+                  />
+                </div>
+              </div>
+              <table
+                aria-label="2909-completed-jobs"
+                class="pf-v5-c-table pf-m-grid-md"
+                data-ouia-component-id="2909-completed-jobs-table"
+                data-ouia-component-type="PF5/Table"
+                data-ouia-safe="true"
+                role="grid"
+              >
+                <thead
+                  class="pf-v5-c-table__thead"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-7"
+                    data-ouia-component-type="PF5/TableRow"
                     data-ouia-safe="true"
-                    id=""
                   >
-                    <div
-                      class="pf-v5-c-toolbar  ins-c-primary-toolbar"
-                      data-ouia-component-id="PrimaryToolbar"
-                      data-ouia-component-type="PF5/Toolbar"
-                      data-ouia-safe="true"
-                      id="ins-primary-data-toolbar"
+                    <th
+                      class="pf-v5-c-table__th"
+                      data-key="0"
+                      data-label=""
+                      scope=""
+                      tabindex="-1"
+                    />
+                    <th
+                      aria-sort="none"
+                      class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      scope="col"
+                      tabindex="-1"
                     >
-                      <div
-                        class="pf-v5-c-toolbar__content"
+                      <button
+                        class="pf-v5-c-table__button"
+                        type="button"
                       >
                         <div
-                          class="pf-v5-c-toolbar__content-section"
+                          class="pf-v5-c-table__button-content"
                         >
-                          <div
-                            class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+                          <span
+                            class="pf-v5-c-table__text"
                           >
-                            <div
-                              class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                            System name
+                          </span>
+                          <span
+                            class="pf-v5-c-table__sort-indicator"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 256 512"
+                              width="1em"
                             >
-                              <div
-                                class="pf-v5-l-split ins-c-conditional-filter"
+                              <path
+                                d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      scope="col"
+                      tabindex="-1"
+                    >
+                      <button
+                        class="pf-v5-c-table__button"
+                        type="button"
+                      >
+                        <div
+                          class="pf-v5-c-table__button-content"
+                        >
+                          <span
+                            class="pf-v5-c-table__text"
+                          >
+                            Status
+                          </span>
+                          <span
+                            class="pf-v5-c-table__sort-indicator"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 256 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="ascending"
+                      class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      scope="col"
+                      tabindex="-1"
+                    >
+                      <button
+                        class="pf-v5-c-table__button"
+                        type="button"
+                      >
+                        <div
+                          class="pf-v5-c-table__button-content"
+                        >
+                          <span
+                            class="pf-v5-c-table__text"
+                          >
+                            Message
+                          </span>
+                          <span
+                            class="pf-v5-c-table__sort-indicator"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 256 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </button>
+                    </th>
+                    <td
+                      class="pf-v5-c-table__th"
+                      data-key="4"
+                      data-label=""
+                      tabindex="-1"
+                    />
+                  </tr>
+                </thead>
+                <tbody
+                  class="pf-v5-c-table__tbody"
+                  role="rowgroup"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-13"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td"
+                      data-key="0"
+                      tabindex="-1"
+                    />
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      centos7-test-device-1
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Success
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
+                      >
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        >
+                          No inhibtors found, conversion should run smoothly for this system.
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+                <tbody
+                  class="pf-v5-c-table__tbody"
+                  role="rowgroup"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-14"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                      data-key="0"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-expanded="false"
+                        aria-label="Details"
+                        aria-labelledby="simple-node1 expandable-toggle1"
+                        class="pf-v5-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                        data-ouia-component-type="PF5/Button"
+                        data-ouia-safe="true"
+                        id="expandable-toggle1"
+                        type="button"
+                      >
+                        <div
+                          class="pf-v5-c-table__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                            />
+                          </svg>
+                        </div>
+                      </button>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      centos7-test-device-3
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Success
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
+                      >
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        >
+                          No inhibtors found, conversion should run smoothly for this system.
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                  <tr
+                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                    data-ouia-component-id="OUIA-Generated-TableRow-15"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                    hidden=""
+                  >
+                    <td
+                      class="pf-v5-c-table__td"
+                      colspan="4"
+                      data-key="0"
+                      id="expanded-content2"
+                      tabindex="-1"
+                    >
+                      <div>
+                        <table
+                          class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                          data-ouia-component-id="OUIA-Generated-Table-5"
+                          data-ouia-component-type="PF5/Table"
+                          data-ouia-safe="true"
+                          role="grid"
+                          style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                        >
+                          <tbody
+                            class="pf-v5-c-table__tbody"
+                            role="rowgroup"
+                          >
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-16"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                            >
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
                               >
-                                <div
-                                  class="pf-v5-l-split__item"
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node0 expand-toggle0"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle0"
+                                  type="button"
                                 >
-                                  <button
-                                    aria-expanded="false"
-                                    aria-label="Conditional filter toggle"
-                                    class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
-                                    data-ouia-component-id="ConditionalFilterToggle"
-                                    type="button"
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
                                   >
                                     <span
-                                      class="pf-v5-c-menu-toggle__text"
+                                      class="pf-v5-c-icon__content pf-m-danger"
                                     >
-                                      <span
-                                        class="pf-v5-c-icon pf-m-md"
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
                                       >
-                                        <span
-                                          class="pf-v5-c-icon__content"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </span>
-                                      <span
-                                        class="ins-c-conditional-filter__value-selector"
-                                      >
-                                        Name
-                                      </span>
+                                        <path
+                                          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                        />
+                                      </svg>
                                     </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(163, 0, 0);"
+                                  >
+                                    <strong>
+                                      Third party packages detected
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-17"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-red pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
                                     <span
-                                      class="pf-v5-c-menu-toggle__controls"
+                                      class="pf-v5-c-label__content"
                                     >
                                       <span
-                                        class="pf-v5-c-menu-toggle__toggle-icon"
+                                        class="pf-v5-c-label__icon"
                                       >
                                         <svg
                                           aria-hidden="true"
@@ -351,145 +1047,161 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                           fill="currentColor"
                                           height="1em"
                                           role="img"
-                                          viewBox="0 0 320 512"
+                                          viewBox="0 0 512 512"
                                           width="1em"
                                         >
                                           <path
-                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
                                           />
                                         </svg>
                                       </span>
-                                    </span>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-l-split__item pf-m-fill"
-                                  data-ouia-component-id="ConditionalFilter"
-                                >
-                                  <span
-                                    class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
-                                  >
-                                    <input
-                                      aria-invalid="false"
-                                      aria-label="text input"
-                                      data-ouia-component-id="ConditionalFilter"
-                                      data-ouia-component-type="PF5/TextInput"
-                                      data-ouia-safe="true"
-                                      placeholder="Filter by name"
-                                      type="text"
-                                      value=""
-                                      widget-type="InsightsInput"
-                                    />
-                                    <span
-                                      class="pf-v5-c-form-control__utilities"
-                                    >
                                       <span
-                                        class="pf-v5-c-form-control__icon"
+                                        class="pf-v5-c-label__text"
                                       >
-                                        <span
-                                          class="pf-v5-c-icon pf-m-md ins-c-search-icon"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
+                                        Overridable
                                       </span>
                                     </span>
                                   </span>
                                 </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="pf-v5-c-toolbar__item pf-m-spacer-sm"
-                          >
-                            <div
-                              style="display: contents;"
-                            >
-                              <button
-                                aria-expanded="false"
-                                aria-label="Export"
-                                class="pf-v5-c-menu-toggle pf-m-plain"
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 1024 1024"
-                                  width="1em"
+                                <div
+                                  class="entry-title"
                                 >
-                                  <path
-                                    d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
-                          >
-                            <div
-                              class="pf-v5-c-pagination pf-m-compact"
-                              data-ouia-component-id="CompactPagination"
-                              data-ouia-component-type="PF5/Pagination"
+                                  Third party packages detected
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      Third party packages will not be replaced during the conversion.
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Diagnosis
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span>
+                                          Only packages signed by CentOS Linux are to be replaced. Red Hat support won't be provided for the following third party packages:convert2rhel-1.5.0-2.20231124114206033039.main.14.g938833b.el7.noarch
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Remediation
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span
+                                          class="remediations-font-family"
+                                        >
+                                          If you wish to ignore this message, set the environment variable 'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' to 1.
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      LIST_THIRD_PARTY_PACKAGES::THIRD_PARTY_PACKAGE_DETECTED
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-18"
+                              data-ouia-component-type="PF5/TableRow"
                               data-ouia-safe="true"
-                              id="options-menu-top-pagination"
-                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                             >
-                              <div
-                                class="pf-v5-c-pagination__total-items"
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
                               >
-                                <b>
-                                  1 - 4
-                                </b>
-                                 of 
-                                <b>
-                                  4
-                                </b>
-                                 
-                              </div>
-                              <div>
                                 <button
+                                  aria-disabled="false"
                                   aria-expanded="false"
-                                  aria-haspopup="listbox"
-                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                                  id="options-menu-top-toggle"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node1 expand-toggle1"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle1"
                                   type="button"
                                 >
-                                  <span
-                                    class="pf-v5-c-menu-toggle__text"
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
                                   >
-                                    <b>
-                                      1 - 4
-                                    </b>
-                                     of 
-                                    <b>
-                                      4
-                                    </b>
-                                     
-                                  </span>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
                                   <span
-                                    class="pf-v5-c-menu-toggle__controls"
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
                                   >
                                     <span
-                                      class="pf-v5-c-menu-toggle__toggle-icon"
+                                      class="pf-v5-c-icon__content pf-m-warning"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -497,34 +1209,140 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                         fill="currentColor"
                                         height="1em"
                                         role="img"
-                                        viewBox="0 0 320 512"
+                                        viewBox="0 0 576 512"
                                         width="1em"
                                       >
                                         <path
-                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                          d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
                                         />
                                       </svg>
                                     </span>
                                   </span>
-                                </button>
-                              </div>
-                              <nav
-                                aria-label="Pagination"
-                                class="pf-v5-c-pagination__nav"
+                                  <span
+                                    style="color: rgb(121, 80, 0);"
+                                  >
+                                    <strong>
+                                      Dbus is running check skip
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-19"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
                               >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 576 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        Warning
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
                                 <div
-                                  class="pf-v5-c-pagination__nav-control"
+                                  class="entry-title"
                                 >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to previous page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="previous"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-7"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
+                                  Dbus is running check skip
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      Skipping the check because we have been asked not to subscribe this system to RHSM
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      DBUS_IS_RUNNING::SECURE_BOOT_DETECTED
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-20"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                            >
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
+                              >
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node2 expand-toggle2"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle2"
+                                  type="button"
+                                >
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -532,1927 +1350,640 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                       fill="currentColor"
                                       height="1em"
                                       role="img"
-                                      viewBox="0 0 256 512"
+                                      viewBox="0 0 320 512"
                                       width="1em"
                                     >
                                       <path
-                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
                                       />
                                     </svg>
-                                  </button>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-info"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(0, 41, 82);"
+                                  >
+                                    <strong>
+                                      Repository file package removal
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-21"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-blue pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        Info
+                                      </span>
+                                    </span>
+                                  </span>
                                 </div>
                                 <div
-                                  class="pf-v5-c-pagination__nav-control"
+                                  class="entry-title"
                                 >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to next page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="next"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-8"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                      />
-                                    </svg>
-                                  </button>
+                                  Repository file package removal
                                 </div>
-                              </nav>
-                            </div>
-                          </div>
-                        </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
                       </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    />
+                  </tr>
+                </tbody>
+                <tbody
+                  class="pf-v5-c-table__tbody"
+                  role="rowgroup"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-22"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td"
+                      data-key="0"
+                      tabindex="-1"
+                    />
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      <span
+                        style="color: rgb(114, 118, 123);"
+                      >
+                        System deleted
+                      </span>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Success
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
                       <div
-                        class="pf-v5-c-toolbar__content pf-m-hidden"
-                        hidden=""
+                        class="pf-v5-l-split"
                       >
                         <div
-                          class="pf-v5-c-toolbar__group"
-                        />
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        >
+                          No inhibtors found, conversion should run smoothly for this system.
+                        </div>
                       </div>
-                    </div>
-                    <table
-                      aria-label="2909-completed-jobs"
-                      class="pf-v5-c-table pf-m-grid-md"
-                      data-ouia-component-id="2909-completed-jobs-table"
-                      data-ouia-component-type="PF5/Table"
-                      data-ouia-safe="true"
-                      role="grid"
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
                     >
-                      <thead
-                        class="pf-v5-c-table__thead"
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
                       >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-7"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
                         >
-                          <th
-                            class="pf-v5-c-table__th"
-                            data-key="0"
-                            data-label=""
-                            scope=""
-                            tabindex="-1"
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                           />
-                          <th
-                            aria-sort="none"
-                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            scope="col"
-                            tabindex="-1"
-                          >
-                            <button
-                              class="pf-v5-c-table__button"
-                              type="button"
-                            >
-                              <div
-                                class="pf-v5-c-table__button-content"
-                              >
-                                <span
-                                  class="pf-v5-c-table__text"
-                                >
-                                  System name
-                                </span>
-                                <span
-                                  class="pf-v5-c-table__sort-indicator"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                    />
-                                  </svg>
-                                </span>
-                              </div>
-                            </button>
-                          </th>
-                          <th
-                            aria-sort="none"
-                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            scope="col"
-                            tabindex="-1"
-                          >
-                            <button
-                              class="pf-v5-c-table__button"
-                              type="button"
-                            >
-                              <div
-                                class="pf-v5-c-table__button-content"
-                              >
-                                <span
-                                  class="pf-v5-c-table__text"
-                                >
-                                  Status
-                                </span>
-                                <span
-                                  class="pf-v5-c-table__sort-indicator"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                    />
-                                  </svg>
-                                </span>
-                              </div>
-                            </button>
-                          </th>
-                          <th
-                            aria-sort="ascending"
-                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            scope="col"
-                            tabindex="-1"
-                          >
-                            <button
-                              class="pf-v5-c-table__button"
-                              type="button"
-                            >
-                              <div
-                                class="pf-v5-c-table__button-content"
-                              >
-                                <span
-                                  class="pf-v5-c-table__text"
-                                >
-                                  Message
-                                </span>
-                                <span
-                                  class="pf-v5-c-table__sort-indicator"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
-                                    />
-                                  </svg>
-                                </span>
-                              </div>
-                            </button>
-                          </th>
-                          <td
-                            class="pf-v5-c-table__th"
-                            data-key="4"
-                            data-label=""
-                            tabindex="-1"
-                          />
-                        </tr>
-                      </thead>
-                      <tbody
-                        class="pf-v5-c-table__tbody"
-                        role="rowgroup"
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+                <tbody
+                  class="pf-v5-c-table__tbody"
+                  role="rowgroup"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-23"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                      data-key="0"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-expanded="false"
+                        aria-label="Details"
+                        aria-labelledby="simple-node4 expandable-toggle4"
+                        class="pf-v5-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                        data-ouia-component-type="PF5/Button"
+                        data-ouia-safe="true"
+                        id="expandable-toggle4"
+                        type="button"
                       >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-13"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
+                        <div
+                          class="pf-v5-c-table__toggle-icon"
                         >
-                          <td
-                            class="pf-v5-c-table__td"
-                            data-key="0"
-                            tabindex="-1"
-                          />
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            tabindex="-1"
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            width="1em"
                           >
-                            centos7-test-device-1
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            tabindex="-1"
-                          >
-                            Success
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
-                            >
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
-                              >
-                                No inhibtors found, conversion should run smoothly for this system.
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          >
-                            <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 192 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                                />
-                              </svg>
-                            </button>
-                          </td>
-                        </tr>
-                      </tbody>
-                      <tbody
-                        class="pf-v5-c-table__tbody"
-                        role="rowgroup"
+                            <path
+                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                            />
+                          </svg>
+                        </div>
+                      </button>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      centos7-test-device-2
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Success
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
                       >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-14"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
                         >
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                            data-key="0"
-                            tabindex="-1"
+                          Your system has 3 inhibitors out of 3 potential problems.
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                  <tr
+                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                    data-ouia-component-id="OUIA-Generated-TableRow-24"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                    hidden=""
+                  >
+                    <td
+                      class="pf-v5-c-table__td"
+                      colspan="4"
+                      data-key="0"
+                      id="expanded-content5"
+                      tabindex="-1"
+                    >
+                      <div>
+                        <table
+                          class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                          data-ouia-component-id="OUIA-Generated-Table-6"
+                          data-ouia-component-type="PF5/Table"
+                          data-ouia-safe="true"
+                          role="grid"
+                          style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                        >
+                          <tbody
+                            class="pf-v5-c-table__tbody"
+                            role="rowgroup"
                           >
-                            <button
-                              aria-disabled="false"
-                              aria-expanded="false"
-                              aria-label="Details"
-                              aria-labelledby="simple-node1 expandable-toggle1"
-                              class="pf-v5-c-button pf-m-plain"
-                              data-ouia-component-id="OUIA-Generated-Button-plain-9"
-                              data-ouia-component-type="PF5/Button"
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-25"
+                              data-ouia-component-type="PF5/TableRow"
                               data-ouia-safe="true"
-                              id="expandable-toggle1"
-                              type="button"
                             >
-                              <div
-                                class="pf-v5-c-table__toggle-icon"
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 320 512"
-                                  width="1em"
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node0 expand-toggle0"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle0"
+                                  type="button"
                                 >
-                                  <path
-                                    d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                  />
-                                </svg>
-                              </div>
-                            </button>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            tabindex="-1"
-                          >
-                            centos7-test-device-3
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            tabindex="-1"
-                          >
-                            Success
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
-                            >
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
                               >
-                                No inhibtors found, conversion should run smoothly for this system.
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          >
-                            <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 192 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                                />
-                              </svg>
-                            </button>
-                          </td>
-                        </tr>
-                        <tr
-                          class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                          data-ouia-component-id="OUIA-Generated-TableRow-15"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                          hidden=""
-                        >
-                          <td
-                            class="pf-v5-c-table__td"
-                            colspan="4"
-                            data-key="0"
-                            id="expanded-content2"
-                            tabindex="-1"
-                          >
-                            <div>
-                              <table
-                                class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                                data-ouia-component-id="OUIA-Generated-Table-5"
-                                data-ouia-component-type="PF5/Table"
-                                data-ouia-safe="true"
-                                role="grid"
-                                style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                              >
-                                <tbody
-                                  class="pf-v5-c-table__tbody"
-                                  role="rowgroup"
-                                >
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-16"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
                                   >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-danger"
                                     >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node0 expand-toggle0"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-10"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle0"
-                                        type="button"
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
                                       >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-danger"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(163, 0, 0);"
-                                        >
-                                          <strong>
-                                            Third party packages detected
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-17"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
+                                        <path
+                                          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(163, 0, 0);"
                                   >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-red pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              Overridable
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        Third party packages detected
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            Third party packages will not be replaced during the conversion.
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Diagnosis
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span>
-                                                Only packages signed by CentOS Linux are to be replaced. Red Hat support won't be provided for the following third party packages:convert2rhel-1.5.0-2.20231124114206033039.main.14.g938833b.el7.noarch
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Remediation
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                If you wish to ignore this message, set the environment variable 'CONVERT2RHEL_THIRD_PARTY_PACKAGE_CHECK_SKIP' to 1.
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            LIST_THIRD_PARTY_PACKAGES::THIRD_PARTY_PACKAGE_DETECTED
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-18"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node1 expand-toggle1"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-11"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle1"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-warning"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 576 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(121, 80, 0);"
-                                        >
-                                          <strong>
-                                            Dbus is running check skip
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-19"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-orange pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 576 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              Warning
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        Dbus is running check skip
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            Skipping the check because we have been asked not to subscribe this system to RHSM
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            DBUS_IS_RUNNING::SECURE_BOOT_DETECTED
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-20"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node2 expand-toggle2"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-12"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle2"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-info"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(0, 41, 82);"
-                                        >
-                                          <strong>
-                                            Repository file package removal
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-21"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-blue pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              Info
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        Repository file package removal
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            The following packages were removed: NetworkManager-1.18.8-2.0.1.el7_9, kernel-core-0:4.18.0-240.10.1.el8_3
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            REMOVE_REPOSITORY_FILES_PACKAGES::REPOSITORY_FILE_PACKAGES_REMOVED
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          />
-                        </tr>
-                      </tbody>
-                      <tbody
-                        class="pf-v5-c-table__tbody"
-                        role="rowgroup"
-                      >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-22"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                        >
-                          <td
-                            class="pf-v5-c-table__td"
-                            data-key="0"
-                            tabindex="-1"
-                          />
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            tabindex="-1"
-                          >
-                            <span
-                              style="color: rgb(114, 118, 123);"
-                            >
-                              System deleted
-                            </span>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            tabindex="-1"
-                          >
-                            Success
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
-                            >
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
-                              >
-                                No inhibtors found, conversion should run smoothly for this system.
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          >
-                            <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 192 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                                />
-                              </svg>
-                            </button>
-                          </td>
-                        </tr>
-                      </tbody>
-                      <tbody
-                        class="pf-v5-c-table__tbody"
-                        role="rowgroup"
-                      >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-23"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                        >
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                            data-key="0"
-                            tabindex="-1"
-                          >
-                            <button
-                              aria-disabled="false"
-                              aria-expanded="false"
-                              aria-label="Details"
-                              aria-labelledby="simple-node4 expandable-toggle4"
-                              class="pf-v5-c-button pf-m-plain"
-                              data-ouia-component-id="OUIA-Generated-Button-plain-13"
-                              data-ouia-component-type="PF5/Button"
+                                    <strong>
+                                      The version of the loaded kernel is different from the latest version
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-26"
+                              data-ouia-component-type="PF5/TableRow"
                               data-ouia-safe="true"
-                              id="expandable-toggle4"
-                              type="button"
+                              hidden=""
                             >
-                              <div
-                                class="pf-v5-c-table__toggle-icon"
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 320 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                  />
-                                </svg>
-                              </div>
-                            </button>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            tabindex="-1"
-                          >
-                            centos7-test-device-2
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            tabindex="-1"
-                          >
-                            Success
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
-                            >
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
-                              >
-                                Your system has 3 inhibitors out of 3 potential problems.
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          >
-                            <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 192 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                                />
-                              </svg>
-                            </button>
-                          </td>
-                        </tr>
-                        <tr
-                          class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                          data-ouia-component-id="OUIA-Generated-TableRow-24"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                          hidden=""
-                        >
-                          <td
-                            class="pf-v5-c-table__td"
-                            colspan="4"
-                            data-key="0"
-                            id="expanded-content5"
-                            tabindex="-1"
-                          >
-                            <div>
-                              <table
-                                class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                                data-ouia-component-id="OUIA-Generated-Table-6"
-                                data-ouia-component-type="PF5/Table"
-                                data-ouia-safe="true"
-                                role="grid"
-                                style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                              >
-                                <tbody
-                                  class="pf-v5-c-table__tbody"
-                                  role="rowgroup"
-                                >
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-25"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-red pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
                                   >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
+                                    <span
+                                      class="pf-v5-c-label__content"
                                     >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node0 expand-toggle0"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-14"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle0"
-                                        type="button"
+                                      <span
+                                        class="pf-v5-c-label__icon"
                                       >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-danger"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(163, 0, 0);"
-                                        >
-                                          <strong>
-                                            The version of the loaded kernel is different from the latest version
-                                          </strong>
-                                        </span>
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
                                       </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-26"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        Inhibitor
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="entry-title"
+                                >
+                                  The version of the loaded kernel is different from the latest version
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
                                   >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      The version of the loaded kernel is different from the latest version in the enabled system repositories.
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Diagnosis
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
                                     >
                                       <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-red pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              Inhibitor
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        The version of the loaded kernel is different from the latest version
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            The version of the loaded kernel is different from the latest version in the enabled system repositories.
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Diagnosis
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span>
-                                                Latest kernel version available in updates: 3.10.0-1160.90.1.el7
+                                        <span>
+                                          Latest kernel version available in updates: 3.10.0-1160.90.1.el7
  Loaded kernel version: 3.10.0-1160.88.1.el7
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Remediation
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span
+                                          class="remediations-font-family"
                                         >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Remediation
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                [hint] To proceed with the conversion, update the kernel version by executing the following steps:
+                                          [hint] To proceed with the conversion, update the kernel version by executing the following steps:
 
 1. yum install kernel-3.10.0-1160.90.1.el7 -y
 2. reboot
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            IS_LOADED_KERNEL_LATEST::INVALID_KERNEL_VERSION
-                                          </div>
-                                        </div>
+                                        </span>
                                       </div>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-27"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
                                   >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
                                     >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node1 expand-toggle1"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-15"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle1"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
                                     >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-danger"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(163, 0, 0);"
-                                        >
-                                          <strong>
-                                            Secure boot detected
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-28"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-red pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              Inhibitor
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        Secure boot detected
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            The conversion with secure boot is currently not possible.
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Diagnosis
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span>
-                                                In order to continue the conversion, secure boot must be disabled
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Remediation
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                [hint] To disable the secure boot, follow the instructions available in this article: https://access.redhat.com/solutions/6753681
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            EFI::SECURE_BOOT_DETECTED
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-29"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node2 expand-toggle2"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-16"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle2"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-danger"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(163, 0, 0);"
-                                        >
-                                          <strong>
-                                            Package up to date check fail
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-30"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-red pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              Overridable
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        Package up to date check fail
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            The conversion with secure boot is currently not possible.
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Diagnosis
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span>
-                                                There was an error while checking whether the installed packages are up-to-date. Having an updated system is an important prerequisite for a successful conversion.
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Remediation
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                [hint] Consider verifyng the system is up to date manually before proceeding with the conversion.
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            PACKAGE_UPDATES::PACKAGE_UP_TO_DATE_CHECK_FAIL
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          />
-                        </tr>
-                      </tbody>
-                    </table>
-                    <div
-                      class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
-                      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-2"
-                      data-ouia-component-type="RHI/TableToolbar"
-                      data-ouia-safe="true"
-                      id="pf-random-id-3"
-                    >
-                      <div
-                        class="pf-v5-c-toolbar__content"
-                      >
-                        <div
-                          class="pf-v5-c-toolbar__content-section"
-                        >
-                          <div
-                            class="pf-v5-c-toolbar__item pf-m-align-self-center"
-                          >
-                            <div>
-                              <div
-                                style="display: contents;"
-                              >
-                                <div
-                                  class="pf-v5-c-content"
-                                >
-                                  <small
-                                    class=""
-                                    data-ouia-component-id="OUIA-Generated-Text-4"
-                                    data-ouia-component-type="PF5/Text"
-                                    data-ouia-safe="true"
-                                    data-pf-content="true"
-                                  >
-                                    Last updated: All jobs completed
-                                  </small>
+                                      IS_LOADED_KERNEL_LATEST::INVALID_KERNEL_VERSION
+                                    </div>
+                                  </div>
                                 </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
-                          >
-                            <div
-                              class="pf-v5-c-pagination pf-m-bottom"
-                              data-ouia-component-id="OUIA-Generated-Pagination-bottom-2"
-                              data-ouia-component-type="PF5/Pagination"
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-27"
+                              data-ouia-component-type="PF5/TableRow"
                               data-ouia-safe="true"
-                              id="options-menu-bottom-pagination"
-                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                             >
-                              <div>
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
+                              >
                                 <button
+                                  aria-disabled="false"
                                   aria-expanded="false"
-                                  aria-haspopup="listbox"
-                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                                  id="options-menu-bottom-toggle"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node1 expand-toggle1"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle1"
                                   type="button"
                                 >
-                                  <span
-                                    class="pf-v5-c-menu-toggle__text"
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
                                   >
-                                    <b>
-                                      1 - 4
-                                    </b>
-                                     of 
-                                    <b>
-                                      4
-                                    </b>
-                                     
-                                  </span>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
                                   <span
-                                    class="pf-v5-c-menu-toggle__controls"
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
                                   >
                                     <span
-                                      class="pf-v5-c-menu-toggle__toggle-icon"
+                                      class="pf-v5-c-icon__content pf-m-danger"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -2460,117 +1991,184 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                         fill="currentColor"
                                         height="1em"
                                         role="img"
-                                        viewBox="0 0 320 512"
+                                        viewBox="0 0 512 512"
                                         width="1em"
                                       >
                                         <path
-                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
                                         />
                                       </svg>
                                     </span>
                                   </span>
-                                </button>
-                              </div>
-                              <nav
-                                aria-label="Pagination"
-                                class="pf-v5-c-pagination__nav"
+                                  <span
+                                    style="color: rgb(163, 0, 0);"
+                                  >
+                                    <strong>
+                                      Secure boot detected
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-28"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
                               >
-                                <div
-                                  class="pf-v5-c-pagination__nav-control pf-m-first"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to first page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="first"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-17"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 448 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-control"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to previous page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="previous"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-18"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-page-select"
-                                >
+                                <div>
                                   <span
-                                    class="pf-v5-c-form-control pf-m-disabled"
+                                    class="pf-v5-c-label pf-m-red pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
                                   >
-                                    <input
-                                      aria-invalid="false"
-                                      aria-label="Current page"
-                                      data-ouia-component-id="OUIA-Generated-TextInputBase-4"
-                                      data-ouia-component-type="PF5/TextInput"
-                                      data-ouia-safe="true"
-                                      disabled=""
-                                      max="1"
-                                      min="1"
-                                      type="number"
-                                      value="1"
-                                    />
-                                  </span>
-                                  <span
-                                    aria-hidden="true"
-                                  >
-                                    of 1
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        Inhibitor
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                                 <div
-                                  class="pf-v5-c-pagination__nav-control"
+                                  class="entry-title"
                                 >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to next page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="next"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-19"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
+                                  Secure boot detected
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      The conversion with secure boot is currently not possible.
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Diagnosis
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span>
+                                          In order to continue the conversion, secure boot must be disabled
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Remediation
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span
+                                          class="remediations-font-family"
+                                        >
+                                          [hint] To disable the secure boot, follow the instructions available in this article: https://access.redhat.com/solutions/6753681
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      EFI::SECURE_BOOT_DETECTED
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-29"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                            >
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
+                              >
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node2 expand-toggle2"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle2"
+                                  type="button"
+                                >
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -2578,70 +2176,459 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                                       fill="currentColor"
                                       height="1em"
                                       role="img"
-                                      viewBox="0 0 256 512"
+                                      viewBox="0 0 320 512"
                                       width="1em"
                                     >
                                       <path
-                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
                                       />
                                     </svg>
-                                  </button>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-danger"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(163, 0, 0);"
+                                  >
+                                    <strong>
+                                      Package up to date check fail
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-30"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-red pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        Overridable
+                                      </span>
+                                    </span>
+                                  </span>
                                 </div>
                                 <div
-                                  class="pf-v5-c-pagination__nav-control pf-m-last"
+                                  class="entry-title"
                                 >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to last page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="last"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-20"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 448 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                                      />
-                                    </svg>
-                                  </button>
+                                  Package up to date check fail
                                 </div>
-                              </nav>
-                            </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      The conversion with secure boot is currently not possible.
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Diagnosis
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span>
+                                          There was an error while checking whether the installed packages are up-to-date. Having an updated system is an important prerequisite for a successful conversion.
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Remediation
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span
+                                          class="remediations-font-family"
+                                        >
+                                          [hint] Consider verifyng the system is up to date manually before proceeding with the conversion.
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      PACKAGE_UPDATES::PACKAGE_UP_TO_DATE_CHECK_FAIL
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    />
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
+                data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-2"
+                data-ouia-component-type="RHI/TableToolbar"
+                data-ouia-safe="true"
+                id="pf-random-id-3"
+              >
+                <div
+                  class="pf-v5-c-toolbar__content"
+                >
+                  <div
+                    class="pf-v5-c-toolbar__content-section"
+                  >
+                    <div
+                      class="pf-v5-c-toolbar__item pf-m-align-self-center"
+                    >
+                      <div>
+                        <div
+                          style="display: contents;"
+                        >
+                          <div
+                            class="pf-v5-c-content"
+                          >
+                            <small
+                              class=""
+                              data-ouia-component-id="OUIA-Generated-Text-4"
+                              data-ouia-component-type="PF5/Text"
+                              data-ouia-safe="true"
+                              data-pf-content="true"
+                            >
+                              Last updated: All jobs completed
+                            </small>
                           </div>
                         </div>
                       </div>
+                    </div>
+                    <div
+                      class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
+                    >
                       <div
-                        class="pf-v5-c-toolbar__content pf-m-hidden"
-                        hidden=""
+                        class="pf-v5-c-pagination pf-m-bottom"
+                        data-ouia-component-id="OUIA-Generated-Pagination-bottom-2"
+                        data-ouia-component-type="PF5/Pagination"
+                        data-ouia-safe="true"
+                        id="options-menu-bottom-pagination"
+                        style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                       >
-                        <div
-                          class="pf-v5-c-toolbar__group"
-                        />
+                        <div>
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                            id="options-menu-bottom-toggle"
+                            type="button"
+                          >
+                            <span
+                              class="pf-v5-c-menu-toggle__text"
+                            >
+                              <b>
+                                1 - 4
+                              </b>
+                               of 
+                              <b>
+                                4
+                              </b>
+                               
+                            </span>
+                            <span
+                              class="pf-v5-c-menu-toggle__controls"
+                            >
+                              <span
+                                class="pf-v5-c-menu-toggle__toggle-icon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 320 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  />
+                                </svg>
+                              </span>
+                            </span>
+                          </button>
+                        </div>
+                        <nav
+                          aria-label="Pagination"
+                          class="pf-v5-c-pagination__nav"
+                        >
+                          <div
+                            class="pf-v5-c-pagination__nav-control pf-m-first"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to first page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="first"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-17"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 448 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-control"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to previous page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="previous"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-page-select"
+                          >
+                            <span
+                              class="pf-v5-c-form-control pf-m-disabled"
+                            >
+                              <input
+                                aria-invalid="false"
+                                aria-label="Current page"
+                                data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+                                data-ouia-component-type="PF5/TextInput"
+                                data-ouia-safe="true"
+                                disabled=""
+                                max="1"
+                                min="1"
+                                type="number"
+                                value="1"
+                              />
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              of 1
+                            </span>
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-control"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to next page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="next"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-19"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-control pf-m-last"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to last page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="last"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-20"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 448 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </nav>
                       </div>
                     </div>
                   </div>
-                </section>
-              </main>
+                </div>
+                <div
+                  class="pf-v5-c-toolbar__content pf-m-hidden"
+                  hidden=""
+                >
+                  <div
+                    class="pf-v5-c-toolbar__group"
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-          <div
-            class="pf-v5-c-drawer__panel"
-            hidden=""
-            id="pf-drawer-panel-2"
-          />
+          </section>
         </div>
       </div>
+      <div
+        class="pf-v5-c-drawer__panel"
+        hidden=""
+        id="log-drawer"
+      />
     </div>
   </div>
 </DocumentFragment>
@@ -2650,157 +2637,417 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
 exports[`CompletedTaskDetails should render correctly completed 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-page my-app-modified-drawer-width"
+    class="pf-v5-c-drawer my-app-modified-drawer-width"
   >
     <div
-      class="pf-v5-c-page__drawer"
+      class="pf-v5-c-drawer__main"
     >
       <div
-        class="pf-v5-c-drawer"
+        class="pf-v5-c-drawer__content"
       >
         <div
-          class="pf-v5-c-drawer__main"
+          class="pf-v5-c-drawer__body"
         >
-          <div
-            class="pf-v5-c-drawer__content"
+          <section
+            class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+            data-ouia-component-id="OUIA-Generated-RHI/Header-true-1"
+            data-ouia-component-type="RHI/Header"
+            data-ouia-safe="true"
+            widget-type="InsightsPageHeader"
+          >
+            <nav
+              aria-label="Breadcrumb"
+              class="pf-v5-c-breadcrumb"
+              data-ouia-component-id="completed-tasks-details-breadcrumb"
+              data-ouia-component-type="PF5/Breadcrumb"
+              data-ouia-safe="true"
+            >
+              <ol
+                class="pf-v5-c-breadcrumb__list"
+                role="list"
+              >
+                <li
+                  class="pf-v5-c-breadcrumb__item"
+                >
+                  <a
+                    class="pf-v5-c-breadcrumb__link"
+                    href="/insights/tasks/executed"
+                  >
+                    Tasks
+                  </a>
+                </li>
+                <li
+                  class="pf-v5-c-breadcrumb__item"
+                >
+                  <span
+                    class="pf-v5-c-breadcrumb__item-divider"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                      />
+                    </svg>
+                  </span>
+                  log4j task
+                </li>
+              </ol>
+            </nav>
+            <div
+              class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
+            >
+              <div
+                class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
+              >
+                <div
+                  class=""
+                >
+                  <div
+                    class="pf-v5-l-flex pf-m-justify-content-space-between"
+                  >
+                    <div
+                      class=""
+                    >
+                      <h1
+                        class="pf-v5-c-title pf-m-2xl"
+                        data-ouia-component-id="OUIA-Generated-RHI/Header-true-2"
+                        data-ouia-component-type="RHI/Header"
+                        data-ouia-safe="true"
+                        widget-type="InsightsPageHeaderTitle"
+                      >
+                        log4j task
+                      </h1>
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-c-content"
+                  >
+                    <small
+                      class=""
+                      data-ouia-component-id="OUIA-Generated-Text-1"
+                      data-ouia-component-type="PF5/Text"
+                      data-ouia-safe="true"
+                      data-pf-content="true"
+                    >
+                      Log4J Detection
+                    </small>
+                  </div>
+                </div>
+                <div
+                  class=""
+                >
+                  <p>
+                    Uses the insights-client to determine if systems are affected by the LogShell vulnerability. Resource intensive scan
+                  </p>
+                </div>
+              </div>
+              <div
+                class="pf-v5-l-flex pf-m-align-right"
+              >
+                <div
+                  class=""
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="log4j-run-task-button"
+                    class="pf-v5-c-button pf-m-secondary"
+                    data-ouia-component-id="OUIA-Generated-Button-secondary-1"
+                    data-ouia-component-type="PF5/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    Run task again
+                  </button>
+                </div>
+              </div>
+              <div
+                class="pf-v5-l-flex pf-m-align-right"
+              >
+                <div
+                  class=""
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-label="Task details menu toggle"
+                    class="pf-v5-c-menu-toggle pf-m-plain"
+                    id="executed-task-kebab"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 192 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section
+            class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
           >
             <div
-              class="pf-v5-c-drawer__body"
+              class="pf-v5-c-card"
+              data-ouia-component-id="OUIA-Generated-Card-1"
+              data-ouia-component-type="PF5/Card"
+              data-ouia-safe="true"
+              id=""
             >
-              <main
-                class="pf-v5-c-page__main"
-                tabindex="-1"
+              <div
+                class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
               >
-                <section
-                  class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
-                  data-ouia-component-id="OUIA-Generated-RHI/Header-true-1"
-                  data-ouia-component-type="RHI/Header"
-                  data-ouia-safe="true"
-                  widget-type="InsightsPageHeader"
+                <div
+                  class="pf-v5-l-flex pf-m-column"
                 >
-                  <nav
-                    aria-label="Breadcrumb"
-                    class="pf-v5-c-breadcrumb"
-                    data-ouia-component-id="completed-tasks-details-breadcrumb"
-                    data-ouia-component-type="PF5/Breadcrumb"
-                    data-ouia-safe="true"
-                  >
-                    <ol
-                      class="pf-v5-c-breadcrumb__list"
-                      role="list"
-                    >
-                      <li
-                        class="pf-v5-c-breadcrumb__item"
-                      >
-                        <a
-                          class="pf-v5-c-breadcrumb__link"
-                          href="/insights/tasks/executed"
-                        >
-                          Tasks
-                        </a>
-                      </li>
-                      <li
-                        class="pf-v5-c-breadcrumb__item"
-                      >
-                        <span
-                          class="pf-v5-c-breadcrumb__item-divider"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 256 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                            />
-                          </svg>
-                        </span>
-                        log4j task
-                      </li>
-                    </ol>
-                  </nav>
                   <div
-                    class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
+                    class=""
+                  >
+                    <b>
+                      Systems
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    3
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Run start
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    21 Apr 2022, 10:10 UTC
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Run end
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    25 Apr 2022, 10:10 UTC (5760 min)
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Initiated by
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    UserX
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Systems with alerts
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    2
+                  </div>
+                </div>
+              </div>
+            </div>
+            <br />
+            <div
+              class="pf-v5-c-card"
+              data-ouia-component-id="OUIA-Generated-Card-2"
+              data-ouia-component-type="PF5/Card"
+              data-ouia-safe="true"
+              id=""
+            >
+              <div
+                class="pf-v5-c-toolbar  ins-c-primary-toolbar"
+                data-ouia-component-id="PrimaryToolbar"
+                data-ouia-component-type="PF5/Toolbar"
+                data-ouia-safe="true"
+                id="ins-primary-data-toolbar"
+              >
+                <div
+                  class="pf-v5-c-toolbar__content"
+                >
+                  <div
+                    class="pf-v5-c-toolbar__content-section"
                   >
                     <div
-                      class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
+                      class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
                     >
                       <div
-                        class=""
+                        class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
                       >
                         <div
-                          class="pf-v5-l-flex pf-m-justify-content-space-between"
+                          class="pf-v5-l-split ins-c-conditional-filter"
                         >
                           <div
-                            class=""
+                            class="pf-v5-l-split__item"
                           >
-                            <h1
-                              class="pf-v5-c-title pf-m-2xl"
-                              data-ouia-component-id="OUIA-Generated-RHI/Header-true-2"
-                              data-ouia-component-type="RHI/Header"
-                              data-ouia-safe="true"
-                              widget-type="InsightsPageHeaderTitle"
+                            <button
+                              aria-expanded="false"
+                              aria-label="Conditional filter toggle"
+                              class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
+                              data-ouia-component-id="ConditionalFilterToggle"
+                              type="button"
                             >
-                              log4j task
-                            </h1>
+                              <span
+                                class="pf-v5-c-menu-toggle__text"
+                              >
+                                <span
+                                  class="pf-v5-c-icon pf-m-md"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon__content"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                                <span
+                                  class="ins-c-conditional-filter__value-selector"
+                                >
+                                  Name
+                                </span>
+                              </span>
+                              <span
+                                class="pf-v5-c-menu-toggle__controls"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-l-split__item pf-m-fill"
+                            data-ouia-component-id="ConditionalFilter"
+                          >
+                            <span
+                              class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
+                            >
+                              <input
+                                aria-invalid="false"
+                                aria-label="text input"
+                                data-ouia-component-id="ConditionalFilter"
+                                data-ouia-component-type="PF5/TextInput"
+                                data-ouia-safe="true"
+                                placeholder="Filter by name"
+                                type="text"
+                                value=""
+                                widget-type="InsightsInput"
+                              />
+                              <span
+                                class="pf-v5-c-form-control__utilities"
+                              >
+                                <span
+                                  class="pf-v5-c-form-control__icon"
+                                >
+                                  <span
+                                    class="pf-v5-c-icon pf-m-md ins-c-search-icon"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </span>
+                              </span>
+                            </span>
                           </div>
                         </div>
-                        <div
-                          class="pf-v5-c-content"
-                        >
-                          <small
-                            class=""
-                            data-ouia-component-id="OUIA-Generated-Text-1"
-                            data-ouia-component-type="PF5/Text"
-                            data-ouia-safe="true"
-                            data-pf-content="true"
-                          >
-                            Log4J Detection
-                          </small>
-                        </div>
-                      </div>
-                      <div
-                        class=""
-                      >
-                        <p>
-                          Uses the insights-client to determine if systems are affected by the LogShell vulnerability. Resource intensive scan
-                        </p>
                       </div>
                     </div>
                     <div
-                      class="pf-v5-l-flex pf-m-align-right"
+                      class="pf-v5-c-toolbar__item pf-m-spacer-sm"
                     >
                       <div
-                        class=""
-                      >
-                        <button
-                          aria-disabled="false"
-                          aria-label="log4j-run-task-button"
-                          class="pf-v5-c-button pf-m-secondary"
-                          data-ouia-component-id="OUIA-Generated-Button-secondary-1"
-                          data-ouia-component-type="PF5/Button"
-                          data-ouia-safe="true"
-                          type="button"
-                        >
-                          Run task again
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="pf-v5-l-flex pf-m-align-right"
-                    >
-                      <div
-                        class=""
+                        style="display: contents;"
                       >
                         <button
                           aria-expanded="false"
-                          aria-label="Task details menu toggle"
+                          aria-label="Export"
                           class="pf-v5-c-menu-toggle pf-m-plain"
-                          id="executed-task-kebab"
                           type="button"
                         >
                           <svg
@@ -2809,269 +3056,64 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                             fill="currentColor"
                             height="1em"
                             role="img"
-                            viewBox="0 0 192 512"
+                            viewBox="0 0 1024 1024"
                             width="1em"
                           >
                             <path
-                              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                              d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
                             />
                           </svg>
                         </button>
                       </div>
                     </div>
-                  </div>
-                </section>
-                <section
-                  class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
-                >
-                  <div
-                    class="pf-v5-c-card"
-                    data-ouia-component-id="OUIA-Generated-Card-1"
-                    data-ouia-component-type="PF5/Card"
-                    data-ouia-safe="true"
-                    id=""
-                  >
                     <div
-                      class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
+                      class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
                     >
                       <div
-                        class="pf-v5-l-flex pf-m-column"
+                        class="pf-v5-c-pagination pf-m-compact"
+                        data-ouia-component-id="CompactPagination"
+                        data-ouia-component-type="PF5/Pagination"
+                        data-ouia-safe="true"
+                        id="options-menu-top-pagination"
+                        style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                       >
                         <div
-                          class=""
+                          class="pf-v5-c-pagination__total-items"
                         >
                           <b>
-                            Systems
+                            1 - 3
                           </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          3
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
+                           of 
                           <b>
-                            Run start
+                            3
                           </b>
+                           
                         </div>
-                        <div
-                          class=""
-                        >
-                          21 Apr 2022, 10:10 UTC
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
-                          <b>
-                            Run end
-                          </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          25 Apr 2022, 10:10 UTC (5760 min)
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
-                          <b>
-                            Initiated by
-                          </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          UserX
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
-                          <b>
-                            Systems with alerts
-                          </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          2
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <br />
-                  <div
-                    class="pf-v5-c-card"
-                    data-ouia-component-id="OUIA-Generated-Card-2"
-                    data-ouia-component-type="PF5/Card"
-                    data-ouia-safe="true"
-                    id=""
-                  >
-                    <div
-                      class="pf-v5-c-toolbar  ins-c-primary-toolbar"
-                      data-ouia-component-id="PrimaryToolbar"
-                      data-ouia-component-type="PF5/Toolbar"
-                      data-ouia-safe="true"
-                      id="ins-primary-data-toolbar"
-                    >
-                      <div
-                        class="pf-v5-c-toolbar__content"
-                      >
-                        <div
-                          class="pf-v5-c-toolbar__content-section"
-                        >
-                          <div
-                            class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+                        <div>
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                            id="options-menu-top-toggle"
+                            type="button"
                           >
-                            <div
-                              class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                            <span
+                              class="pf-v5-c-menu-toggle__text"
                             >
-                              <div
-                                class="pf-v5-l-split ins-c-conditional-filter"
-                              >
-                                <div
-                                  class="pf-v5-l-split__item"
-                                >
-                                  <button
-                                    aria-expanded="false"
-                                    aria-label="Conditional filter toggle"
-                                    class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
-                                    data-ouia-component-id="ConditionalFilterToggle"
-                                    type="button"
-                                  >
-                                    <span
-                                      class="pf-v5-c-menu-toggle__text"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon pf-m-md"
-                                      >
-                                        <span
-                                          class="pf-v5-c-icon__content"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </span>
-                                      <span
-                                        class="ins-c-conditional-filter__value-selector"
-                                      >
-                                        Name
-                                      </span>
-                                    </span>
-                                    <span
-                                      class="pf-v5-c-menu-toggle__controls"
-                                    >
-                                      <span
-                                        class="pf-v5-c-menu-toggle__toggle-icon"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 320 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-l-split__item pf-m-fill"
-                                  data-ouia-component-id="ConditionalFilter"
-                                >
-                                  <span
-                                    class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
-                                  >
-                                    <input
-                                      aria-invalid="false"
-                                      aria-label="text input"
-                                      data-ouia-component-id="ConditionalFilter"
-                                      data-ouia-component-type="PF5/TextInput"
-                                      data-ouia-safe="true"
-                                      placeholder="Filter by name"
-                                      type="text"
-                                      value=""
-                                      widget-type="InsightsInput"
-                                    />
-                                    <span
-                                      class="pf-v5-c-form-control__utilities"
-                                    >
-                                      <span
-                                        class="pf-v5-c-form-control__icon"
-                                      >
-                                        <span
-                                          class="pf-v5-c-icon pf-m-md ins-c-search-icon"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="pf-v5-c-toolbar__item pf-m-spacer-sm"
-                          >
-                            <div
-                              style="display: contents;"
+                              <b>
+                                1 - 3
+                              </b>
+                               of 
+                              <b>
+                                3
+                              </b>
+                               
+                            </span>
+                            <span
+                              class="pf-v5-c-menu-toggle__controls"
                             >
-                              <button
-                                aria-expanded="false"
-                                aria-label="Export"
-                                class="pf-v5-c-menu-toggle pf-m-plain"
-                                type="button"
+                              <span
+                                class="pf-v5-c-menu-toggle__toggle-icon"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3079,843 +3121,775 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                                   fill="currentColor"
                                   height="1em"
                                   role="img"
-                                  viewBox="0 0 1024 1024"
+                                  viewBox="0 0 320 512"
                                   width="1em"
                                 >
                                   <path
-                                    d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
                                   />
                                 </svg>
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
-                          >
-                            <div
-                              class="pf-v5-c-pagination pf-m-compact"
-                              data-ouia-component-id="CompactPagination"
-                              data-ouia-component-type="PF5/Pagination"
-                              data-ouia-safe="true"
-                              id="options-menu-top-pagination"
-                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-                            >
-                              <div
-                                class="pf-v5-c-pagination__total-items"
-                              >
-                                <b>
-                                  1 - 3
-                                </b>
-                                 of 
-                                <b>
-                                  3
-                                </b>
-                                 
-                              </div>
-                              <div>
-                                <button
-                                  aria-expanded="false"
-                                  aria-haspopup="listbox"
-                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                                  id="options-menu-top-toggle"
-                                  type="button"
-                                >
-                                  <span
-                                    class="pf-v5-c-menu-toggle__text"
-                                  >
-                                    <b>
-                                      1 - 3
-                                    </b>
-                                     of 
-                                    <b>
-                                      3
-                                    </b>
-                                     
-                                  </span>
-                                  <span
-                                    class="pf-v5-c-menu-toggle__controls"
-                                  >
-                                    <span
-                                      class="pf-v5-c-menu-toggle__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </span>
-                                </button>
-                              </div>
-                              <nav
-                                aria-label="Pagination"
-                                class="pf-v5-c-pagination__nav"
-                              >
-                                <div
-                                  class="pf-v5-c-pagination__nav-control"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to previous page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="previous"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-control"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to next page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="next"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                              </nav>
-                            </div>
-                          </div>
+                              </span>
+                            </span>
+                          </button>
                         </div>
-                      </div>
-                      <div
-                        class="pf-v5-c-toolbar__content pf-m-hidden"
-                        hidden=""
-                      >
-                        <div
-                          class="pf-v5-c-toolbar__group"
-                        />
-                      </div>
-                    </div>
-                    <table
-                      aria-label="42-completed-jobs"
-                      class="pf-v5-c-table pf-m-grid-md"
-                      data-ouia-component-id="42-completed-jobs-table"
-                      data-ouia-component-type="PF5/Table"
-                      data-ouia-safe="true"
-                      role="grid"
-                    >
-                      <thead
-                        class="pf-v5-c-table__thead"
-                      >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-1"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                        >
-                          <th
-                            aria-sort="none"
-                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
-                            data-key="0"
-                            data-label="System name"
-                            scope="col"
-                            tabindex="-1"
-                          >
-                            <button
-                              class="pf-v5-c-table__button"
-                              type="button"
-                            >
-                              <div
-                                class="pf-v5-c-table__button-content"
-                              >
-                                <span
-                                  class="pf-v5-c-table__text"
-                                >
-                                  System name
-                                </span>
-                                <span
-                                  class="pf-v5-c-table__sort-indicator"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                    />
-                                  </svg>
-                                </span>
-                              </div>
-                            </button>
-                          </th>
-                          <th
-                            aria-sort="none"
-                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
-                            data-key="1"
-                            data-label="Status"
-                            scope="col"
-                            tabindex="-1"
-                          >
-                            <button
-                              class="pf-v5-c-table__button"
-                              type="button"
-                            >
-                              <div
-                                class="pf-v5-c-table__button-content"
-                              >
-                                <span
-                                  class="pf-v5-c-table__text"
-                                >
-                                  Status
-                                </span>
-                                <span
-                                  class="pf-v5-c-table__sort-indicator"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                    />
-                                  </svg>
-                                </span>
-                              </div>
-                            </button>
-                          </th>
-                          <th
-                            aria-sort="none"
-                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-35"
-                            data-key="2"
-                            data-label="Message"
-                            scope="col"
-                            tabindex="-1"
-                          >
-                            <button
-                              class="pf-v5-c-table__button"
-                              type="button"
-                            >
-                              <div
-                                class="pf-v5-c-table__button-content"
-                              >
-                                <span
-                                  class="pf-v5-c-table__text"
-                                >
-                                  Message
-                                </span>
-                                <span
-                                  class="pf-v5-c-table__sort-indicator"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                    />
-                                  </svg>
-                                </span>
-                              </div>
-                            </button>
-                          </th>
-                          <td
-                            class="pf-v5-c-table__th"
-                            data-key="3"
-                            data-label=""
-                            tabindex="-1"
-                          />
-                        </tr>
-                      </thead>
-                      <tbody
-                        class="pf-v5-c-table__tbody"
-                        role="rowgroup"
-                      >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-2"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                        >
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="0"
-                            data-label="System name"
-                            tabindex="-1"
-                          >
-                            dl-test-device-2
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="1"
-                            data-label="Status"
-                            tabindex="-1"
-                          >
-                            Success
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="2"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
-                            >
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
-                              >
-                                This was a success.
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="3"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          >
-                            <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 192 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                                />
-                              </svg>
-                            </button>
-                          </td>
-                        </tr>
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-3"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                        >
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="0"
-                            data-label="System name"
-                            tabindex="-1"
-                          >
-                            MG-test-device
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="1"
-                            data-label="Status"
-                            tabindex="-1"
-                          >
-                            Failure
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="2"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
-                            >
-                              <div
-                                class="pf-v5-l-split__item"
-                                style="padding-right: 8px;"
-                              >
-                                <span
-                                  class="pf-v5-c-icon"
-                                >
-                                  <span
-                                    class="pf-v5-c-icon__content pf-m-danger"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 512 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                              </div>
-                              <div
-                                class="pf-v5-l-split__item"
-                                style="padding-right: 16px;"
-                              >
-                                <span
-                                  style="color: rgb(201, 25, 11);"
-                                >
-                                  Alert
-                                </span>
-                              </div>
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
-                              >
-                                Task failed to complete for an unknown reason. Retry this task at a later time.
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="3"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          >
-                            <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 192 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                                />
-                              </svg>
-                            </button>
-                          </td>
-                        </tr>
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-4"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                        >
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="0"
-                            data-label="System name"
-                            tabindex="-1"
-                          >
-                            YL-test-device-85
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="1"
-                            data-label="Status"
-                            tabindex="-1"
-                          >
-                            Timeout
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="2"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
-                            >
-                              <div
-                                class="pf-v5-l-split__item"
-                                style="padding-right: 8px;"
-                              >
-                                <span
-                                  class="pf-v5-c-icon"
-                                >
-                                  <span
-                                    class="pf-v5-c-icon__content pf-m-danger"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 512 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                              </div>
-                              <div
-                                class="pf-v5-l-split__item"
-                                style="padding-right: 16px;"
-                              >
-                                <span
-                                  style="color: rgb(201, 25, 11);"
-                                >
-                                  Alert
-                                </span>
-                              </div>
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
-                              >
-                                Task failed to complete due to timing out. Retry this task at a later time.
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="3"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          >
-                            <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 192 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                                />
-                              </svg>
-                            </button>
-                          </td>
-                        </tr>
-                      </tbody>
-                    </table>
-                    <div
-                      class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
-                      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
-                      data-ouia-component-type="RHI/TableToolbar"
-                      data-ouia-safe="true"
-                      id="pf-random-id-1"
-                    >
-                      <div
-                        class="pf-v5-c-toolbar__content"
-                      >
-                        <div
-                          class="pf-v5-c-toolbar__content-section"
+                        <nav
+                          aria-label="Pagination"
+                          class="pf-v5-c-pagination__nav"
                         >
                           <div
-                            class="pf-v5-c-toolbar__item pf-m-align-self-center"
+                            class="pf-v5-c-pagination__nav-control"
                           >
-                            <div>
-                              <div
-                                style="display: contents;"
-                              >
-                                <div
-                                  class="pf-v5-c-content"
-                                >
-                                  <small
-                                    class=""
-                                    data-ouia-component-id="OUIA-Generated-Text-2"
-                                    data-ouia-component-type="PF5/Text"
-                                    data-ouia-safe="true"
-                                    data-pf-content="true"
-                                  >
-                                    Last updated: All jobs completed
-                                  </small>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
-                          >
-                            <div
-                              class="pf-v5-c-pagination pf-m-bottom"
-                              data-ouia-component-id="OUIA-Generated-Pagination-bottom-1"
-                              data-ouia-component-type="PF5/Pagination"
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to previous page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="previous"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                              data-ouia-component-type="PF5/Button"
                               data-ouia-safe="true"
-                              id="options-menu-bottom-pagination"
-                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                              disabled=""
+                              type="button"
                             >
-                              <div>
-                                <button
-                                  aria-expanded="false"
-                                  aria-haspopup="listbox"
-                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                                  id="options-menu-bottom-toggle"
-                                  type="button"
-                                >
-                                  <span
-                                    class="pf-v5-c-menu-toggle__text"
-                                  >
-                                    <b>
-                                      1 - 3
-                                    </b>
-                                     of 
-                                    <b>
-                                      3
-                                    </b>
-                                     
-                                  </span>
-                                  <span
-                                    class="pf-v5-c-menu-toggle__controls"
-                                  >
-                                    <span
-                                      class="pf-v5-c-menu-toggle__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </span>
-                                </button>
-                              </div>
-                              <nav
-                                aria-label="Pagination"
-                                class="pf-v5-c-pagination__nav"
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
                               >
-                                <div
-                                  class="pf-v5-c-pagination__nav-control pf-m-first"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to first page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="first"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 448 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-control"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to previous page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="previous"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-4"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-page-select"
-                                >
-                                  <span
-                                    class="pf-v5-c-form-control pf-m-disabled"
-                                  >
-                                    <input
-                                      aria-invalid="false"
-                                      aria-label="Current page"
-                                      data-ouia-component-id="OUIA-Generated-TextInputBase-2"
-                                      data-ouia-component-type="PF5/TextInput"
-                                      data-ouia-safe="true"
-                                      disabled=""
-                                      max="1"
-                                      min="1"
-                                      type="number"
-                                      value="1"
-                                    />
-                                  </span>
-                                  <span
-                                    aria-hidden="true"
-                                  >
-                                    of 1
-                                  </span>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-control"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to next page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="next"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-5"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-control pf-m-last"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to last page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="last"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-6"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 448 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                              </nav>
-                            </div>
+                                <path
+                                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                />
+                              </svg>
+                            </button>
                           </div>
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-c-toolbar__content pf-m-hidden"
-                        hidden=""
-                      >
-                        <div
-                          class="pf-v5-c-toolbar__group"
-                        />
+                          <div
+                            class="pf-v5-c-pagination__nav-control"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to next page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="next"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </nav>
                       </div>
                     </div>
                   </div>
-                </section>
-              </main>
+                </div>
+                <div
+                  class="pf-v5-c-toolbar__content pf-m-hidden"
+                  hidden=""
+                >
+                  <div
+                    class="pf-v5-c-toolbar__group"
+                  />
+                </div>
+              </div>
+              <table
+                aria-label="42-completed-jobs"
+                class="pf-v5-c-table pf-m-grid-md"
+                data-ouia-component-id="42-completed-jobs-table"
+                data-ouia-component-type="PF5/Table"
+                data-ouia-safe="true"
+                role="grid"
+              >
+                <thead
+                  class="pf-v5-c-table__thead"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-1"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <th
+                      aria-sort="none"
+                      class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
+                      data-key="0"
+                      data-label="System name"
+                      scope="col"
+                      tabindex="-1"
+                    >
+                      <button
+                        class="pf-v5-c-table__button"
+                        type="button"
+                      >
+                        <div
+                          class="pf-v5-c-table__button-content"
+                        >
+                          <span
+                            class="pf-v5-c-table__text"
+                          >
+                            System name
+                          </span>
+                          <span
+                            class="pf-v5-c-table__sort-indicator"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 256 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
+                      data-key="1"
+                      data-label="Status"
+                      scope="col"
+                      tabindex="-1"
+                    >
+                      <button
+                        class="pf-v5-c-table__button"
+                        type="button"
+                      >
+                        <div
+                          class="pf-v5-c-table__button-content"
+                        >
+                          <span
+                            class="pf-v5-c-table__text"
+                          >
+                            Status
+                          </span>
+                          <span
+                            class="pf-v5-c-table__sort-indicator"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 256 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-35"
+                      data-key="2"
+                      data-label="Message"
+                      scope="col"
+                      tabindex="-1"
+                    >
+                      <button
+                        class="pf-v5-c-table__button"
+                        type="button"
+                      >
+                        <div
+                          class="pf-v5-c-table__button-content"
+                        >
+                          <span
+                            class="pf-v5-c-table__text"
+                          >
+                            Message
+                          </span>
+                          <span
+                            class="pf-v5-c-table__sort-indicator"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 256 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </button>
+                    </th>
+                    <td
+                      class="pf-v5-c-table__th"
+                      data-key="3"
+                      data-label=""
+                      tabindex="-1"
+                    />
+                  </tr>
+                </thead>
+                <tbody
+                  class="pf-v5-c-table__tbody"
+                  role="rowgroup"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-2"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="0"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      dl-test-device-2
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="1"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Success
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="2"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
+                      >
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        >
+                          This was a success.
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="3"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-3"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="0"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      MG-test-device
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="1"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Failure
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="2"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
+                      >
+                        <div
+                          class="pf-v5-l-split__item"
+                          style="padding-right: 8px;"
+                        >
+                          <span
+                            class="pf-v5-c-icon"
+                          >
+                            <span
+                              class="pf-v5-c-icon__content pf-m-danger"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="pf-v5-l-split__item"
+                          style="padding-right: 16px;"
+                        >
+                          <span
+                            style="color: rgb(201, 25, 11);"
+                          >
+                            Alert
+                          </span>
+                        </div>
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        >
+                          Task failed to complete for an unknown reason. Retry this task at a later time.
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="3"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-4"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="0"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      YL-test-device-85
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="1"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Timeout
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="2"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
+                      >
+                        <div
+                          class="pf-v5-l-split__item"
+                          style="padding-right: 8px;"
+                        >
+                          <span
+                            class="pf-v5-c-icon"
+                          >
+                            <span
+                              class="pf-v5-c-icon__content pf-m-danger"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="pf-v5-l-split__item"
+                          style="padding-right: 16px;"
+                        >
+                          <span
+                            style="color: rgb(201, 25, 11);"
+                          >
+                            Alert
+                          </span>
+                        </div>
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        >
+                          Task failed to complete due to timing out. Retry this task at a later time.
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="3"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
+                data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
+                data-ouia-component-type="RHI/TableToolbar"
+                data-ouia-safe="true"
+                id="pf-random-id-1"
+              >
+                <div
+                  class="pf-v5-c-toolbar__content"
+                >
+                  <div
+                    class="pf-v5-c-toolbar__content-section"
+                  >
+                    <div
+                      class="pf-v5-c-toolbar__item pf-m-align-self-center"
+                    >
+                      <div>
+                        <div
+                          style="display: contents;"
+                        >
+                          <div
+                            class="pf-v5-c-content"
+                          >
+                            <small
+                              class=""
+                              data-ouia-component-id="OUIA-Generated-Text-2"
+                              data-ouia-component-type="PF5/Text"
+                              data-ouia-safe="true"
+                              data-pf-content="true"
+                            >
+                              Last updated: All jobs completed
+                            </small>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
+                    >
+                      <div
+                        class="pf-v5-c-pagination pf-m-bottom"
+                        data-ouia-component-id="OUIA-Generated-Pagination-bottom-1"
+                        data-ouia-component-type="PF5/Pagination"
+                        data-ouia-safe="true"
+                        id="options-menu-bottom-pagination"
+                        style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                      >
+                        <div>
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                            id="options-menu-bottom-toggle"
+                            type="button"
+                          >
+                            <span
+                              class="pf-v5-c-menu-toggle__text"
+                            >
+                              <b>
+                                1 - 3
+                              </b>
+                               of 
+                              <b>
+                                3
+                              </b>
+                               
+                            </span>
+                            <span
+                              class="pf-v5-c-menu-toggle__controls"
+                            >
+                              <span
+                                class="pf-v5-c-menu-toggle__toggle-icon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 320 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  />
+                                </svg>
+                              </span>
+                            </span>
+                          </button>
+                        </div>
+                        <nav
+                          aria-label="Pagination"
+                          class="pf-v5-c-pagination__nav"
+                        >
+                          <div
+                            class="pf-v5-c-pagination__nav-control pf-m-first"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to first page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="first"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 448 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-control"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to previous page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="previous"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-page-select"
+                          >
+                            <span
+                              class="pf-v5-c-form-control pf-m-disabled"
+                            >
+                              <input
+                                aria-invalid="false"
+                                aria-label="Current page"
+                                data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+                                data-ouia-component-type="PF5/TextInput"
+                                data-ouia-safe="true"
+                                disabled=""
+                                max="1"
+                                min="1"
+                                type="number"
+                                value="1"
+                              />
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              of 1
+                            </span>
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-control"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to next page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="next"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-control pf-m-last"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to last page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="last"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 448 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </nav>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-c-toolbar__content pf-m-hidden"
+                  hidden=""
+                >
+                  <div
+                    class="pf-v5-c-toolbar__group"
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-          <div
-            class="pf-v5-c-drawer__panel"
-            hidden=""
-            id="pf-drawer-panel-0"
-          />
+          </section>
         </div>
       </div>
+      <div
+        class="pf-v5-c-drawer__panel"
+        hidden=""
+        id="log-drawer"
+      />
     </div>
   </div>
 </DocumentFragment>
@@ -3924,493 +3898,384 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
 exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-page my-app-modified-drawer-width"
+    class="pf-v5-c-drawer my-app-modified-drawer-width"
   >
     <div
-      class="pf-v5-c-page__drawer"
+      class="pf-v5-c-drawer__main"
     >
       <div
-        class="pf-v5-c-drawer"
+        class="pf-v5-c-drawer__content"
       >
         <div
-          class="pf-v5-c-drawer__main"
+          class="pf-v5-c-drawer__body"
         >
-          <div
-            class="pf-v5-c-drawer__content"
+          <section
+            class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+            data-ouia-component-id="OUIA-Generated-RHI/Header-true-5"
+            data-ouia-component-type="RHI/Header"
+            data-ouia-safe="true"
+            widget-type="InsightsPageHeader"
+          >
+            <nav
+              aria-label="Breadcrumb"
+              class="pf-v5-c-breadcrumb"
+              data-ouia-component-id="completed-tasks-details-breadcrumb"
+              data-ouia-component-type="PF5/Breadcrumb"
+              data-ouia-safe="true"
+            >
+              <ol
+                class="pf-v5-c-breadcrumb__list"
+                role="list"
+              >
+                <li
+                  class="pf-v5-c-breadcrumb__item"
+                >
+                  <a
+                    class="pf-v5-c-breadcrumb__link"
+                    href="/insights/tasks/executed"
+                  >
+                    Tasks
+                  </a>
+                </li>
+                <li
+                  class="pf-v5-c-breadcrumb__item"
+                >
+                  <span
+                    class="pf-v5-c-breadcrumb__item-divider"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                      />
+                    </svg>
+                  </span>
+                  leapp task
+                </li>
+              </ol>
+            </nav>
+            <div
+              class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
+            >
+              <div
+                class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
+              >
+                <div
+                  class=""
+                >
+                  <div
+                    class="pf-v5-l-flex pf-m-justify-content-space-between"
+                  >
+                    <div
+                      class=""
+                    >
+                      <h1
+                        class="pf-v5-c-title pf-m-2xl"
+                        data-ouia-component-id="OUIA-Generated-RHI/Header-true-6"
+                        data-ouia-component-type="RHI/Header"
+                        data-ouia-safe="true"
+                        widget-type="InsightsPageHeaderTitle"
+                      >
+                        leapp task
+                      </h1>
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-c-content"
+                  >
+                    <small
+                      class=""
+                      data-ouia-component-id="OUIA-Generated-Text-5"
+                      data-ouia-component-type="PF5/Text"
+                      data-ouia-safe="true"
+                      data-pf-content="true"
+                    >
+                      Upgrade RHEL version with LEAP tool
+                    </small>
+                  </div>
+                </div>
+                <div
+                  class=""
+                >
+                  <p>
+                    Uses the insights-client to determine if RHEL version can be upgraded with LEAP tool. Resource intensive scan
+                  </p>
+                </div>
+              </div>
+              <div
+                class="pf-v5-l-flex pf-m-align-right"
+              >
+                <div
+                  class=""
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="leapp-preupgrade-run-task-button"
+                    class="pf-v5-c-button pf-m-secondary"
+                    data-ouia-component-id="OUIA-Generated-Button-secondary-3"
+                    data-ouia-component-type="PF5/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    Run task again
+                  </button>
+                </div>
+              </div>
+              <div
+                class="pf-v5-l-flex pf-m-align-right"
+              >
+                <div
+                  class=""
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-label="Task details menu toggle"
+                    class="pf-v5-c-menu-toggle pf-m-plain"
+                    id="executed-task-kebab"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 192 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section
+            class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
           >
             <div
-              class="pf-v5-c-drawer__body"
+              class="pf-v5-c-card"
+              data-ouia-component-id="OUIA-Generated-Card-5"
+              data-ouia-component-type="PF5/Card"
+              data-ouia-safe="true"
+              id=""
             >
-              <main
-                class="pf-v5-c-page__main"
-                tabindex="-1"
+              <div
+                class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
               >
-                <section
-                  class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
-                  data-ouia-component-id="OUIA-Generated-RHI/Header-true-5"
-                  data-ouia-component-type="RHI/Header"
-                  data-ouia-safe="true"
-                  widget-type="InsightsPageHeader"
-                >
-                  <nav
-                    aria-label="Breadcrumb"
-                    class="pf-v5-c-breadcrumb"
-                    data-ouia-component-id="completed-tasks-details-breadcrumb"
-                    data-ouia-component-type="PF5/Breadcrumb"
-                    data-ouia-safe="true"
-                  >
-                    <ol
-                      class="pf-v5-c-breadcrumb__list"
-                      role="list"
-                    >
-                      <li
-                        class="pf-v5-c-breadcrumb__item"
-                      >
-                        <a
-                          class="pf-v5-c-breadcrumb__link"
-                          href="/insights/tasks/executed"
-                        >
-                          Tasks
-                        </a>
-                      </li>
-                      <li
-                        class="pf-v5-c-breadcrumb__item"
-                      >
-                        <span
-                          class="pf-v5-c-breadcrumb__item-divider"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 256 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                            />
-                          </svg>
-                        </span>
-                        leapp task
-                      </li>
-                    </ol>
-                  </nav>
-                  <div
-                    class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-column-gap-sm"
-                  >
-                    <div
-                      class="pf-v5-l-flex pf-m-flex-1 pf-m-column"
-                    >
-                      <div
-                        class=""
-                      >
-                        <div
-                          class="pf-v5-l-flex pf-m-justify-content-space-between"
-                        >
-                          <div
-                            class=""
-                          >
-                            <h1
-                              class="pf-v5-c-title pf-m-2xl"
-                              data-ouia-component-id="OUIA-Generated-RHI/Header-true-6"
-                              data-ouia-component-type="RHI/Header"
-                              data-ouia-safe="true"
-                              widget-type="InsightsPageHeaderTitle"
-                            >
-                              leapp task
-                            </h1>
-                          </div>
-                        </div>
-                        <div
-                          class="pf-v5-c-content"
-                        >
-                          <small
-                            class=""
-                            data-ouia-component-id="OUIA-Generated-Text-5"
-                            data-ouia-component-type="PF5/Text"
-                            data-ouia-safe="true"
-                            data-pf-content="true"
-                          >
-                            Upgrade RHEL version with LEAP tool
-                          </small>
-                        </div>
-                      </div>
-                      <div
-                        class=""
-                      >
-                        <p>
-                          Uses the insights-client to determine if RHEL version can be upgraded with LEAP tool. Resource intensive scan
-                        </p>
-                      </div>
-                    </div>
-                    <div
-                      class="pf-v5-l-flex pf-m-align-right"
-                    >
-                      <div
-                        class=""
-                      >
-                        <button
-                          aria-disabled="false"
-                          aria-label="leapp-preupgrade-run-task-button"
-                          class="pf-v5-c-button pf-m-secondary"
-                          data-ouia-component-id="OUIA-Generated-Button-secondary-3"
-                          data-ouia-component-type="PF5/Button"
-                          data-ouia-safe="true"
-                          type="button"
-                        >
-                          Run task again
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="pf-v5-l-flex pf-m-align-right"
-                    >
-                      <div
-                        class=""
-                      >
-                        <button
-                          aria-expanded="false"
-                          aria-label="Task details menu toggle"
-                          class="pf-v5-c-menu-toggle pf-m-plain"
-                          id="executed-task-kebab"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v5-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 192 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                            />
-                          </svg>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </section>
-                <section
-                  class="pf-v5-l-page__main-section pf-v5-c-page__main-section"
+                <div
+                  class="pf-v5-l-flex pf-m-column"
                 >
                   <div
-                    class="pf-v5-c-card"
-                    data-ouia-component-id="OUIA-Generated-Card-5"
-                    data-ouia-component-type="PF5/Card"
-                    data-ouia-safe="true"
-                    id=""
+                    class=""
                   >
-                    <div
-                      class="pf-v5-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between completed-task-details-info-border"
-                    >
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
-                          <b>
-                            Systems
-                          </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          6
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
-                          <b>
-                            Run start
-                          </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          21 Apr 2022, 10:10 UTC
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
-                          <b>
-                            Run end
-                          </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          -
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
-                          <b>
-                            Initiated by
-                          </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          Michael
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-l-flex pf-m-column"
-                      >
-                        <div
-                          class=""
-                        >
-                          <b>
-                            Systems with alerts
-                          </b>
-                        </div>
-                        <div
-                          class=""
-                        >
-                          2
-                        </div>
-                      </div>
-                    </div>
+                    <b>
+                      Systems
+                    </b>
                   </div>
-                  <br />
                   <div
-                    class="pf-v5-c-card"
-                    data-ouia-component-id="OUIA-Generated-Card-6"
-                    data-ouia-component-type="PF5/Card"
-                    data-ouia-safe="true"
-                    id=""
+                    class=""
+                  >
+                    6
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Run start
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    21 Apr 2022, 10:10 UTC
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Run end
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    -
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Initiated by
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    Michael
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-l-flex pf-m-column"
+                >
+                  <div
+                    class=""
+                  >
+                    <b>
+                      Systems with alerts
+                    </b>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    2
+                  </div>
+                </div>
+              </div>
+            </div>
+            <br />
+            <div
+              class="pf-v5-c-card"
+              data-ouia-component-id="OUIA-Generated-Card-6"
+              data-ouia-component-type="PF5/Card"
+              data-ouia-safe="true"
+              id=""
+            >
+              <div
+                class="pf-v5-c-toolbar  ins-c-primary-toolbar"
+                data-ouia-component-id="PrimaryToolbar"
+                data-ouia-component-type="PF5/Toolbar"
+                data-ouia-safe="true"
+                id="ins-primary-data-toolbar"
+              >
+                <div
+                  class="pf-v5-c-toolbar__content"
+                >
+                  <div
+                    class="pf-v5-c-toolbar__content-section"
                   >
                     <div
-                      class="pf-v5-c-toolbar  ins-c-primary-toolbar"
-                      data-ouia-component-id="PrimaryToolbar"
-                      data-ouia-component-type="PF5/Toolbar"
-                      data-ouia-safe="true"
-                      id="ins-primary-data-toolbar"
+                      class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
                     >
                       <div
-                        class="pf-v5-c-toolbar__content"
+                        class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
                       >
                         <div
-                          class="pf-v5-c-toolbar__content-section"
+                          class="pf-v5-l-split ins-c-conditional-filter"
                         >
                           <div
-                            class="pf-v5-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+                            class="pf-v5-l-split__item"
                           >
-                            <div
-                              class="pf-v5-c-toolbar__item ins-c-primary-toolbar__filter"
+                            <button
+                              aria-expanded="false"
+                              aria-label="Conditional filter toggle"
+                              class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
+                              data-ouia-component-id="ConditionalFilterToggle"
+                              type="button"
                             >
-                              <div
-                                class="pf-v5-l-split ins-c-conditional-filter"
+                              <span
+                                class="pf-v5-c-menu-toggle__text"
                               >
-                                <div
-                                  class="pf-v5-l-split__item"
-                                >
-                                  <button
-                                    aria-expanded="false"
-                                    aria-label="Conditional filter toggle"
-                                    class="pf-v5-c-menu-toggle ins-c-conditional-filter__group"
-                                    data-ouia-component-id="ConditionalFilterToggle"
-                                    type="button"
-                                  >
-                                    <span
-                                      class="pf-v5-c-menu-toggle__text"
-                                    >
-                                      <span
-                                        class="pf-v5-c-icon pf-m-md"
-                                      >
-                                        <span
-                                          class="pf-v5-c-icon__content"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 512 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </span>
-                                      <span
-                                        class="ins-c-conditional-filter__value-selector"
-                                      >
-                                        Name
-                                      </span>
-                                    </span>
-                                    <span
-                                      class="pf-v5-c-menu-toggle__controls"
-                                    >
-                                      <span
-                                        class="pf-v5-c-menu-toggle__toggle-icon"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="pf-v5-svg"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          viewBox="0 0 320 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </span>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-l-split__item pf-m-fill"
-                                  data-ouia-component-id="ConditionalFilter"
+                                <span
+                                  class="pf-v5-c-icon pf-m-md"
                                 >
                                   <span
-                                    class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
+                                    class="pf-v5-c-icon__content"
                                   >
-                                    <input
-                                      aria-invalid="false"
-                                      aria-label="text input"
-                                      data-ouia-component-id="ConditionalFilter"
-                                      data-ouia-component-type="PF5/TextInput"
-                                      data-ouia-safe="true"
-                                      placeholder="Filter by name"
-                                      type="text"
-                                      value=""
-                                      widget-type="InsightsInput"
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                                <span
+                                  class="ins-c-conditional-filter__value-selector"
+                                >
+                                  Name
+                                </span>
+                              </span>
+                              <span
+                                class="pf-v5-c-menu-toggle__controls"
+                              >
+                                <span
+                                  class="pf-v5-c-menu-toggle__toggle-icon"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v5-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
                                     />
-                                    <span
-                                      class="pf-v5-c-form-control__utilities"
-                                    >
-                                      <span
-                                        class="pf-v5-c-form-control__icon"
-                                      >
-                                        <span
-                                          class="pf-v5-c-icon pf-m-md ins-c-search-icon"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                      </span>
-                                    </span>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
                           </div>
                           <div
-                            class="pf-v5-c-toolbar__item pf-m-spacer-sm"
+                            class="pf-v5-l-split__item pf-m-fill"
+                            data-ouia-component-id="ConditionalFilter"
                           >
-                            <div
-                              style="display: contents;"
+                            <span
+                              class="pf-v5-c-form-control pf-m-icon ins-c-conditional-filter"
                             >
-                              <button
-                                aria-expanded="false"
-                                aria-label="Export"
-                                class="pf-v5-c-menu-toggle pf-m-plain"
-                                type="button"
+                              <input
+                                aria-invalid="false"
+                                aria-label="text input"
+                                data-ouia-component-id="ConditionalFilter"
+                                data-ouia-component-type="PF5/TextInput"
+                                data-ouia-safe="true"
+                                placeholder="Filter by name"
+                                type="text"
+                                value=""
+                                widget-type="InsightsInput"
+                              />
+                              <span
+                                class="pf-v5-c-form-control__utilities"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 1024 1024"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
-                          >
-                            <div
-                              class="pf-v5-c-pagination pf-m-compact"
-                              data-ouia-component-id="CompactPagination"
-                              data-ouia-component-type="PF5/Pagination"
-                              data-ouia-safe="true"
-                              id="options-menu-top-pagination"
-                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-                            >
-                              <div
-                                class="pf-v5-c-pagination__total-items"
-                              >
-                                <b>
-                                  1 - 6
-                                </b>
-                                 of 
-                                <b>
-                                  6
-                                </b>
-                                 
-                              </div>
-                              <div>
-                                <button
-                                  aria-expanded="false"
-                                  aria-haspopup="listbox"
-                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                                  id="options-menu-top-toggle"
-                                  type="button"
+                                <span
+                                  class="pf-v5-c-form-control__icon"
                                 >
                                   <span
-                                    class="pf-v5-c-menu-toggle__text"
-                                  >
-                                    <b>
-                                      1 - 6
-                                    </b>
-                                     of 
-                                    <b>
-                                      6
-                                    </b>
-                                     
-                                  </span>
-                                  <span
-                                    class="pf-v5-c-menu-toggle__controls"
+                                    class="pf-v5-c-icon pf-m-md ins-c-search-icon"
                                   >
                                     <span
-                                      class="pf-v5-c-menu-toggle__toggle-icon"
+                                      class="pf-v5-c-icon__content"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -4418,339 +4283,132 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                         fill="currentColor"
                                         height="1em"
                                         role="img"
-                                        viewBox="0 0 320 512"
+                                        viewBox="0 0 512 512"
                                         width="1em"
                                       >
                                         <path
-                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                          d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
                                         />
                                       </svg>
                                     </span>
                                   </span>
-                                </button>
-                              </div>
-                              <nav
-                                aria-label="Pagination"
-                                class="pf-v5-c-pagination__nav"
-                              >
-                                <div
-                                  class="pf-v5-c-pagination__nav-control"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to previous page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="previous"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-21"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-control"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to next page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="next"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-22"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                              </nav>
-                            </div>
+                                </span>
+                              </span>
+                            </span>
                           </div>
                         </div>
                       </div>
+                    </div>
+                    <div
+                      class="pf-v5-c-toolbar__item pf-m-spacer-sm"
+                    >
                       <div
-                        class="pf-v5-c-toolbar__content pf-m-hidden"
-                        hidden=""
+                        style="display: contents;"
                       >
-                        <div
-                          class="pf-v5-c-toolbar__group"
-                        />
+                        <button
+                          aria-expanded="false"
+                          aria-label="Export"
+                          class="pf-v5-c-menu-toggle pf-m-plain"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 1024 1024"
+                            width="1em"
+                          >
+                            <path
+                              d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                            />
+                          </svg>
+                        </button>
                       </div>
                     </div>
-                    <table
-                      aria-label="43-completed-jobs"
-                      class="pf-v5-c-table pf-m-grid-md"
-                      data-ouia-component-id="43-completed-jobs-table"
-                      data-ouia-component-type="PF5/Table"
-                      data-ouia-safe="true"
-                      role="grid"
+                    <div
+                      class="pf-v5-c-toolbar__item ins-c-primary-toolbar__pagination"
                     >
-                      <thead
-                        class="pf-v5-c-table__thead"
+                      <div
+                        class="pf-v5-c-pagination pf-m-compact"
+                        data-ouia-component-id="CompactPagination"
+                        data-ouia-component-type="PF5/Pagination"
+                        data-ouia-safe="true"
+                        id="options-menu-top-pagination"
+                        style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
                       >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-31"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
+                        <div
+                          class="pf-v5-c-pagination__total-items"
                         >
-                          <th
-                            class="pf-v5-c-table__th"
-                            data-key="0"
-                            data-label=""
-                            scope=""
-                            tabindex="-1"
-                          />
-                          <th
-                            aria-sort="none"
-                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            scope="col"
-                            tabindex="-1"
+                          <b>
+                            1 - 6
+                          </b>
+                           of 
+                          <b>
+                            6
+                          </b>
+                           
+                        </div>
+                        <div>
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                            id="options-menu-top-toggle"
+                            type="button"
                           >
-                            <button
-                              class="pf-v5-c-table__button"
-                              type="button"
+                            <span
+                              class="pf-v5-c-menu-toggle__text"
                             >
-                              <div
-                                class="pf-v5-c-table__button-content"
-                              >
-                                <span
-                                  class="pf-v5-c-table__text"
-                                >
-                                  System name
-                                </span>
-                                <span
-                                  class="pf-v5-c-table__sort-indicator"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                    />
-                                  </svg>
-                                </span>
-                              </div>
-                            </button>
-                          </th>
-                          <th
-                            aria-sort="none"
-                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            scope="col"
-                            tabindex="-1"
-                          >
-                            <button
-                              class="pf-v5-c-table__button"
-                              type="button"
+                              <b>
+                                1 - 6
+                              </b>
+                               of 
+                              <b>
+                                6
+                              </b>
+                               
+                            </span>
+                            <span
+                              class="pf-v5-c-menu-toggle__controls"
                             >
-                              <div
-                                class="pf-v5-c-table__button-content"
+                              <span
+                                class="pf-v5-c-menu-toggle__toggle-icon"
                               >
-                                <span
-                                  class="pf-v5-c-table__text"
+                                <svg
+                                  aria-hidden="true"
+                                  class="pf-v5-svg"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  viewBox="0 0 320 512"
+                                  width="1em"
                                 >
-                                  Status
-                                </span>
-                                <span
-                                  class="pf-v5-c-table__sort-indicator"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                    />
-                                  </svg>
-                                </span>
-                              </div>
-                            </button>
-                          </th>
-                          <th
-                            aria-sort="ascending"
-                            class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            scope="col"
-                            tabindex="-1"
-                          >
-                            <button
-                              class="pf-v5-c-table__button"
-                              type="button"
-                            >
-                              <div
-                                class="pf-v5-c-table__button-content"
-                              >
-                                <span
-                                  class="pf-v5-c-table__text"
-                                >
-                                  Message
-                                </span>
-                                <span
-                                  class="pf-v5-c-table__sort-indicator"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v5-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
-                                    />
-                                  </svg>
-                                </span>
-                              </div>
-                            </button>
-                          </th>
-                          <td
-                            class="pf-v5-c-table__th"
-                            data-key="4"
-                            data-label=""
-                            tabindex="-1"
-                          />
-                        </tr>
-                      </thead>
-                      <tbody
-                        class="pf-v5-c-table__tbody"
-                        role="rowgroup"
-                      >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-37"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
+                                  <path
+                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  />
+                                </svg>
+                              </span>
+                            </span>
+                          </button>
+                        </div>
+                        <nav
+                          aria-label="Pagination"
+                          class="pf-v5-c-pagination__nav"
                         >
-                          <td
-                            class="pf-v5-c-table__td"
-                            data-key="0"
-                            tabindex="-1"
-                          />
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            tabindex="-1"
-                          >
-                            YL-test-device-85
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            tabindex="-1"
-                          >
-                            Timeout
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
-                            >
-                              <div
-                                class="pf-v5-l-split__item"
-                                style="padding-right: 8px;"
-                              >
-                                <span
-                                  class="pf-v5-c-icon"
-                                >
-                                  <span
-                                    class="pf-v5-c-icon__content pf-m-danger"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 512 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                              </div>
-                              <div
-                                class="pf-v5-l-split__item"
-                                style="padding-right: 16px;"
-                              >
-                                <span
-                                  style="color: rgb(201, 25, 11);"
-                                >
-                                  Alert
-                                </span>
-                              </div>
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
-                              >
-                                Task failed to complete due to timing out. Retry this task at a later time.
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
+                          <div
+                            class="pf-v5-c-pagination__nav-control"
                           >
                             <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
+                              aria-disabled="true"
+                              aria-label="Go to previous page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="previous"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-21"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
                               type="button"
                             >
                               <svg
@@ -4759,111 +4417,27 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 fill="currentColor"
                                 height="1em"
                                 role="img"
-                                viewBox="0 0 192 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
                                 />
                               </svg>
                             </button>
-                          </td>
-                        </tr>
-                      </tbody>
-                      <tbody
-                        class="pf-v5-c-table__tbody"
-                        role="rowgroup"
-                      >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-38"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                        >
-                          <td
-                            class="pf-v5-c-table__td"
-                            data-key="0"
-                            tabindex="-1"
-                          />
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            tabindex="-1"
-                          >
-                            MG-test-device
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            tabindex="-1"
-                          >
-                            Failure
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
-                            >
-                              <div
-                                class="pf-v5-l-split__item"
-                                style="padding-right: 8px;"
-                              >
-                                <span
-                                  class="pf-v5-c-icon"
-                                >
-                                  <span
-                                    class="pf-v5-c-icon__content pf-m-danger"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 512 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                              </div>
-                              <div
-                                class="pf-v5-l-split__item"
-                                style="padding-right: 16px;"
-                              >
-                                <span
-                                  style="color: rgb(201, 25, 11);"
-                                >
-                                  Alert
-                                </span>
-                              </div>
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
-                              >
-                                Task failed to complete for an unknown reason. Retry this task at a later time.
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-control"
                           >
                             <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
+                              aria-disabled="true"
+                              aria-label="Go to next page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="next"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-22"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
                               type="button"
                             >
                               <svg
@@ -4872,182 +4446,230 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 fill="currentColor"
                                 height="1em"
                                 role="img"
-                                viewBox="0 0 192 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
                                 />
                               </svg>
                             </button>
-                          </td>
-                        </tr>
-                      </tbody>
-                      <tbody
-                        class="pf-v5-c-table__tbody"
-                        role="rowgroup"
+                          </div>
+                        </nav>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="pf-v5-c-toolbar__content pf-m-hidden"
+                  hidden=""
+                >
+                  <div
+                    class="pf-v5-c-toolbar__group"
+                  />
+                </div>
+              </div>
+              <table
+                aria-label="43-completed-jobs"
+                class="pf-v5-c-table pf-m-grid-md"
+                data-ouia-component-id="43-completed-jobs-table"
+                data-ouia-component-type="PF5/Table"
+                data-ouia-safe="true"
+                role="grid"
+              >
+                <thead
+                  class="pf-v5-c-table__thead"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-31"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <th
+                      class="pf-v5-c-table__th"
+                      data-key="0"
+                      data-label=""
+                      scope=""
+                      tabindex="-1"
+                    />
+                    <th
+                      aria-sort="none"
+                      class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      scope="col"
+                      tabindex="-1"
+                    >
+                      <button
+                        class="pf-v5-c-table__button"
+                        type="button"
                       >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-39"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
+                        <div
+                          class="pf-v5-c-table__button-content"
                         >
-                          <td
-                            class="pf-v5-c-table__td"
-                            data-key="0"
-                            tabindex="-1"
-                          />
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            tabindex="-1"
+                          <span
+                            class="pf-v5-c-table__text"
                           >
-                            dl-test-device-2
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            tabindex="-1"
+                            System name
+                          </span>
+                          <span
+                            class="pf-v5-c-table__sort-indicator"
                           >
-                            Success
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 256 512"
+                              width="1em"
                             >
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
+                              <path
+                                d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                               />
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          >
-                            <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
-                              type="button"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="pf-v5-svg"
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                viewBox="0 0 192 512"
-                                width="1em"
-                              >
-                                <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                                />
-                              </svg>
-                            </button>
-                          </td>
-                        </tr>
-                      </tbody>
-                      <tbody
-                        class="pf-v5-c-table__tbody"
-                        role="rowgroup"
+                            </svg>
+                          </span>
+                        </div>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      scope="col"
+                      tabindex="-1"
+                    >
+                      <button
+                        class="pf-v5-c-table__button"
+                        type="button"
                       >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-40"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
+                        <div
+                          class="pf-v5-c-table__button-content"
                         >
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                            data-key="0"
-                            tabindex="-1"
+                          <span
+                            class="pf-v5-c-table__text"
                           >
-                            <button
-                              aria-disabled="false"
-                              aria-expanded="false"
-                              aria-label="Details"
-                              aria-labelledby="simple-node3 expandable-toggle3"
-                              class="pf-v5-c-button pf-m-plain"
-                              data-ouia-component-id="OUIA-Generated-Button-plain-23"
-                              data-ouia-component-type="PF5/Button"
-                              data-ouia-safe="true"
-                              id="expandable-toggle3"
-                              type="button"
+                            Status
+                          </span>
+                          <span
+                            class="pf-v5-c-table__sort-indicator"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 256 512"
+                              width="1em"
                             >
-                              <div
-                                class="pf-v5-c-table__toggle-icon"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 320 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                  />
-                                </svg>
-                              </div>
-                            </button>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            tabindex="-1"
+                              <path
+                                d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="ascending"
+                      class="pf-v5-c-table__th pf-v5-c-table__sort pf-m-selected pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      scope="col"
+                      tabindex="-1"
+                    >
+                      <button
+                        class="pf-v5-c-table__button"
+                        type="button"
+                      >
+                        <div
+                          class="pf-v5-c-table__button-content"
+                        >
+                          <span
+                            class="pf-v5-c-table__text"
                           >
-                            dl-test-device-4
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            tabindex="-1"
+                            Message
+                          </span>
+                          <span
+                            class="pf-v5-c-table__sort-indicator"
                           >
-                            Success
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v5-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 256 512"
+                              width="1em"
                             >
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
-                              >
-                                Your system has 1 inhibitor out of 4 potential problems
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
+                              <path
+                                d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </button>
+                    </th>
+                    <td
+                      class="pf-v5-c-table__th"
+                      data-key="4"
+                      data-label=""
+                      tabindex="-1"
+                    />
+                  </tr>
+                </thead>
+                <tbody
+                  class="pf-v5-c-table__tbody"
+                  role="rowgroup"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-37"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td"
+                      data-key="0"
+                      tabindex="-1"
+                    />
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      YL-test-device-85
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Timeout
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
+                      >
+                        <div
+                          class="pf-v5-l-split__item"
+                          style="padding-right: 8px;"
+                        >
+                          <span
+                            class="pf-v5-c-icon"
                           >
-                            <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
-                              type="button"
+                            <span
+                              class="pf-v5-c-icon__content pf-m-danger"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5055,890 +4677,112 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 fill="currentColor"
                                 height="1em"
                                 role="img"
-                                viewBox="0 0 192 512"
+                                viewBox="0 0 512 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
                                 />
                               </svg>
-                            </button>
-                          </td>
-                        </tr>
-                        <tr
-                          class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                          data-ouia-component-id="OUIA-Generated-TableRow-41"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                          hidden=""
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="pf-v5-l-split__item"
+                          style="padding-right: 16px;"
                         >
-                          <td
-                            class="pf-v5-c-table__td"
-                            colspan="4"
-                            data-key="0"
-                            id="expanded-content4"
-                            tabindex="-1"
+                          <span
+                            style="color: rgb(201, 25, 11);"
                           >
-                            <div>
-                              <table
-                                class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                                data-ouia-component-id="OUIA-Generated-Table-9"
-                                data-ouia-component-type="PF5/Table"
-                                data-ouia-safe="true"
-                                role="grid"
-                                style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                              >
-                                <tbody
-                                  class="pf-v5-c-table__tbody"
-                                  role="rowgroup"
-                                >
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-42"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node0 expand-toggle0"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-24"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle0"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-danger"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(163, 0, 0);"
-                                        >
-                                          <strong>
-                                            Leapp could not identify where GRUB core is located
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-43"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-red pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              High risk
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        Leapp could not identify where GRUB core is located
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Remediation
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            ca7a1a66906a7df3da890aa538562708d3ea6ecd
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-44"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node1 expand-toggle1"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-25"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle1"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-warning"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 576 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(121, 80, 0);"
-                                        >
-                                          <strong>
-                                            SElinux will be set to permissive mode
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-45"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-orange pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 576 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              Low risk
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        SElinux will be set to permissive mode
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Remediation
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-46"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node2 expand-toggle2"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-26"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle2"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-warning"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 576 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(121, 80, 0);"
-                                        >
-                                          <strong>
-                                            The subscription-manager release is going to be set after the upgrade
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-47"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-orange pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 576 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              Low risk
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        The subscription-manager release is going to be set after the upgrade
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            After the upgrade has completed the release of the subscription-manager will be set to 9.0. This will ensure that you will receive and keep the version you choose to upgrade to.
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Remediation
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                [hint] If you wish to receive updates for the latest released version of the target system, run \`subscription-manager release --unset\` after the upgrade.
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            747a4ca25303eda17d1891bb85eeb226be14f252
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-48"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node3 expand-toggle3"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-27"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle3"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-info"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(0, 41, 82);"
-                                        >
-                                          <strong>
-                                            SElinux relabeling will be scheduled
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-49"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-blue pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              Info
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        SElinux relabeling will be scheduled
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            SElinux relabeling will be scheduled as the status is permissive/enforcing.
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            8fb81863f8413bd617c2a55b69b8e10ff03d7c72
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
+                            Alert
+                          </span>
+                        </div>
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        >
+                          Task failed to complete due to timing out. Retry this task at a later time.
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                           />
-                        </tr>
-                      </tbody>
-                      <tbody
-                        class="pf-v5-c-table__tbody"
-                        role="rowgroup"
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+                <tbody
+                  class="pf-v5-c-table__tbody"
+                  role="rowgroup"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-38"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td"
+                      data-key="0"
+                      tabindex="-1"
+                    />
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      MG-test-device
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Failure
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
                       >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-50"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
+                        <div
+                          class="pf-v5-l-split__item"
+                          style="padding-right: 8px;"
                         >
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                            data-key="0"
-                            tabindex="-1"
+                          <span
+                            class="pf-v5-c-icon"
                           >
-                            <button
-                              aria-disabled="false"
-                              aria-expanded="false"
-                              aria-label="Details"
-                              aria-labelledby="simple-node5 expandable-toggle5"
-                              class="pf-v5-c-button pf-m-plain"
-                              data-ouia-component-id="OUIA-Generated-Button-plain-28"
-                              data-ouia-component-type="PF5/Button"
-                              data-ouia-safe="true"
-                              id="expandable-toggle5"
-                              type="button"
-                            >
-                              <div
-                                class="pf-v5-c-table__toggle-icon"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="pf-v5-svg"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  viewBox="0 0 320 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                  />
-                                </svg>
-                              </div>
-                            </button>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            tabindex="-1"
-                          >
-                            dl-test-device-5
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            tabindex="-1"
-                          >
-                            Success
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
-                            >
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
-                              >
-                                Your system has 1 inhibitor out of 4 potential problems
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          >
-                            <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
-                              type="button"
+                            <span
+                              class="pf-v5-c-icon__content pf-m-danger"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5946,45 +4790,1165 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                                 fill="currentColor"
                                 height="1em"
                                 role="img"
-                                viewBox="0 0 192 512"
+                                viewBox="0 0 512 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
                                 />
                               </svg>
-                            </button>
-                          </td>
-                        </tr>
-                        <tr
-                          class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                          data-ouia-component-id="OUIA-Generated-TableRow-51"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                          hidden=""
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="pf-v5-l-split__item"
+                          style="padding-right: 16px;"
                         >
-                          <td
-                            class="pf-v5-c-table__td"
-                            colspan="4"
-                            data-key="0"
-                            id="expanded-content6"
-                            tabindex="-1"
+                          <span
+                            style="color: rgb(201, 25, 11);"
                           >
-                            <div>
-                              <div
-                                class="pf-v5-c-code-block"
-                                style="--pf-v5-c-code-block__header--BorderBottomColor: [object Object]; background-color: rgb(255, 255, 255);"
+                            Alert
+                          </span>
+                        </div>
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        >
+                          Task failed to complete for an unknown reason. Retry this task at a later time.
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+                <tbody
+                  class="pf-v5-c-table__tbody"
+                  role="rowgroup"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-39"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td"
+                      data-key="0"
+                      tabindex="-1"
+                    />
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      dl-test-device-2
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Success
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
+                      >
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        />
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+                <tbody
+                  class="pf-v5-c-table__tbody"
+                  role="rowgroup"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-40"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                      data-key="0"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-expanded="false"
+                        aria-label="Details"
+                        aria-labelledby="simple-node3 expandable-toggle3"
+                        class="pf-v5-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-23"
+                        data-ouia-component-type="PF5/Button"
+                        data-ouia-safe="true"
+                        id="expandable-toggle3"
+                        type="button"
+                      >
+                        <div
+                          class="pf-v5-c-table__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                            />
+                          </svg>
+                        </div>
+                      </button>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      dl-test-device-4
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Success
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
+                      >
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        >
+                          Your system has 1 inhibitor out of 4 potential problems
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                  <tr
+                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                    data-ouia-component-id="OUIA-Generated-TableRow-41"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                    hidden=""
+                  >
+                    <td
+                      class="pf-v5-c-table__td"
+                      colspan="4"
+                      data-key="0"
+                      id="expanded-content4"
+                      tabindex="-1"
+                    >
+                      <div>
+                        <table
+                          class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                          data-ouia-component-id="OUIA-Generated-Table-9"
+                          data-ouia-component-type="PF5/Table"
+                          data-ouia-safe="true"
+                          role="grid"
+                          style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                        >
+                          <tbody
+                            class="pf-v5-c-table__tbody"
+                            role="rowgroup"
+                          >
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-42"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                            >
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
                               >
-                                <div
-                                  class="pf-v5-c-code-block__content"
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node0 expand-toggle0"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-24"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle0"
+                                  type="button"
                                 >
-                                  <pre
-                                    class="pf-v5-c-code-block__pre"
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
                                   >
-                                    <code
-                                      class="pf-v5-c-code-block__code"
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
                                     >
-                                      Risk Factor: high
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-danger"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(163, 0, 0);"
+                                  >
+                                    <strong>
+                                      Leapp could not identify where GRUB core is located
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-43"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-red pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        High risk
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="entry-title"
+                                >
+                                  Leapp could not identify where GRUB core is located
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Remediation
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span
+                                          class="remediations-font-family"
+                                        >
+                                          [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      ca7a1a66906a7df3da890aa538562708d3ea6ecd
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-44"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                            >
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
+                              >
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node1 expand-toggle1"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-25"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle1"
+                                  type="button"
+                                >
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-warning"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 576 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(121, 80, 0);"
+                                  >
+                                    <strong>
+                                      SElinux will be set to permissive mode
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-45"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 576 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        Low risk
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="entry-title"
+                                >
+                                  SElinux will be set to permissive mode
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Remediation
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span
+                                          class="remediations-font-family"
+                                        >
+                                          [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-46"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                            >
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
+                              >
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node2 expand-toggle2"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-26"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle2"
+                                  type="button"
+                                >
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-warning"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 576 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(121, 80, 0);"
+                                  >
+                                    <strong>
+                                      The subscription-manager release is going to be set after the upgrade
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-47"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 576 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        Low risk
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="entry-title"
+                                >
+                                  The subscription-manager release is going to be set after the upgrade
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      After the upgrade has completed the release of the subscription-manager will be set to 9.0. This will ensure that you will receive and keep the version you choose to upgrade to.
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Remediation
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span
+                                          class="remediations-font-family"
+                                        >
+                                          [hint] If you wish to receive updates for the latest released version of the target system, run \`subscription-manager release --unset\` after the upgrade.
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      747a4ca25303eda17d1891bb85eeb226be14f252
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-48"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                            >
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
+                              >
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node3 expand-toggle3"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-27"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle3"
+                                  type="button"
+                                >
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-info"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(0, 41, 82);"
+                                  >
+                                    <strong>
+                                      SElinux relabeling will be scheduled
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-49"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-blue pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        Info
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="entry-title"
+                                >
+                                  SElinux relabeling will be scheduled
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      SElinux relabeling will be scheduled as the status is permissive/enforcing.
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      8fb81863f8413bd617c2a55b69b8e10ff03d7c72
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    />
+                  </tr>
+                </tbody>
+                <tbody
+                  class="pf-v5-c-table__tbody"
+                  role="rowgroup"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-50"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                      data-key="0"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-expanded="false"
+                        aria-label="Details"
+                        aria-labelledby="simple-node5 expandable-toggle5"
+                        class="pf-v5-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-28"
+                        data-ouia-component-type="PF5/Button"
+                        data-ouia-safe="true"
+                        id="expandable-toggle5"
+                        type="button"
+                      >
+                        <div
+                          class="pf-v5-c-table__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                            />
+                          </svg>
+                        </div>
+                      </button>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      dl-test-device-5
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Success
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
+                      >
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        >
+                          Your system has 1 inhibitor out of 4 potential problems
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                  <tr
+                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                    data-ouia-component-id="OUIA-Generated-TableRow-51"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                    hidden=""
+                  >
+                    <td
+                      class="pf-v5-c-table__td"
+                      colspan="4"
+                      data-key="0"
+                      id="expanded-content6"
+                      tabindex="-1"
+                    >
+                      <div>
+                        <div
+                          class="pf-v5-c-code-block"
+                          style="--pf-v5-c-code-block__header--BorderBottomColor: [object Object]; background-color: rgb(255, 255, 255);"
+                        >
+                          <div
+                            class="pf-v5-c-code-block__content"
+                          >
+                            <pre
+                              class="pf-v5-c-code-block__pre"
+                            >
+                              <code
+                                class="pf-v5-c-code-block__code"
+                              >
+                                Risk Factor: high
 Title: Leapp could not identify where GRUB core is located
 Summary: We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
 Remediation: [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
@@ -6008,62 +5972,1199 @@ Summary: SElinux relabeling will be scheduled as the status is permissive/enforc
 Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
 ----------------------------------------
 
-                                    </code>
-                                  </pre>
-                                </div>
-                              </div>
-                              <table
-                                class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                                data-ouia-component-id="OUIA-Generated-Table-10"
-                                data-ouia-component-type="PF5/Table"
-                                data-ouia-safe="true"
-                                role="grid"
-                                style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                              >
-                                <tbody
-                                  class="pf-v5-c-table__tbody"
-                                  role="rowgroup"
-                                />
-                              </table>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          />
-                        </tr>
-                      </tbody>
-                      <tbody
-                        class="pf-v5-c-table__tbody"
-                        role="rowgroup"
-                      >
-                        <tr
-                          class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-52"
-                          data-ouia-component-type="PF5/TableRow"
+                              </code>
+                            </pre>
+                          </div>
+                        </div>
+                        <table
+                          class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                          data-ouia-component-id="OUIA-Generated-Table-10"
+                          data-ouia-component-type="PF5/Table"
                           data-ouia-safe="true"
+                          role="grid"
+                          style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
                         >
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                            data-key="0"
-                            tabindex="-1"
+                          <tbody
+                            class="pf-v5-c-table__tbody"
+                            role="rowgroup"
+                          />
+                        </table>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    />
+                  </tr>
+                </tbody>
+                <tbody
+                  class="pf-v5-c-table__tbody"
+                  role="rowgroup"
+                >
+                  <tr
+                    class="pf-v5-c-table__tr"
+                    data-ouia-component-id="OUIA-Generated-TableRow-52"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                  >
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                      data-key="0"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-expanded="false"
+                        aria-label="Details"
+                        aria-labelledby="simple-node7 expandable-toggle7"
+                        class="pf-v5-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-29"
+                        data-ouia-component-type="PF5/Button"
+                        data-ouia-safe="true"
+                        id="expandable-toggle7"
+                        type="button"
+                      >
+                        <div
+                          class="pf-v5-c-table__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v5-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            width="1em"
                           >
-                            <button
-                              aria-disabled="false"
-                              aria-expanded="false"
-                              aria-label="Details"
-                              aria-labelledby="simple-node7 expandable-toggle7"
-                              class="pf-v5-c-button pf-m-plain"
-                              data-ouia-component-id="OUIA-Generated-Button-plain-29"
-                              data-ouia-component-type="PF5/Button"
+                            <path
+                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                            />
+                          </svg>
+                        </div>
+                      </button>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-30"
+                      data-key="1"
+                      data-label="System name"
+                      tabindex="-1"
+                    >
+                      dl-test-device-3
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-10"
+                      data-key="2"
+                      data-label="Status"
+                      tabindex="-1"
+                    >
+                      Success
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-m-width-35"
+                      data-key="3"
+                      data-label="Message"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="pf-v5-l-split"
+                      >
+                        <div
+                          class="pf-v5-l-split__item"
+                          color="#A30000"
+                        >
+                          Your system has 3 inhibitors out of 5 potential problems.
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-label="Kebab toggle"
+                        class="pf-v5-c-menu-toggle pf-m-plain"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v5-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 192 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                  <tr
+                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                    data-ouia-component-id="OUIA-Generated-TableRow-53"
+                    data-ouia-component-type="PF5/TableRow"
+                    data-ouia-safe="true"
+                    hidden=""
+                  >
+                    <td
+                      class="pf-v5-c-table__td"
+                      colspan="4"
+                      data-key="0"
+                      id="expanded-content8"
+                      tabindex="-1"
+                    >
+                      <div>
+                        <table
+                          class="pf-v5-c-table pf-m-grid-md pf-m-compact"
+                          data-ouia-component-id="OUIA-Generated-Table-11"
+                          data-ouia-component-type="PF5/Table"
+                          data-ouia-safe="true"
+                          role="grid"
+                          style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
+                        >
+                          <tbody
+                            class="pf-v5-c-table__tbody"
+                            role="rowgroup"
+                          >
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-54"
+                              data-ouia-component-type="PF5/TableRow"
                               data-ouia-safe="true"
-                              id="expandable-toggle7"
-                              type="button"
                             >
-                              <div
-                                class="pf-v5-c-table__toggle-icon"
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
+                              >
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node0 expand-toggle0"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-30"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle0"
+                                  type="button"
+                                >
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-danger"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(163, 0, 0);"
+                                  >
+                                    <strong>
+                                      Leapp could not identify where GRUB core is located
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-55"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-red pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        High risk
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="entry-title"
+                                >
+                                  Leapp could not identify where GRUB core is located
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Remediation
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span
+                                          class="remediations-font-family"
+                                        >
+                                          [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      ca7a1a66906a7df3da890aa538562708d3ea6ecd
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-56"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                            >
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
+                              >
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node1 expand-toggle1"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-31"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle1"
+                                  type="button"
+                                >
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-danger"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(163, 0, 0);"
+                                  >
+                                    <strong>
+                                      Firewalld Configuration AllowZoneDrifting Is Unsupported
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-57"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-red pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        High risk
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="entry-title"
+                                >
+                                  Firewalld Configuration AllowZoneDrifting Is Unsupported
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      Firewalld has enabled configuration option "AllowZoneDrifiting" which has been removed in RHEL-9. New behavior is as if "AllowZoneDrifiting" was set to "no".
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Remediation
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span
+                                          class="remediations-font-family"
+                                        >
+                                          [hint] Set AllowZoneDrifting=no in /etc/firewalld/firewalld.conf
+                                        </span>
+                                      </div>
+                                      <div>
+                                        <span>
+                                          <br />
+                                        </span>
+                                        <span
+                                          class="remediations-font-family"
+                                        >
+                                          [command] sed -i "s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/" /etc/firewalld/firewalld.conf
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      5b1cf050e1a877b0358b6e8c612277c591d40c13
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-58"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                            >
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
+                              >
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node2 expand-toggle2"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-32"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle2"
+                                  type="button"
+                                >
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-danger"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(163, 0, 0);"
+                                  >
+                                    <strong>
+                                      VDO devices migration to LVM management
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-59"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-red pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        High risk
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="entry-title"
+                                >
+                                  VDO devices migration to LVM management
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      VDO devices 'vda, vda1, vda2' require migration to LVM management.After performing the upgrade VDO devices can only be managed via LVM. Any VDO device not currently managed by LVM must be converted to LVM management before upgrading. The data on any VDO device not converted to LVM management will be inaccessible after upgrading.
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Remediation
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span
+                                          class="remediations-font-family"
+                                        >
+                                          [hint] Consult the VDO to LVM conversion process documentation for how to perform the conversion.
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      f7c335398cc449f5d7baf4e73255d44c34ad2620
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-60"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                            >
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
+                              >
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node3 expand-toggle3"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-33"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle3"
+                                  type="button"
+                                >
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-warning"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 576 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(121, 80, 0);"
+                                  >
+                                    <strong>
+                                      SElinux will be set to permissive mode
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-61"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-orange pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 576 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        Low risk
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="entry-title"
+                                >
+                                  SElinux will be set to permissive mode
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Remediation
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      <div>
+                                        <span
+                                          class="remediations-font-family"
+                                        >
+                                          [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr"
+                              data-ouia-component-id="OUIA-Generated-TableRow-62"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                            >
+                              <td
+                                class="pf-v5-c-table__td pf-v5-c-table__toggle"
+                                tabindex="-1"
+                              >
+                                <button
+                                  aria-disabled="false"
+                                  aria-expanded="false"
+                                  aria-label="Details"
+                                  aria-labelledby="simple-node4 expand-toggle4"
+                                  class="pf-v5-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-34"
+                                  data-ouia-component-type="PF5/Button"
+                                  data-ouia-safe="true"
+                                  id="expand-toggle4"
+                                  type="button"
+                                >
+                                  <div
+                                    class="pf-v5-c-table__toggle-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-v5-svg"
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </td>
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <span>
+                                  <span
+                                    class="pf-v5-c-icon"
+                                    style="margin-right: 8px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-icon__content pf-m-info"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="pf-v5-svg"
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                  <span
+                                    style="color: rgb(0, 41, 82);"
+                                  >
+                                    <strong>
+                                      SElinux relabeling will be scheduled
+                                    </strong>
+                                  </span>
+                                </span>
+                              </td>
+                            </tr>
+                            <tr
+                              class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
+                              data-ouia-component-id="OUIA-Generated-TableRow-63"
+                              data-ouia-component-type="PF5/TableRow"
+                              data-ouia-safe="true"
+                              hidden=""
+                            >
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              />
+                              <td
+                                class="pf-v5-c-table__td"
+                                tabindex="-1"
+                              >
+                                <div>
+                                  <span
+                                    class="pf-v5-c-label pf-m-blue pf-m-compact"
+                                    style="margin-top: 16px; margin-bottom: 4px;"
+                                  >
+                                    <span
+                                      class="pf-v5-c-label__content"
+                                    >
+                                      <span
+                                        class="pf-v5-c-label__icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="pf-v5-svg"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          viewBox="0 0 512 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span
+                                        class="pf-v5-c-label__text"
+                                      >
+                                        Info
+                                      </span>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="entry-title"
+                                >
+                                  SElinux relabeling will be scheduled
+                                </div>
+                                <div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Summary
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      SElinux relabeling will be scheduled as the status is permissive/enforcing.
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="pf-v5-l-grid pf-m-gutter entry-detail-title"
+                                  >
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
+                                    >
+                                      Key
+                                    </div>
+                                    <div
+                                      class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
+                                      l="6"
+                                      m="7"
+                                      style="white-space: pre-line;"
+                                    >
+                                      8fb81863f8413bd617c2a55b69b8e10ff03d7c72
+                                    </div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                    </td>
+                    <td
+                      class="pf-v5-c-table__td pf-v5-c-table__action"
+                      data-key="4"
+                      style="padding-right: 0px;"
+                      tabindex="-1"
+                    />
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
+                data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-3"
+                data-ouia-component-type="RHI/TableToolbar"
+                data-ouia-safe="true"
+                id="pf-random-id-5"
+              >
+                <div
+                  class="pf-v5-c-toolbar__content"
+                >
+                  <div
+                    class="pf-v5-c-toolbar__content-section"
+                  >
+                    <div
+                      class="pf-v5-c-toolbar__item pf-m-align-self-center"
+                    >
+                      <div>
+                        <div
+                          style="display: contents;"
+                        >
+                          <div
+                            class="pf-v5-c-content"
+                          >
+                            <small
+                              class=""
+                              data-ouia-component-id="OUIA-Generated-Text-6"
+                              data-ouia-component-type="PF5/Text"
+                              data-ouia-safe="true"
+                              data-pf-content="true"
+                            >
+                              Last updated: All jobs completed
+                            </small>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
+                    >
+                      <div
+                        class="pf-v5-c-pagination pf-m-bottom"
+                        data-ouia-component-id="OUIA-Generated-Pagination-bottom-3"
+                        data-ouia-component-type="PF5/Pagination"
+                        data-ouia-safe="true"
+                        id="options-menu-bottom-pagination"
+                        style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                      >
+                        <div>
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
+                            id="options-menu-bottom-toggle"
+                            type="button"
+                          >
+                            <span
+                              class="pf-v5-c-menu-toggle__text"
+                            >
+                              <b>
+                                1 - 6
+                              </b>
+                               of 
+                              <b>
+                                6
+                              </b>
+                               
+                            </span>
+                            <span
+                              class="pf-v5-c-menu-toggle__controls"
+                            >
+                              <span
+                                class="pf-v5-c-menu-toggle__toggle-icon"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -6075,55 +7176,29 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                   width="1em"
                                 >
                                   <path
-                                    d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
                                   />
                                 </svg>
-                              </div>
-                            </button>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-30"
-                            data-key="1"
-                            data-label="System name"
-                            tabindex="-1"
-                          >
-                            dl-test-device-3
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-10"
-                            data-key="2"
-                            data-label="Status"
-                            tabindex="-1"
-                          >
-                            Success
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-m-width-35"
-                            data-key="3"
-                            data-label="Message"
-                            tabindex="-1"
-                          >
-                            <div
-                              class="pf-v5-l-split"
-                            >
-                              <div
-                                class="pf-v5-l-split__item"
-                                color="#A30000"
-                              >
-                                Your system has 3 inhibitors out of 5 potential problems.
-                              </div>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
+                              </span>
+                            </span>
+                          </button>
+                        </div>
+                        <nav
+                          aria-label="Pagination"
+                          class="pf-v5-c-pagination__nav"
+                        >
+                          <div
+                            class="pf-v5-c-pagination__nav-control pf-m-first"
                           >
                             <button
-                              aria-expanded="false"
-                              aria-label="Kebab toggle"
-                              class="pf-v5-c-menu-toggle pf-m-plain"
+                              aria-disabled="true"
+                              aria-label="Go to first page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="first"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-35"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
                               type="button"
                             >
                               <svg
@@ -6132,1264 +7207,150 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                                 fill="currentColor"
                                 height="1em"
                                 role="img"
-                                viewBox="0 0 192 512"
+                                viewBox="0 0 448 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
                                 />
                               </svg>
                             </button>
-                          </td>
-                        </tr>
-                        <tr
-                          class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                          data-ouia-component-id="OUIA-Generated-TableRow-53"
-                          data-ouia-component-type="PF5/TableRow"
-                          data-ouia-safe="true"
-                          hidden=""
-                        >
-                          <td
-                            class="pf-v5-c-table__td"
-                            colspan="4"
-                            data-key="0"
-                            id="expanded-content8"
-                            tabindex="-1"
-                          >
-                            <div>
-                              <table
-                                class="pf-v5-c-table pf-m-grid-md pf-m-compact"
-                                data-ouia-component-id="OUIA-Generated-Table-11"
-                                data-ouia-component-type="PF5/Table"
-                                data-ouia-safe="true"
-                                role="grid"
-                                style="margin-bottom: 16px; --pf-v5-c-table__expandable-row--after--border-width--base: 0;"
-                              >
-                                <tbody
-                                  class="pf-v5-c-table__tbody"
-                                  role="rowgroup"
-                                >
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-54"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node0 expand-toggle0"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-30"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle0"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-danger"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(163, 0, 0);"
-                                        >
-                                          <strong>
-                                            Leapp could not identify where GRUB core is located
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-55"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-red pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              High risk
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        Leapp could not identify where GRUB core is located
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            We assume GRUB core is located on the same device as /boot. Leapp needs to update GRUB core as it is not done automatically on legacy (BIOS) systems. 
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Remediation
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                [hint] Please run "grub2-install &lt;GRUB_DEVICE&gt; command manually after upgrade
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            ca7a1a66906a7df3da890aa538562708d3ea6ecd
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-56"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node1 expand-toggle1"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-31"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle1"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-danger"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(163, 0, 0);"
-                                        >
-                                          <strong>
-                                            Firewalld Configuration AllowZoneDrifting Is Unsupported
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-57"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-red pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              High risk
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        Firewalld Configuration AllowZoneDrifting Is Unsupported
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            Firewalld has enabled configuration option "AllowZoneDrifiting" which has been removed in RHEL-9. New behavior is as if "AllowZoneDrifiting" was set to "no".
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Remediation
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                [hint] Set AllowZoneDrifting=no in /etc/firewalld/firewalld.conf
-                                              </span>
-                                            </div>
-                                            <div>
-                                              <span>
-                                                <br />
-                                              </span>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                [command] sed -i "s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/" /etc/firewalld/firewalld.conf
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            5b1cf050e1a877b0358b6e8c612277c591d40c13
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-58"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node2 expand-toggle2"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-32"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle2"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-danger"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(163, 0, 0);"
-                                        >
-                                          <strong>
-                                            VDO devices migration to LVM management
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-59"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-red pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              High risk
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        VDO devices migration to LVM management
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            VDO devices 'vda, vda1, vda2' require migration to LVM management.After performing the upgrade VDO devices can only be managed via LVM. Any VDO device not currently managed by LVM must be converted to LVM management before upgrading. The data on any VDO device not converted to LVM management will be inaccessible after upgrading.
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Remediation
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                [hint] Consult the VDO to LVM conversion process documentation for how to perform the conversion.
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            f7c335398cc449f5d7baf4e73255d44c34ad2620
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-60"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node3 expand-toggle3"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-33"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle3"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-warning"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 576 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(121, 80, 0);"
-                                        >
-                                          <strong>
-                                            SElinux will be set to permissive mode
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-61"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-orange pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 576 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              Low risk
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        SElinux will be set to permissive mode
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            SElinux will be set to permissive mode. Current mode: enforcing. This action is required by the upgrade process to make sure the upgraded system can boot without beinig blocked by SElinux rules.
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Remediation
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            <div>
-                                              <span
-                                                class="remediations-font-family"
-                                              >
-                                                [hint] Make sure there are no SElinux related warnings after the upgrade and enable SElinux manually afterwards. Notice: You can ignore the "/root/tmp_leapp_py3" SElinux warnings.
-                                              </span>
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            39d7183dafba798aa4bbb1e70b0ef2bbe5b1772f
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-62"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td pf-v5-c-table__toggle"
-                                      tabindex="-1"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-expanded="false"
-                                        aria-label="Details"
-                                        aria-labelledby="simple-node4 expand-toggle4"
-                                        class="pf-v5-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-34"
-                                        data-ouia-component-type="PF5/Button"
-                                        data-ouia-safe="true"
-                                        id="expand-toggle4"
-                                        type="button"
-                                      >
-                                        <div
-                                          class="pf-v5-c-table__toggle-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="pf-v5-svg"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </button>
-                                    </td>
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <span>
-                                        <span
-                                          class="pf-v5-c-icon"
-                                          style="margin-right: 8px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-icon__content pf-m-info"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="pf-v5-svg"
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              viewBox="0 0 512 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                              />
-                                            </svg>
-                                          </span>
-                                        </span>
-                                        <span
-                                          style="color: rgb(0, 41, 82);"
-                                        >
-                                          <strong>
-                                            SElinux relabeling will be scheduled
-                                          </strong>
-                                        </span>
-                                      </span>
-                                    </td>
-                                  </tr>
-                                  <tr
-                                    class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                                    data-ouia-component-id="OUIA-Generated-TableRow-63"
-                                    data-ouia-component-type="PF5/TableRow"
-                                    data-ouia-safe="true"
-                                    hidden=""
-                                  >
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    />
-                                    <td
-                                      class="pf-v5-c-table__td"
-                                      tabindex="-1"
-                                    >
-                                      <div>
-                                        <span
-                                          class="pf-v5-c-label pf-m-blue pf-m-compact"
-                                          style="margin-top: 16px; margin-bottom: 4px;"
-                                        >
-                                          <span
-                                            class="pf-v5-c-label__content"
-                                          >
-                                            <span
-                                              class="pf-v5-c-label__icon"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="pf-v5-svg"
-                                                fill="currentColor"
-                                                height="1em"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span
-                                              class="pf-v5-c-label__text"
-                                            >
-                                              Info
-                                            </span>
-                                          </span>
-                                        </span>
-                                      </div>
-                                      <div
-                                        class="entry-title"
-                                      >
-                                        SElinux relabeling will be scheduled
-                                      </div>
-                                      <div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Summary
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            SElinux relabeling will be scheduled as the status is permissive/enforcing.
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="pf-v5-l-grid pf-m-gutter entry-detail-title"
-                                        >
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-2-col entry-detail-content"
-                                          >
-                                            Key
-                                          </div>
-                                          <div
-                                            class="pf-v5-l-grid__item pf-m-8-col-on-sm pf-m-5-col-on-xl pf-m-5-col-on-2xl"
-                                            l="6"
-                                            m="7"
-                                            style="white-space: pre-line;"
-                                          >
-                                            8fb81863f8413bd617c2a55b69b8e10ff03d7c72
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </td>
-                                  </tr>
-                                </tbody>
-                              </table>
-                            </div>
-                          </td>
-                          <td
-                            class="pf-v5-c-table__td pf-v5-c-table__action"
-                            data-key="4"
-                            style="padding-right: 0px;"
-                            tabindex="-1"
-                          />
-                        </tr>
-                      </tbody>
-                    </table>
-                    <div
-                      class="pf-v5-c-toolbar ins-c-table__toolbar ins-m-footer"
-                      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-3"
-                      data-ouia-component-type="RHI/TableToolbar"
-                      data-ouia-safe="true"
-                      id="pf-random-id-5"
-                    >
-                      <div
-                        class="pf-v5-c-toolbar__content"
-                      >
-                        <div
-                          class="pf-v5-c-toolbar__content-section"
-                        >
-                          <div
-                            class="pf-v5-c-toolbar__item pf-m-align-self-center"
-                          >
-                            <div>
-                              <div
-                                style="display: contents;"
-                              >
-                                <div
-                                  class="pf-v5-c-content"
-                                >
-                                  <small
-                                    class=""
-                                    data-ouia-component-id="OUIA-Generated-Text-6"
-                                    data-ouia-component-type="PF5/Text"
-                                    data-ouia-safe="true"
-                                    data-pf-content="true"
-                                  >
-                                    Last updated: All jobs completed
-                                  </small>
-                                </div>
-                              </div>
-                            </div>
                           </div>
                           <div
-                            class="pf-v5-c-toolbar__item pf-m-pagination pf-m-align-right"
+                            class="pf-v5-c-pagination__nav-control"
                           >
-                            <div
-                              class="pf-v5-c-pagination pf-m-bottom"
-                              data-ouia-component-id="OUIA-Generated-Pagination-bottom-3"
-                              data-ouia-component-type="PF5/Pagination"
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to previous page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="previous"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-36"
+                              data-ouia-component-type="PF5/Button"
                               data-ouia-safe="true"
-                              id="options-menu-bottom-pagination"
-                              style="--pf-v5-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                              disabled=""
+                              type="button"
                             >
-                              <div>
-                                <button
-                                  aria-expanded="false"
-                                  aria-haspopup="listbox"
-                                  class="pf-v5-c-menu-toggle pf-m-plain pf-m-text"
-                                  id="options-menu-bottom-toggle"
-                                  type="button"
-                                >
-                                  <span
-                                    class="pf-v5-c-menu-toggle__text"
-                                  >
-                                    <b>
-                                      1 - 6
-                                    </b>
-                                     of 
-                                    <b>
-                                      6
-                                    </b>
-                                     
-                                  </span>
-                                  <span
-                                    class="pf-v5-c-menu-toggle__controls"
-                                  >
-                                    <span
-                                      class="pf-v5-c-menu-toggle__toggle-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="pf-v5-svg"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </span>
-                                </button>
-                              </div>
-                              <nav
-                                aria-label="Pagination"
-                                class="pf-v5-c-pagination__nav"
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
                               >
-                                <div
-                                  class="pf-v5-c-pagination__nav-control pf-m-first"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to first page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="first"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-35"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 448 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-control"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to previous page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="previous"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-36"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-page-select"
-                                >
-                                  <span
-                                    class="pf-v5-c-form-control pf-m-disabled"
-                                  >
-                                    <input
-                                      aria-invalid="false"
-                                      aria-label="Current page"
-                                      data-ouia-component-id="OUIA-Generated-TextInputBase-6"
-                                      data-ouia-component-type="PF5/TextInput"
-                                      data-ouia-safe="true"
-                                      disabled=""
-                                      max="1"
-                                      min="1"
-                                      type="number"
-                                      value="1"
-                                    />
-                                  </span>
-                                  <span
-                                    aria-hidden="true"
-                                  >
-                                    of 1
-                                  </span>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-control"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to next page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="next"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-37"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                                <div
-                                  class="pf-v5-c-pagination__nav-control pf-m-last"
-                                >
-                                  <button
-                                    aria-disabled="true"
-                                    aria-label="Go to last page"
-                                    class="pf-v5-c-button pf-m-plain pf-m-disabled"
-                                    data-action="last"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-38"
-                                    data-ouia-component-type="PF5/Button"
-                                    data-ouia-safe="true"
-                                    disabled=""
-                                    type="button"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="pf-v5-svg"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      viewBox="0 0 448 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                                      />
-                                    </svg>
-                                  </button>
-                                </div>
-                              </nav>
-                            </div>
+                                <path
+                                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                />
+                              </svg>
+                            </button>
                           </div>
-                        </div>
-                      </div>
-                      <div
-                        class="pf-v5-c-toolbar__content pf-m-hidden"
-                        hidden=""
-                      >
-                        <div
-                          class="pf-v5-c-toolbar__group"
-                        />
+                          <div
+                            class="pf-v5-c-pagination__nav-page-select"
+                          >
+                            <span
+                              class="pf-v5-c-form-control pf-m-disabled"
+                            >
+                              <input
+                                aria-invalid="false"
+                                aria-label="Current page"
+                                data-ouia-component-id="OUIA-Generated-TextInputBase-6"
+                                data-ouia-component-type="PF5/TextInput"
+                                data-ouia-safe="true"
+                                disabled=""
+                                max="1"
+                                min="1"
+                                type="number"
+                                value="1"
+                              />
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              of 1
+                            </span>
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-control"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to next page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="next"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-37"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 256 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <div
+                            class="pf-v5-c-pagination__nav-control pf-m-last"
+                          >
+                            <button
+                              aria-disabled="true"
+                              aria-label="Go to last page"
+                              class="pf-v5-c-button pf-m-plain pf-m-disabled"
+                              data-action="last"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-38"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 448 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </nav>
                       </div>
                     </div>
                   </div>
-                </section>
-              </main>
+                </div>
+                <div
+                  class="pf-v5-c-toolbar__content pf-m-hidden"
+                  hidden=""
+                >
+                  <div
+                    class="pf-v5-c-toolbar__group"
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-          <div
-            class="pf-v5-c-drawer__panel"
-            hidden=""
-            id="pf-drawer-panel-4"
-          />
+          </section>
         </div>
       </div>
+      <div
+        class="pf-v5-c-drawer__panel"
+        hidden=""
+        id="log-drawer"
+      />
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
The JobLogDrawer has been moved out of the Page component and wrapped around the contents of the CompletedTaskDetails component.

Previously, we had to put the Drawer inside of the Page component in order to display the drawer correct when expanded. But this caused there to be an additional scrollbar on the page.

Steps to Reproduce
- Find a tasks execution with more than 20 hosts or execute one
- Click on the task details to see individual host results
- Select the paginator to show more than 10 (or simply shrink the height of the page)
- Try to scroll the list

Also, test the JobLogDrawer by clicking the kebab on a system and click "View system logs" and make sure the functionality has remained.