### PR TITLE
feat(RHINENG-11806): Handle OPTIONAL_REPOSITORIES task parameter

### DIFF
--- a/src/SmartComponents/RunTaskModal/ConversionTaskInputParameters.js
+++ b/src/SmartComponents/RunTaskModal/ConversionTaskInputParameters.js
@@ -1,14 +1,22 @@
-import React, { useState } from 'react';
+import React from 'react';
 import propTypes from 'prop-types';
 import {
   Alert,
-  Checkbox,
   Form,
   Text,
   TextContent,
   TextVariants,
 } from '@patternfly/react-core';
 import { findParameterByKey } from '../../Utilities/helpers';
+import { ParameterCheckboxGroup } from './ParameterCheckboxGroup';
+import { ParameterCheckbox } from './ParameterCheckbox';
+import {
+  CONVERT2RHEL_CONVERSION_TITLE,
+  CONVERT2RHEL_CONVERSION_DESCRIPTION,
+  CONVERT2RHEL_ANALYSIS_TITLE,
+  CONVERT2RHEL_ANALYSIS_DESCRIPTION,
+  ELS_DISABLED_CUSTOM_DESCRIPTION,
+} from '../../constants';
 
 const ConversionTaskInputParameters = ({
   slug,
@@ -28,15 +36,9 @@ const ConversionTaskInputParameters = ({
     parameters,
     'CONVERT2RHEL_OUTDATED_PACKAGE_CHECK_SKIP'
   );
-  const [elsDisabledValue, setElsDisabledValue] = useState(elsDisabled.default);
-  const [unavailableKmodsValue, setUnavailableKmodsValue] = useState(
-    unavailableKmods.default
-  );
-  const [skipKernelCheckValue, setSkipKernelCheckValue] = useState(
-    skipKernelCheck.default
-  );
-  const [skipPackageCheckValue, setSkipPackageCheckValue] = useState(
-    skipPackageCheck.default
+  const optionalRepositories = findParameterByKey(
+    parameters,
+    'OPTIONAL_REPOSITORIES'
   );
 
   const updateParameters = (parameter, newValue) => {
@@ -50,103 +52,25 @@ const ConversionTaskInputParameters = ({
       });
     });
   };
-  const toBool = (value) => {
-    return value.toLowerCase() === 'true' || value === '1' || value === 1;
-  };
 
-  const createCheckbox = (
-    parameter,
-    currValue,
-    setValue,
-    customDescription = undefined
-  ) => {
-    return (
-      <Checkbox
-        id={parameter.key}
-        label={parameter.title}
-        description={customDescription || parameter.description}
-        isChecked={toBool(currValue)}
-        onChange={(_event, checkedValue) => {
-          let newValue;
-          if (currValue === '0' || currValue === '1') {
-            newValue = checkedValue ? '1' : '0';
-          } else {
-            newValue = checkedValue ? 'True' : 'False';
-          }
-          setValue(newValue);
-          updateParameters(parameter, newValue);
-        }}
-      />
-    );
-  };
-
-  const createLink = (href, text) => (
-    <a href={href} target="_blank" rel="noopener noreferrer">
-      {text}
-    </a>
-  );
-
-  const readMoreLink = createLink(
-    'https://www.redhat.com/en/blog/announcing-4-years-extended-life-cycle-support-els-red-hat-enterprise-linux-7',
-    'Read more about ELS for RHEL 7.'
-  );
-
-  const convert2RHELSupportLink = createLink(
-    'https://access.redhat.com/support/policy/convert2rhel-support',
-    'Convert2RHEL Support Policy'
-  );
-
-  const inPlaceSupportLink = createLink(
-    'https://access.redhat.com/support/policy/ipu-support',
-    'In-place upgrade Support Policy'
-  );
-
-  const analysisTitleSection = (
-    <TextContent>
-      <Text component={TextVariants.h4}>
-        Analyze conversion to RHEL 7 without Extended Lifecycle Support (ELS)
-      </Text>
-      <Text component={TextVariants.p}>
-        By default, the task analyzes a conversion of your CentOS Linux 7 to a
-        supported RHEL 7 system with the latest security patches and updates via
-        ELS. {readMoreLink}
-      </Text>
-    </TextContent>
-  );
-
-  const convertTitleSection = (
-    <TextContent>
-      <Text component={TextVariants.h4}>
-        Convert to RHEL 7 without Extended Lifecycle Support (ELS)
-      </Text>
-      <Text component={TextVariants.p}>
-        By default, the task converts your CentOS Linux 7 to a supported RHEL 7
-        system with the latest security patches and updates via ELS.{' '}
-        {readMoreLink}
-      </Text>
-    </TextContent>
-  );
-
-  const elsDisabledDescription = (
-    <div>
-      If you plan to upgrade to RHEL 8 right after the conversion, you may opt
-      opt not to use the ELS subscription. Note that the conversion and the
-      subsequent upgrade without an ELS subscription come with a limited support
-      scope per the {convert2RHELSupportLink} and the {inPlaceSupportLink}.
-    </div>
-  );
+  let formTitle = CONVERT2RHEL_CONVERSION_TITLE;
+  let formDescription = CONVERT2RHEL_CONVERSION_DESCRIPTION;
+  if (slug.includes('analysis')) {
+    formTitle = CONVERT2RHEL_ANALYSIS_TITLE;
+    formDescription = CONVERT2RHEL_ANALYSIS_DESCRIPTION;
+  }
 
   return (
     <Form className="pf-v5-u-pb-lg">
-      {slug.includes('analysis') ? analysisTitleSection : convertTitleSection}
-
-      {createCheckbox(
-        elsDisabled,
-        elsDisabledValue,
-        setElsDisabledValue,
-        elsDisabledDescription
-      )}
-
+      <TextContent>
+        <Text component={TextVariants.h4}>{formTitle}</Text>
+        <Text component={TextVariants.p}>{formDescription}</Text>
+      </TextContent>
+      <ParameterCheckbox
+        parameter={elsDisabled}
+        updateParameters={updateParameters}
+        customDescription={ELS_DISABLED_CUSTOM_DESCRIPTION}
+      />
       <TextContent>
         <Text component={TextVariants.h4}>
           Ignore specific pre-conversion analysis check results.
@@ -157,24 +81,22 @@ const ConversionTaskInputParameters = ({
         Overriding issues can cause the conversion to fail, resulting in a
         deteriorated system state.
       </Alert>
-
-      {createCheckbox(
-        unavailableKmods,
-        unavailableKmodsValue,
-        setUnavailableKmodsValue
-      )}
-
-      {createCheckbox(
-        skipKernelCheck,
-        skipKernelCheckValue,
-        setSkipKernelCheckValue
-      )}
-
-      {createCheckbox(
-        skipPackageCheck,
-        skipPackageCheckValue,
-        setSkipPackageCheckValue
-      )}
+      <ParameterCheckbox
+        parameter={unavailableKmods}
+        updateParameters={updateParameters}
+      />
+      <ParameterCheckbox
+        parameter={skipKernelCheck}
+        updateParameters={updateParameters}
+      />
+      <ParameterCheckbox
+        parameter={skipPackageCheck}
+        updateParameters={updateParameters}
+      />
+      <ParameterCheckboxGroup
+        parameter={optionalRepositories}
+        updateParameters={updateParameters}
+      />
     </Form>
   );
 };

--- a/src/SmartComponents/RunTaskModal/ParameterCheckbox.js
+++ b/src/SmartComponents/RunTaskModal/ParameterCheckbox.js
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import propTypes from 'prop-types';
+import { Checkbox } from '@patternfly/react-core';
+import { toBool } from '../../Utilities/helpers';
+
+const ParameterCheckbox = ({
+  parameter,
+  updateParameters,
+  customDescription = undefined,
+}) => {
+  const [parameterValue, setParameterValue] = useState(parameter.default);
+
+  return (
+    <Checkbox
+      id={parameter.key}
+      label={parameter.title}
+      aria-label={parameter.key}
+      description={customDescription || parameter.description}
+      isChecked={toBool(parameterValue)}
+      onChange={(_event, isChecked) => {
+        let newParameterValue;
+        if (['0', '1'].includes(parameterValue)) {
+          newParameterValue = isChecked ? '1' : '0';
+        } else {
+          newParameterValue = isChecked ? 'True' : 'False';
+        }
+        setParameterValue(newParameterValue);
+        updateParameters(parameter, newParameterValue);
+      }}
+    />
+  );
+};
+
+ParameterCheckbox.propTypes = {
+  parameter: propTypes.object.isRequired,
+  updateParameters: propTypes.func.isRequired,
+  customDescription: propTypes.string || propTypes.node,
+};
+
+export { ParameterCheckbox };

--- a/src/SmartComponents/RunTaskModal/ParameterCheckboxGroup.js
+++ b/src/SmartComponents/RunTaskModal/ParameterCheckboxGroup.js
@@ -1,0 +1,61 @@
+import {
+  Checkbox,
+  FormGroup,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import React, { useState } from 'react';
+import propTypes from 'prop-types';
+
+const ParameterCheckboxGroup = ({
+  parameter,
+  updateParameters,
+  customDescription = undefined,
+}) => {
+  const [parameterValue, setParameterValue] = useState(
+    ['None', ''].includes(parameter.default) ? [] : parameter.default.split(',')
+  );
+
+  return (
+    <FormGroup role="group" fieldId={parameter.key}>
+      <TextContent>
+        <Text component={TextVariants.h4}>{parameter.title}</Text>
+        <Text component={TextVariants.p}>
+          {customDescription || parameter.description}
+        </Text>
+      </TextContent>
+      <div style={{ paddingTop: '0.5rem', paddingLeft: '1rem' }}>
+        {parameter.values
+          .filter((val) => !['None', ''].includes(val)) // remove vals that indicate nothing was selected
+          .map((val) => (
+            <Checkbox
+              id={val}
+              key={val}
+              label={val}
+              aria-label={`${parameter.key}.${val}`}
+              isChecked={parameterValue.includes(val)}
+              onChange={(_event, isChecked) => {
+                const newParameterValue = isChecked
+                  ? [...parameterValue, val]
+                  : parameterValue.filter((pv) => pv !== val);
+                setParameterValue(newParameterValue);
+                updateParameters(
+                  parameter,
+                  newParameterValue.join(',') || 'None'
+                );
+              }}
+            />
+          ))}
+      </div>
+    </FormGroup>
+  );
+};
+
+ParameterCheckboxGroup.propTypes = {
+  parameter: propTypes.object.isRequired,
+  updateParameters: propTypes.func.isRequired,
+  customDescription: propTypes.string || propTypes.node,
+};
+
+export { ParameterCheckboxGroup };

--- a/src/Utilities/helpers.js
+++ b/src/Utilities/helpers.js
@@ -89,3 +89,7 @@ export const camelCase = (string) => {
 export const findParameterByKey = (parameters, key) => {
   return parameters.find((param) => param.key === key);
 };
+
+export const toBool = (value) => {
+  return value.toLowerCase() === 'true' || value === '1' || value === 1;
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,6 +17,7 @@ import {
   SkeletonSize,
 } from '@redhat-cloud-services/frontend-components/Skeleton';
 import RunTaskButton from './PresentationalComponents/RunTaskButton/RunTaskButton';
+import { createLink } from './helpers';
 
 /**
  * String constants
@@ -328,3 +329,45 @@ export const CANCEL_TASK_BODY = (startTime, title) => {
 export const CANCEL_TASK_ERROR = (title) => {
   return `Error: Task "${title}" could not be cancelled`;
 };
+
+/**
+ * Conversion task parameter constants
+ */
+export const READ_MORE_ABOUT_ELS_LINK = createLink(
+  'https://www.redhat.com/en/blog/announcing-4-years-extended-life-cycle-support-els-red-hat-enterprise-linux-7',
+  'Read more about ELS for RHEL 7.'
+);
+export const CONVERT2RHEL_SUPPORT_LINK = createLink(
+  'https://access.redhat.com/support/policy/convert2rhel-support',
+  'Convert2RHEL Support Policy'
+);
+export const IN_PLACE_UPGRADE_SUPPORT_LINK = createLink(
+  'https://access.redhat.com/support/policy/ipu-support',
+  'In-place upgrade Support Policy'
+);
+export const CONVERT2RHEL_ANALYSIS_TITLE =
+  'Analyze conversion to RHEL 7 without Extended Lifecycle Support (ELS)';
+export const CONVERT2RHEL_CONVERSION_TITLE =
+  'Convert to RHEL 7 without Extended Lifecycle Support (ELS)';
+export const CONVERT2RHEL_ANALYSIS_DESCRIPTION = (
+  <React.Fragment>
+    By default, the task analyzes a conversion of your CentOS Linux 7 to a
+    supported RHEL 7 system with the latest security patches and updates via
+    ELS. {READ_MORE_ABOUT_ELS_LINK}
+  </React.Fragment>
+);
+export const CONVERT2RHEL_CONVERSION_DESCRIPTION = (
+  <React.Fragment>
+    By default, the task converts your CentOS Linux 7 to a supported RHEL 7
+    system with the latest security patches and updates via ELS.{' '}
+    {READ_MORE_ABOUT_ELS_LINK}
+  </React.Fragment>
+);
+export const ELS_DISABLED_CUSTOM_DESCRIPTION = (
+  <React.Fragment>
+    If you plan to upgrade to RHEL 8 right after the conversion, you may opt not
+    to use the ELS subscription. Note that the conversion and the subsequent
+    upgrade without an ELS subscription come with a limited support scope per
+    the {CONVERT2RHEL_SUPPORT_LINK} and the {IN_PLACE_UPGRADE_SUPPORT_LINK}.
+  </React.Fragment>
+);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,6 +13,12 @@ export const createSystemLink = (id, name, keyData) => (
   </a>
 );
 
+export const createLink = (href, text) => (
+  <a href={href} target="_blank" rel="noopener noreferrer">
+    {text}
+  </a>
+);
+
 export const createEligibilityTooltip = (eligibility) => {
   return eligibility.tooltip ? (
     <Tooltip content={eligibility.tooltip}>


### PR DESCRIPTION
Screenshots showing the Parameter form with the optional repositories checkboxes all checked and the value produced that is sent to the Tasks API:
![Screenshot from 2024-08-22 15-39-58](https://github.com/user-attachments/assets/fb597e9b-cf30-4979-b89c-7e0a77fa9b61)
![Screenshot from 2024-08-22 15-40-10](https://github.com/user-attachments/assets/03478574-ad5c-4061-93ab-6041bb93b7f8)


More screenshots showing none of the optional repositories checkboxes checked and the value 'None' sent to the backend:
![Screenshot from 2024-08-22 15-42-04](https://github.com/user-attachments/assets/e20a4af9-98a3-4836-b38e-2373be977c64)
![Screenshot from 2024-08-22 15-42-14](https://github.com/user-attachments/assets/c52e15f9-7305-4738-9777-3c0ff274f356)
