### PR TITLE
fix(RHINENG-11439): Display eligible systems alert only when eligible systems filtered

### DIFF
--- a/src/SmartComponents/RunTaskModal/RunTaskModalBody.js
+++ b/src/SmartComponents/RunTaskModal/RunTaskModalBody.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import propTypes from 'prop-types';
 import SystemsSelect from './SystemsSelect';
 import InputParameters from './InputParameters';
@@ -25,6 +25,8 @@ const RunTaskModalBody = ({
   taskName,
   filterMessage,
 }) => {
+  const [showEligibilityAlert, setShowEligibilityAlert] = useState(true);
+
   const warningConstantMapper = `${slug
     ?.toUpperCase()
     .replace(/-/g, '_')}_WARNING`;
@@ -50,13 +52,20 @@ const RunTaskModalBody = ({
       />
       <div id="task-warnings-and-alerts" aria-label="Task warnings and alerts">
         {warningConstants[warningConstantMapper]}
-        <Alert variant="info" isInline title="Only eligible systems are shown">
-          {filterMessage || INFO_ALERT_SYSTEMS}
-        </Alert>
+        {showEligibilityAlert && (
+          <Alert
+            variant="info"
+            isInline
+            title="Only eligible systems are shown"
+          >
+            {filterMessage || INFO_ALERT_SYSTEMS}
+          </Alert>
+        )}
       </div>
       <SystemsSelect
         selectedIds={selectedIds}
         setSelectedIds={setSelectedIds}
+        setShowEligibilityAlert={setShowEligibilityAlert}
         slug={slug}
       />
     </Flex>

--- a/src/SmartComponents/RunTaskModal/SystemsSelect.js
+++ b/src/SmartComponents/RunTaskModal/SystemsSelect.js
@@ -4,7 +4,12 @@ import React, { useState } from 'react';
 import SystemTable from '../SystemTable/SystemTable';
 import { useSystemBulkSelect } from './hooks/useBulkSystemSelect';
 
-const SystemsSelect = ({ selectedIds, setSelectedIds, slug }) => {
+const SystemsSelect = ({
+  selectedIds,
+  setSelectedIds,
+  setShowEligibilityAlert,
+  slug,
+}) => {
   const [filterSortString, setFilterSortString] = useState('');
 
   const { bulkSelectIds, selectIds } = useSystemBulkSelect(
@@ -22,6 +27,7 @@ const SystemsSelect = ({ selectedIds, setSelectedIds, slug }) => {
         selectedIds={selectedIds}
         selectIds={selectIds}
         setFilterSortString={setFilterSortString}
+        setShowEligibilityAlert={setShowEligibilityAlert}
         slug={slug}
       />
     </>
@@ -31,6 +37,7 @@ const SystemsSelect = ({ selectedIds, setSelectedIds, slug }) => {
 SystemsSelect.propTypes = {
   selectedIds: propTypes.array,
   setSelectedIds: propTypes.func,
+  setShowEligibilityAlert: propTypes.func,
   slug: propTypes.string,
 };
 

--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -27,6 +27,7 @@ const SystemTable = ({
   selectedIds,
   selectIds,
   setFilterSortString,
+  setShowEligibilityAlert,
   slug,
 }) => {
   const [items, setItems] = useState([]);
@@ -100,6 +101,7 @@ const SystemTable = ({
     filterValues: {
       onChange: (event, value) => {
         setEligibility(value);
+        setShowEligibilityAlert(value === ELIGIBLE_SYSTEMS);
       },
       items: eligibilityFilterItems,
       value: eligibility,
@@ -118,12 +120,17 @@ const SystemTable = ({
     onDelete: (event, itemsToRemove, isAll) => {
       if (isAll) {
         setEligibility(ELIGIBLE_SYSTEMS);
+        setShowEligibilityAlert(true);
       } else {
         itemsToRemove.map((item) => {
           if (item.category === 'Task eligibility') {
-            eligibility === ALL_SYSTEMS
-              ? setEligibility(ELIGIBLE_SYSTEMS)
-              : setEligibility(ALL_SYSTEMS);
+            if (eligibility === ALL_SYSTEMS) {
+              setEligibility(ELIGIBLE_SYSTEMS);
+              setShowEligibilityAlert(true);
+            } else {
+              setEligibility(ALL_SYSTEMS);
+              setShowEligibilityAlert(false);
+            }
           }
         });
       }
@@ -240,6 +247,7 @@ SystemTable.propTypes = {
   selectedIds: propTypes.array,
   selectIds: propTypes.func,
   setFilterSortString: propTypes.func,
+  setShowEligibilityAlert: propTypes.func,
   slug: propTypes.string,
 };
 


### PR DESCRIPTION
Alert box only displayed when Eligible Systems filter is active:

![Screenshot from 2024-09-09 10-56-49](https://github.com/user-attachments/assets/e6792a0e-f2d7-46d3-b5ca-6d544244bc47)

![Screenshot from 2024-09-09 10-56-55](https://github.com/user-attachments/assets/9abf588f-821f-4d4d-8974-5628308bb707)
