### PR TITLE
fix(RHINENG-12517): Change 'Success' job status to 'Completed' for all jobs

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/Columns.js
+++ b/src/SmartComponents/CompletedTaskDetails/Columns.js
@@ -32,11 +32,6 @@ export const StatusColumn = {
     width: 10,
   },
   sortByProp: 'status',
-  renderExport: (job) => job.status,
-};
-
-export const ConversionStatusColumn = {
-  ...StatusColumn,
   renderExport: (job) => (job.status === 'Success' ? 'Completed' : job.status),
   renderFunc: (_, _empty, job) =>
     job.status === 'Success' ? 'Completed' : job.status,
@@ -102,11 +97,6 @@ export const IssueRemediationColumn = {
 };
 
 export const exportableColumns = [SystemColumn, StatusColumn, MessageColumn];
-export const conversionColumns = [
-  SystemColumn,
-  ConversionStatusColumn,
-  MessageColumn,
-];
 export const extendedReportColumns = [
   IssueTitleColumn,
   IssueSeverityColumn,

--- a/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
+++ b/src/SmartComponents/CompletedTaskDetails/CompletedTaskDetails.js
@@ -18,7 +18,6 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import columns, {
-  conversionColumns,
   exportableColumns,
   ReportColumn,
   extendedReportColumns,
@@ -29,7 +28,6 @@ import {
   COMPLETED_INFO_PANEL_FLEX_PROPS,
   COMPLETED_INFO_BUTTONS,
   COMPLETED_INFO_BUTTONS_FLEX_PROPS,
-  CONVERSION_SLUG,
   LOADING_INFO_PANEL,
   LOADING_JOBS_TABLE,
   TASK_ERROR,
@@ -182,17 +180,9 @@ const CompletedTaskDetails = () => {
     [completedTaskJobs, tableLoading]
   );
 
-  const isConversionTask = () => {
-    return (
-      completedTaskDetails.task_slug ===
-        `${CONVERSION_SLUG}-conversion-stage` ||
-      completedTaskDetails.task_slug === `${CONVERSION_SLUG}-conversion`
-    );
-  };
-
   const buildFilterConfig = () => {
     return {
-      filterConfig: [...systemFilter, ...buildStatusFilter(isConversionTask())],
+      filterConfig: [...systemFilter, ...buildStatusFilter()],
     };
   };
 
@@ -313,16 +303,14 @@ const CompletedTaskDetails = () => {
                   <TasksTables
                     label={`${completedTaskDetails.id}-completed-jobs`}
                     ouiaId={`${completedTaskDetails.id}-completed-jobs-table`}
-                    columns={isConversionTask() ? conversionColumns : columns}
+                    columns={columns}
                     items={completedTaskJobs}
                     filters={buildFilterConfig()}
                     options={{
                       ...TASKS_TABLE_DEFAULTS,
                       exportable: {
                         ...TASKS_TABLE_DEFAULTS.exportable,
-                        columns: isConversionTask()
-                          ? conversionColumns
-                          : exportableColumns,
+                        columns: exportableColumns,
                         extraExportColumns: [
                           ...(hasPlainReport ? [ReportColumn] : []),
                           ...(hasReportJson ? extendedReportColumns : []),

--- a/src/SmartComponents/CompletedTaskDetails/Filters.js
+++ b/src/SmartComponents/CompletedTaskDetails/Filters.js
@@ -13,7 +13,7 @@ export const systemFilter = [
   },
 ];
 
-export const buildStatusFilter = (isConversionTask) => {
+export const buildStatusFilter = () => {
   return [
     {
       type: conditionalFilterType.checkbox,
@@ -22,7 +22,7 @@ export const buildStatusFilter = (isConversionTask) => {
         jobs.filter((job) => value.includes(job.status.toLowerCase())),
       items: [
         { label: 'Running', value: 'running' },
-        { label: isConversionTask ? 'Completed' : 'Success', value: 'success' },
+        { label: 'Completed', value: 'success' },
         { label: 'Failure', value: 'failure' },
         { label: 'Timeout', value: 'timeout' },
       ],

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/CompletedTaskDetails.tests.js
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/CompletedTaskDetails.tests.js
@@ -223,7 +223,7 @@ describe('CompletedTaskDetails', () => {
     );
     userEvent.click(screen.getAllByText('Status')[0]);
     await waitFor(() => userEvent.click(screen.getByLabelText('Options menu')));
-    await waitFor(() => userEvent.click(screen.getAllByText('Success')[0]));
+    await waitFor(() => userEvent.click(screen.getAllByText('Completed')[0]));
     await waitFor(() =>
       expect(screen.getByText('dl-test-device-2')).toBeInTheDocument()
     );
@@ -315,7 +315,7 @@ describe('CompletedTaskDetails', () => {
     await waitFor(() => expect(fetchExecutedTaskJobs).toHaveBeenCalled());
 
     const row = screen.getByRole('row', {
-      name: /details centos7-test-device-3 success no inhibtors found, conversion should run smoothly for this system\./i,
+      name: /details centos7-test-device-3 Completed no inhibtors found, conversion should run smoothly for this system\./i,
     });
 
     fireEvent.click(
@@ -358,7 +358,7 @@ describe('CompletedTaskDetails', () => {
     await waitFor(() => expect(fetchExecutedTaskJobs).toHaveBeenCalled());
 
     const row = screen.getByRole('row', {
-      name: /details centos7-test-device-3 success no inhibtors found, conversion should run smoothly for this system\./i,
+      name: /details centos7-test-device-3 Completed no inhibtors found, conversion should run smoothly for this system\./i,
     });
 
     fireEvent.click(
@@ -395,7 +395,7 @@ describe('CompletedTaskDetails', () => {
     await waitFor(() => expect(fetchExecutedTaskJobs).toHaveBeenCalled());
 
     const row = screen.getByRole('row', {
-      name: /system deleted success no inhibtors found, conversion should run smoothly for this system\./i,
+      name: /system deleted Completed no inhibtors found, conversion should run smoothly for this system\./i,
     });
 
     fireEvent.click(

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -755,7 +755,7 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                       data-label="Status"
                       tabindex="-1"
                     >
-                      Success
+                      Completed
                     </td>
                     <td
                       class="pf-v5-c-table__td pf-m-width-35"
@@ -863,7 +863,7 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                       data-label="Status"
                       tabindex="-1"
                     >
-                      Success
+                      Completed
                     </td>
                     <td
                       class="pf-v5-c-table__td pf-m-width-35"
@@ -1446,7 +1446,7 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                       data-label="Status"
                       tabindex="-1"
                     >
-                      Success
+                      Completed
                     </td>
                     <td
                       class="pf-v5-c-table__td pf-m-width-35"
@@ -1554,7 +1554,7 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                       data-label="Status"
                       tabindex="-1"
                     >
-                      Success
+                      Completed
                     </td>
                     <td
                       class="pf-v5-c-table__td pf-m-width-35"
@@ -3203,7 +3203,7 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                       data-label="Status"
                       tabindex="-1"
                     >
-                      Success
+                      Completed
                     </td>
                     <td
                       class="pf-v5-c-table__td pf-m-width-35"
@@ -4702,7 +4702,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                       data-label="Status"
                       tabindex="-1"
                     >
-                      Success
+                      Completed
                     </td>
                     <td
                       class="pf-v5-c-table__td pf-m-width-35"
@@ -4808,7 +4808,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                       data-label="Status"
                       tabindex="-1"
                     >
-                      Success
+                      Completed
                     </td>
                     <td
                       class="pf-v5-c-table__td pf-m-width-35"
@@ -5583,7 +5583,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                       data-label="Status"
                       tabindex="-1"
                     >
-                      Success
+                      Completed
                     </td>
                     <td
                       class="pf-v5-c-table__td pf-m-width-35"
@@ -5769,7 +5769,7 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                       data-label="Status"
                       tabindex="-1"
                     >
-                      Success
+                      Completed
                     </td>
                     <td
                       class="pf-v5-c-table__td pf-m-width-35"


### PR DESCRIPTION
- makes the change for all task jobs, not just conversion task jobs


Before PR (job status says 'Success'):
![Screenshot from 2024-09-13 17-34-32](https://github.com/user-attachments/assets/3577c941-edbb-4403-8fa3-cca1eab59bf4)


After PR (job status says 'Completed'):
![Screenshot from 2024-09-13 17-32-46](https://github.com/user-attachments/assets/3cea333d-950a-4488-8ef3-719c3df8f345)
