### PR TITLE
fix(RHINENG-12622): Optionally render conversion parameters

### DIFF
--- a/src/SmartComponents/RunTaskModal/ConversionTaskInputParameters.js
+++ b/src/SmartComponents/RunTaskModal/ConversionTaskInputParameters.js
@@ -98,15 +98,19 @@ const ConversionTaskInputParameters = ({
         parameter={skipPackageCheck}
         updateParameter={updateParameter}
       />
-      <ParameterCheckbox
-        parameter={skipTaintedKernelModuleCheck}
-        updateParameter={updateParameter}
-        customDescription={TAINTED_KERNEL_MODULE_CUSTOM_DESCRIPTION}
-      />
-      <ParameterCheckboxGroup
-        parameter={optionalRepositories}
-        updateParameter={updateParameter}
-      />
+      {skipTaintedKernelModuleCheck && (
+        <ParameterCheckbox
+          parameter={skipTaintedKernelModuleCheck}
+          updateParameter={updateParameter}
+          customDescription={TAINTED_KERNEL_MODULE_CUSTOM_DESCRIPTION}
+        />
+      )}
+      {optionalRepositories && (
+        <ParameterCheckboxGroup
+          parameter={optionalRepositories}
+          updateParameter={updateParameter}
+        />
+      )}
     </Form>
   );
 };


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-12622.

This makes CONVERT2RHEL_TAINTED_KERNEL_MODULE_CHECK_SKIP and OPTIONAL_REPOSITORIES parameters render optionally for the conversion-to-rhel*-like tasks. This aims to avoid errors when backend hasn't yet updated the tasks with new parameters.

## How to test

1. Run the PR against stage
2. Go to available tasks, select Pre-conversion analysis for converting to RHEL or Convert to RHEL from CentOS Linux 7 tasks
3. Select eligible system and click Next
4. The modal should stay and no error should happen at this step