### PR TITLE
fix(RHINENG-13682): Update to remove All systems chip

### DIFF
--- a/src/SmartComponents/SystemTable/SelectCustomFilter.js
+++ b/src/SmartComponents/SystemTable/SelectCustomFilter.js
@@ -18,6 +18,7 @@ const SelectCustomFilter = ({
 
   const handleSelectChange = (value) => {
     setFilterData(findFilterData(value, options));
+    setOpen(false);
   };
 
   const toggle = (toggleRef) => (
@@ -29,7 +30,7 @@ const SelectCustomFilter = ({
         width: 'auto',
       }}
     >
-      {options.find((item) => item.value === selectedValue.value)?.label}
+      {options.find((item) => item.value === selectedValue)?.label}
     </MenuToggle>
   );
 
@@ -44,7 +45,7 @@ const SelectCustomFilter = ({
         key={filterId}
         onSelect={(event, optionName) => handleSelectChange(optionName)}
         onOpenChange={(isOpen) => setOpen(isOpen)}
-        selected={selectedValue.label}
+        selected={options.find((item) => item.value === selectedValue)?.label}
         toggle={toggle}
         shouldFocusToggleOnSelect
       >

--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -109,7 +109,7 @@ const SystemTable = ({
         <SelectCustomFilter
           filterId="task-eligibility"
           options={eligibilityFilterItems}
-          selectedValue={eligibility}
+          selectedValue={eligibility.value}
           setFilterData={setEligibilityData}
         />
       ),
@@ -117,13 +117,16 @@ const SystemTable = ({
   };
 
   const activeFiltersConfig = {
-    filters: [
-      {
-        id: 'Task eligibility',
-        category: 'Task eligibility',
-        chips: [{ name: eligibility.label, value: eligibility.value }],
-      },
-    ],
+    filters:
+      eligibility.value === ELIGIBLE_SYSTEMS_VALUE
+        ? [
+            {
+              id: 'Task eligibility',
+              category: 'Task eligibility',
+              chips: [{ name: eligibility.label, value: eligibility.value }],
+            },
+          ]
+        : [],
     onDelete: (event, itemsToRemove, isAll) => {
       if (isAll) {
         setEligibility(eligibilityFilterItems[0]);

--- a/src/SmartComponents/SystemTable/__tests__/SelectCustomFilter.tests.js
+++ b/src/SmartComponents/SystemTable/__tests__/SelectCustomFilter.tests.js
@@ -17,7 +17,7 @@ describe('SelectCustomFilter component', () => {
 
     render(
       <SelectCustomFilter
-        selectedValue={selectedValue}
+        selectedValue={selectedValue.value}
         setFilterData={setFilterData}
         options={options}
         filterId={filterId}

--- a/src/SmartComponents/SystemTable/__tests__/helpers.test.js
+++ b/src/SmartComponents/SystemTable/__tests__/helpers.test.js
@@ -9,7 +9,7 @@ describe('buildFilterSortString', () => {
   const workloadFilters = [];
   const activeFiltersConfig = { filters: {} };
 
-  it('should return an default filterstring when no filters given', () => {
+  it('should return a default filterstring when no filters given', () => {
     expect(
       buildFilterSortString(
         limit,
@@ -20,6 +20,30 @@ describe('buildFilterSortString', () => {
         tags,
         workloadFilters,
         activeFiltersConfig
+      )
+    ).toEqual('?limit=25&offset=0&sort=name&all_systems=true');
+  });
+
+  it('should not return all_systems=true when eligible systems filter applied', () => {
+    let activefilters = {
+      filters: [
+        {
+          id: 'Task eligibility',
+          category: 'Task eligibility',
+          chips: [{ name: 'Eligible Systems', value: 'eligible-systems' }],
+        },
+      ],
+    };
+    expect(
+      buildFilterSortString(
+        limit,
+        offset,
+        orderBy,
+        orderDirection,
+        {},
+        tags,
+        workloadFilters,
+        activefilters
       )
     ).toEqual('?limit=25&offset=0&sort=name');
   });
@@ -44,7 +68,9 @@ describe('buildFilterSortString', () => {
         workloadFilters,
         activeFiltersConfig
       )
-    ).toEqual('?limit=25&offset=0&sort=name&operating_system=RHEL|9.4');
+    ).toEqual(
+      '?limit=25&offset=0&sort=name&operating_system=RHEL|9.4&all_systems=true'
+    );
 
     filters = {
       osFilter: {
@@ -66,7 +92,9 @@ describe('buildFilterSortString', () => {
         workloadFilters,
         activeFiltersConfig
       )
-    ).toEqual('?limit=25&offset=0&sort=name&operating_system=RHEL|9.3');
+    ).toEqual(
+      '?limit=25&offset=0&sort=name&operating_system=RHEL|9.3&all_systems=true'
+    );
 
     filters = {
       osFilter: {
@@ -99,7 +127,7 @@ describe('buildFilterSortString', () => {
         activeFiltersConfig
       )
     ).toEqual(
-      '?limit=25&offset=0&sort=name&operating_system=RHEL|9.4,RHEL|9.3,RHEL|9.9,RHEL|8.4,AlmaLinux|8.4,AlmaLinux|8.5'
+      '?limit=25&offset=0&sort=name&operating_system=RHEL|9.4,RHEL|9.3,RHEL|9.9,RHEL|8.4,AlmaLinux|8.4,AlmaLinux|8.5&all_systems=true'
     );
 
     filters = {
@@ -132,7 +160,7 @@ describe('buildFilterSortString', () => {
         activeFiltersConfig
       )
     ).toEqual(
-      '?limit=25&offset=0&sort=name&operating_system=RHEL|9.5,RHEL|9.4,RHEL|9.3,RHEL|9.2,RHEL|9.1,RHEL|9.0,Cent Os Linux|8.4,Cent Os Linux|8.5'
+      '?limit=25&offset=0&sort=name&operating_system=RHEL|9.5,RHEL|9.4,RHEL|9.3,RHEL|9.2,RHEL|9.1,RHEL|9.0,Cent Os Linux|8.4,Cent Os Linux|8.5&all_systems=true'
     );
 
     filters = {
@@ -176,7 +204,7 @@ describe('buildFilterSortString', () => {
         activeFiltersConfig
       )
     ).toEqual(
-      '?limit=25&offset=0&sort=name&operating_system=RHEL|9.4,RHEL|9.3,RHEL|9.9,RHEL|8.4,Alma Linux|8.4,Alma Linux|8.5,Cent Os|8.4,Cent Os|8.5,Cent Os|30.99,Cent Os|30.88'
+      '?limit=25&offset=0&sort=name&operating_system=RHEL|9.4,RHEL|9.3,RHEL|9.9,RHEL|8.4,Alma Linux|8.4,Alma Linux|8.5,Cent Os|8.4,Cent Os|8.5,Cent Os|30.99,Cent Os|30.88&all_systems=true'
     );
 
     filters = {
@@ -209,7 +237,7 @@ describe('buildFilterSortString', () => {
         activeFiltersConfig
       )
     ).toEqual(
-      '?limit=25&offset=0&sort=name&operating_system=RHEL|9.4,RHEL|9.3,RHEL|9.9,AlmaLinux|8.4,AlmaLinux|8.5'
+      '?limit=25&offset=0&sort=name&operating_system=RHEL|9.4,RHEL|9.3,RHEL|9.9,AlmaLinux|8.4,AlmaLinux|8.5&all_systems=true'
     );
   });
 });

--- a/src/SmartComponents/SystemTable/helpers.js
+++ b/src/SmartComponents/SystemTable/helpers.js
@@ -1,4 +1,4 @@
-import { ALL_SYSTEMS_VALUE } from './constants';
+import { ELIGIBLE_SYSTEMS_VALUE } from './constants';
 
 const buildSortString = (orderBy, orderDirection) => {
   let sortString = orderBy ? '&sort=' : '';
@@ -87,9 +87,10 @@ const buildWorkloadFiltersString = (filters) => {
 };
 
 const buildEligibilityFilterString = ({ filters }) => {
-  return filters[0]?.chips[0]?.value === ALL_SYSTEMS_VALUE
-    ? '&all_systems=true'
-    : '';
+  return filters[0]?.chips &&
+    filters[0]?.chips[0]?.value === ELIGIBLE_SYSTEMS_VALUE
+    ? ''
+    : '&all_systems=true';
 };
 
 // TODO this should be based on a URLSearchParams object and use its toString() function


### PR DESCRIPTION
To test:

- Go to the Available tab
- Click Select systems on a task
- Use the eligibility filter

Test by removing the Eligible systems chip. It should remove the chip and apply All systems filter with no chip. Before, we swapped between the All systems and Eligible systems chips.