### PR TITLE
fix(RHINENG-14254): If a job has a failure message then display it

### DIFF
--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -3354,7 +3354,7 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          Task failed to complete for an unknown reason. Retry this task at a later time.
+                          This was a failure.
                         </div>
                       </div>
                     </td>
@@ -4691,7 +4691,7 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          Task failed to complete for an unknown reason. Retry this task at a later time.
+                          This was a failure.
                         </div>
                       </div>
                     </td>

--- a/src/SmartComponents/completedTaskDetailsHelpers.js
+++ b/src/SmartComponents/completedTaskDetailsHelpers.js
@@ -63,7 +63,7 @@ export const fetchTaskJobs = async (taskDetails, setError) => {
       }).length || '-';
     taskDetails.system_count = taskJobs.data.length;
     taskJobs.data.forEach((job) => {
-      if (job.status === 'Failure') {
+      if (job.status === 'Failure' && !job.results.message) {
         job.results.message = JOB_FAILED_MESSAGE;
       } else if (job.status === 'Timeout') {
         job.results.message = JOB_TIMED_OUT_MESSAGE;


### PR DESCRIPTION
If the job has a failure message, then display that, rather than the generic message that provides no information as to why the job failed.