### PR TITLE
Truncate long job message text with Show more / Show less links

### DIFF
--- a/src/PresentationalComponents/SplitMessages/SplitMessages.js
+++ b/src/PresentationalComponents/SplitMessages/SplitMessages.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Icon, Split, SplitItem } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import Truncate from '@redhat-cloud-services/frontend-components/Truncate';
 import propTypes from 'prop-types';
 
 const SplitMessages = ({ alert, content }) => {
@@ -18,7 +19,9 @@ const SplitMessages = ({ alert, content }) => {
           </SplitItem>
         </React.Fragment>
       ) : null}
-      <SplitItem color="#A30000">{content}</SplitItem>
+      <SplitItem color="#A30000">
+        <Truncate text={content} length={150} inline />
+      </SplitItem>
     </Split>
   );
 };

--- a/src/SmartComponents/CompletedTaskDetails/Columns.js
+++ b/src/SmartComponents/CompletedTaskDetails/Columns.js
@@ -2,6 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { renderColumnComponent } from '../../Utilities/helpers';
 import SplitMessages from '../../PresentationalComponents/SplitMessages/SplitMessages';
+import { Skeleton } from '@patternfly/react-core';
 
 const SystemNameCell = ({ display_name }) => {
   if (display_name) {
@@ -44,16 +45,19 @@ export const MessageColumn = {
   },
   sortByFunction: (job) => job.results.message,
   renderExport: (job) => job.results.message,
-  renderFunc: (_, _empty, job) => (
-    <SplitMessages
-      content={job.results.message}
-      alert={
-        job.results.alert === 'true' ||
-        job.status === 'Failure' ||
-        job.status === 'Timeout'
-      }
-    />
-  ),
+  renderFunc: (_, _empty, job) =>
+    job.results.message?.length ? (
+      <SplitMessages
+        content={job.results.message}
+        alert={
+          job.results.alert === 'true' ||
+          job.status === 'Failure' ||
+          job.status === 'Timeout'
+        }
+      />
+    ) : (
+      <Skeleton width="100%" />
+    ),
 };
 
 export const ReportColumn = {

--- a/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
+++ b/src/SmartComponents/CompletedTaskDetails/__tests__/__snapshots__/CompletedTaskDetails.tests.js.snap
@@ -778,7 +778,12 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          No inhibtors found, conversion should run smoothly for this system.
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            No inhibtors found, conversion should run smoothly for this system.
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -889,7 +894,12 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          No inhibtors found, conversion should run smoothly for this system.
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            No inhibtors found, conversion should run smoothly for this system.
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -1475,7 +1485,12 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          No inhibtors found, conversion should run smoothly for this system.
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            No inhibtors found, conversion should run smoothly for this system.
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -1586,7 +1601,12 @@ exports[`CompletedTaskDetails should render convert2rhel correctly completed 1`]
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          Your system has 3 inhibitors out of 3 potential problems.
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            Your system has 3 inhibitors out of 3 potential problems.
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -3248,7 +3268,12 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          This was a success.
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            This was a success.
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -3354,7 +3379,12 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          This was a failure.
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            This was a failure.
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -3460,7 +3490,12 @@ exports[`CompletedTaskDetails should render correctly completed 1`] = `
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          Task failed to complete due to timing out. Retry this task at a later time.
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            Task failed to complete due to timing out. Retry this task at a later time.
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -4575,7 +4610,12 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          Task failed to complete due to timing out. Retry this task at a later time.
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            Task failed to complete due to timing out. Retry this task at a later time.
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -4691,7 +4731,12 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          This was a failure.
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            This was a failure.
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -4765,11 +4810,11 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                       tabindex="-1"
                     >
                       <div
-                        class="pf-v5-l-split"
+                        class="pf-v5-c-skeleton"
+                        style="--pf-v5-c-skeleton--Width: 100%;"
                       >
-                        <div
-                          class="pf-v5-l-split__item"
-                          color="#A30000"
+                        <span
+                          class="pf-v5-screen-reader"
                         />
                       </div>
                     </td>
@@ -4880,7 +4925,12 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          Your system has 1 inhibitor out of 4 potential problems
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            Your system has 1 inhibitor out of 4 potential problems
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -5658,7 +5708,12 @@ exports[`CompletedTaskDetails should render expandable rows correctly 1`] = `
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          Your system has 1 inhibitor out of 4 potential problems
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            Your system has 1 inhibitor out of 4 potential problems
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -5847,7 +5902,12 @@ Key: 8fb81863f8413bd617c2a55b69b8e10ff03d7c72
                           class="pf-v5-l-split__item"
                           color="#A30000"
                         >
-                          Your system has 3 inhibitors out of 5 potential problems.
+                          <span
+                            class="ins-c-truncate is-inline"
+                            widget-type="InsightsTruncateInline"
+                          >
+                            Your system has 3 inhibitors out of 5 potential problems.
+                          </span>
                         </div>
                       </div>
                     </td>

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,7 +44,7 @@ export const TASKS_ERROR = [
   '',
 ];
 export const COMPLETED_TASKS_ERROR = [
-  'Activities connot be displayed at this time. Please return and if the problem persists contact your system administrator.',
+  'Activities cannot be displayed at this time. Please return and if the problem persists contact your system administrator.',
   '',
 ];
 export const TASK_ERROR = [
@@ -57,7 +57,7 @@ export const EMPTY_TASKS_MESSAGE = [
 ];
 export const EMPTY_COMPLETED_TASKS_TITLE = 'No completed tasks';
 export const EMPTY_COMPLETED_TASKS_MESSAGE = [
-  'Tasks allows you to run resource -intesive additional troubleshooting on your connected systems. Ansible Playbooks are written by Red Hat to do the selected tasks.',
+  'Tasks allows you to run resource-intensive additional troubleshooting on your connected systems. Ansible Playbooks are written by Red Hat to do the selected tasks.',
   '',
   'To use a task, navigate to the "Available tasks" tab and choose a task to run.',
 ];


### PR DESCRIPTION
I was going to use the Patternfly Truncate component, but I didn't like the expanded text being displayed in a popover.  I couldn't find another Patternfly component that did text truncation with 'Show more / Show less' links, so I used my own.  If there is a Patternfly component that does something similar, then please let me know and I will consider using it instead of the one in this PR.

Screenshot showing 'Show more':
![Screenshot from 2025-03-27 12-46-24](https://github.com/user-attachments/assets/3d8db96d-ae67-496b-ae1d-e6203d7848b0)

Screenshot showing 'Show less':
![Screenshot from 2025-03-27 12-46-32](https://github.com/user-attachments/assets/46349cbd-d0fb-4675-bd1f-c341aed27d6a)

