### PR TITLE
feat(RHINENG-17466): Add RHEL AI column to task systems table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "react-router-dom": "^6.26.1",
         "redux": "^4.2.0",
         "redux-logger": "^3.0.6",
-        "redux-promise-middleware": "^6.2.0"
+        "redux-promise-middleware": "^6.2.0",
+        "semver": "^7.7.1"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -131,6 +132,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/eslint-parser": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.27.0.tgz",
@@ -147,6 +157,16 @@
       "peerDependencies": {
         "@babel/core": "^7.11.0",
         "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
@@ -191,6 +211,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
@@ -212,6 +241,16 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.0.tgz",
@@ -227,6 +266,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -1495,6 +1544,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
@@ -1715,6 +1774,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/preset-modules": {
@@ -2424,18 +2493,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@jest/reporters/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -2720,29 +2777,6 @@
       },
       "peerDependencies": {
         "webpack": "^5.75.0"
-      }
-    },
-    "node_modules/@openshift/dynamic-plugin-sdk-webpack/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@openshift/dynamic-plugin-sdk/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -5495,6 +5529,16 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
@@ -6644,18 +6688,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/css-loader/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/css-select": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -7765,6 +7797,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/eslint-plugin-rulesdir": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.2.2.tgz",
@@ -8561,18 +8603,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/form-data": {
@@ -10303,6 +10333,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -11140,18 +11180,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -11886,18 +11914,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -12100,18 +12116,6 @@
         "is-core-module": "^2.5.0",
         "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/meow/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -15257,11 +15261,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -16680,18 +16688,6 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/ts-loader/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ts-patch": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.3.0.tgz",
@@ -16740,18 +16736,6 @@
       "dev": true,
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/ts-patch/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ts-patch/node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "react-router-dom": "^6.26.1",
     "redux": "^4.2.0",
     "redux-logger": "^3.0.6",
-    "redux-promise-middleware": "^6.2.0"
+    "redux-promise-middleware": "^6.2.0",
+    "semver": "^7.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -78,7 +78,7 @@ const SystemTable = ({
   });
 
   const mergedColumns = (defaultColumns) =>
-    systemColumns().map((column) => {
+    systemColumns(slug).map((column) => {
       const isStringCol = typeof column === 'string';
       const key = isStringCol ? column : column.key;
       const defaultColumn = defaultColumns.find(
@@ -191,7 +191,7 @@ const SystemTable = ({
       columns={mergedColumns}
       ref={inventory}
       fallback={<Spinner />}
-      onLoad={defaultOnLoad(systemColumns(), getRegistry)}
+      onLoad={defaultOnLoad(systemColumns(slug), getRegistry)}
       customFilters={{
         tags: tagsFilter,
         workloadFilters: generateFilter(

--- a/src/SmartComponents/SystemTable/__tests__/constants.test.js
+++ b/src/SmartComponents/SystemTable/__tests__/constants.test.js
@@ -1,0 +1,23 @@
+import { systemColumns } from '../constants';
+
+describe('systemColumns', () => {
+  it('should not contain system_profile column when slug is not "rhel-ai-update"', () => {
+    const result = systemColumns('some-other-slug');
+    expect(result).not.toContainEqual({
+      key: 'system_profile',
+      props: { width: 10, isStatic: true },
+      title: 'RHEL AI Version',
+      renderFunc: expect.any(Function),
+    });
+  });
+
+  it('should return additional "RHEL AI Version" column when slug is "rhel-ai-update"', () => {
+    const result = systemColumns('rhel-ai-update');
+    expect(result).toContainEqual({
+      key: 'system_profile',
+      props: { width: 10, isStatic: true },
+      title: 'RHEL AI Version',
+      renderFunc: expect.any(Function),
+    });
+  });
+});

--- a/src/SmartComponents/SystemTable/constants.js
+++ b/src/SmartComponents/SystemTable/constants.js
@@ -3,44 +3,64 @@ import {
   createSystemLink,
   populateConnectedColumn,
   populateEligibilityColumn,
+  populateRHELAIColumn,
 } from '../../helpers';
 
-export const systemColumns = () => [
-  {
-    key: 'display_name',
-    sortKey: 'display_name',
-    props: { width: 20 },
-    title: 'Name',
-    renderFunc: (name, id) => {
-      return createSystemLink(id, name, `system-name-${id}`);
+export const systemColumns = (slug) => {
+  let columns = [
+    {
+      key: 'display_name',
+      sortKey: 'display_name',
+      props: { width: 20 },
+      title: 'Name',
+      renderFunc: (name, id) => {
+        return createSystemLink(id, name, `system-name-${id}`);
+      },
     },
-  },
-  {
-    key: 'eligibility',
-    props: { width: 10, isStatic: true }, // column isn't sortable
-    title: 'Eligibility',
-    renderFunc: (eligibility) => {
-      return populateEligibilityColumn(eligibility);
+  ];
+  if (slug === 'rhel-ai-update') {
+    columns = [
+      ...columns,
+      {
+        key: 'system_profile',
+        props: { width: 10, isStatic: true },
+        title: 'RHEL AI Version',
+        renderFunc: (system_profile) => {
+          return populateRHELAIColumn(system_profile);
+        },
+      },
+    ];
+  }
+  columns = [
+    ...columns,
+    {
+      key: 'eligibility',
+      props: { width: 10, isStatic: true }, // column isn't sortable
+      title: 'Eligibility',
+      renderFunc: (eligibility) => {
+        return populateEligibilityColumn(eligibility);
+      },
     },
-  },
-  {
-    key: 'connected',
-    props: { width: 10, isStatic: true }, // column isn't sortable
-    title: 'Connection Status',
-    renderFunc: (connected) => {
-      return populateConnectedColumn(connected);
+    {
+      key: 'connected',
+      props: { width: 15, isStatic: true }, // column isn't sortable
+      title: 'Connection Status',
+      renderFunc: (connected) => {
+        return populateConnectedColumn(connected);
+      },
     },
-  },
-  'groups',
-  'tags',
-  {
-    key: 'os_version',
-    sortKey: 'os_version',
-    props: { width: 10 },
-    title: 'OS',
-  },
-  'updated',
-];
+    'groups',
+    'tags',
+    {
+      key: 'os_version',
+      sortKey: 'os_version',
+      props: { width: 10 },
+      title: 'OS',
+    },
+    'updated',
+  ];
+  return columns;
+};
 
 export const defaultOnLoad = (columns, getRegistry) => {
   return ({ INVENTORY_ACTION_TYPES, mergeWithEntities }) =>

--- a/src/__tests__/helpers.test.js
+++ b/src/__tests__/helpers.test.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { populateRHELAIColumn } from '../helpers';
+import { Icon, Tooltip } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+
+describe('populateRHELAIColumn', () => {
+  it('should return "N/A" when not a bootc image or not a RHEL AI image"', () => {
+    expect(populateRHELAIColumn({})).toEqual('N/A');
+    expect(
+      populateRHELAIColumn({
+        bootc_status: { booted: { image: 'registry/image:latest' } },
+      })
+    ).toEqual('N/A');
+  });
+
+  it('should return "Unknown" when RHEL AI image version is not a known version', () => {
+    expect(
+      populateRHELAIColumn({
+        bootc_status: { booted: { image: 'registry/rhelai1/image:version' } },
+      })
+    ).toEqual('Unknown');
+  });
+
+  it('should not display exclamation icon when RHEL AI version is the latest version', () => {
+    const result = populateRHELAIColumn({
+      bootc_status: { booted: { image: 'registry/rhelai1/image:1.5' } },
+    });
+    expect(result).toEqual(<span>1.5</span>);
+  });
+
+  it('should display tooltip/icon when RHEL AI version is not the latest', () => {
+    const result = populateRHELAIColumn({
+      bootc_status: {
+        booted: { image: 'registry/rhelai1/image:1.1-1724974282' },
+      },
+    });
+    expect(result).toEqual(
+      <Tooltip
+        position="top-start"
+        content={
+          <div>A later version of this system&#39;s image is available</div>
+        }
+      >
+        <div>
+          <Icon size="sm" status="warning">
+            <ExclamationTriangleIcon />
+          </Icon>
+          <span style={{ marginLeft: '0.5rem' }}>1.1-1724974282</span>
+        </div>
+      </Tooltip>
+    );
+  });
+});

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Flex, Icon, Popover, Title } from '@patternfly/react-core';
+import semver from 'semver';
+import { Flex, Icon, Popover, Title, Tooltip } from '@patternfly/react-core';
 import {
   BanIcon,
   ConnectedIcon,
   DisconnectedIcon,
+  ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
 
 const boldText = 'pf-v5-u-font-weight-bold';
@@ -119,5 +121,35 @@ export const populateConnectedColumn = (connected) => {
         </span>
       </div>
     </Popover>
+  );
+};
+
+const MAX_RHELAI_VERSION = '1.5.0'; // TODO: How to get this dynamically?
+export const populateRHELAIColumn = (system_profile) => {
+  const bootcImage = system_profile?.bootc_status?.booted?.image;
+  if (!bootcImage || !bootcImage.includes('/rhelai')) {
+    return 'N/A';
+  }
+  const rhelaiVersionMatch = bootcImage.match(/:([0-9.-]+)$/);
+  if (!rhelaiVersionMatch) {
+    return 'Unknown';
+  }
+  const rhelaiVersion = rhelaiVersionMatch[1];
+  return semver.lt(semver.coerce(rhelaiVersion), MAX_RHELAI_VERSION) ? (
+    <Tooltip
+      position="top-start"
+      content={
+        <div>A later version of this system&#39;s image is available</div>
+      }
+    >
+      <div>
+        <Icon size="sm" status="warning">
+          <ExclamationTriangleIcon />
+        </Icon>
+        <span style={{ marginLeft: '0.5rem' }}>{rhelaiVersion}</span>
+      </div>
+    </Tooltip>
+  ) : (
+    <span>{rhelaiVersion}</span>
   );
 };


### PR DESCRIPTION
Adds a RHEL AI column to the task systems table, but only when the rhel-ai-update task is chosen.  When testing locally, proxy requests to prod, because stage doesn't have any RHEL AI systems registered.

![Screenshot from 2025-05-01 12-02-32](https://github.com/user-attachments/assets/c630bf75-7daf-41eb-972c-db3366dd3f33)
