### PR TITLE
fix(RHINENG-17743): Remove link from ActivityTable when table is loading

### DIFF
--- a/src/SmartComponents/ActivityTable/Columns.js
+++ b/src/SmartComponents/ActivityTable/Columns.js
@@ -20,12 +20,17 @@ import {
   InProgressIcon,
 } from '@patternfly/react-icons';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
+import { Skeleton } from '@redhat-cloud-services/frontend-components/Skeleton';
 
-const TaskNameCell = ({ id, name }, index) => (
-  <InsightsLink key={`task-name-${index}`} to={`/executed/${id}`}>
-    {name}
-  </InsightsLink>
-);
+const TaskNameCell = ({ id, name }, index) => {
+  return id ? (
+    <InsightsLink key={`task-name-${index}`} to={`/executed/${id}`}>
+      {name}
+    </InsightsLink>
+  ) : (
+    <Skeleton width="100%" />
+  );
+};
 
 TaskNameCell.propTypes = {
   id: propTypes.number,

--- a/src/SmartComponents/ActivityTable/__tests__/__snapshots__/ActivityTable.tests.js.snap
+++ b/src/SmartComponents/ActivityTable/__tests__/__snapshots__/ActivityTable.tests.js.snap
@@ -395,17 +395,14 @@ exports[`ActivityTable should render correctly 1`] = `
             data-label="Task"
             tabindex="-1"
           >
-            <a
-              href="/insights/tasks/executed/undefined"
+            <div
+              class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__md"
+              style="--pf-v5-c-skeleton--Width: 100%;"
             >
-              <div
-                class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__md"
-              >
-                <span
-                  class="pf-v5-screen-reader"
-                />
-              </div>
-            </a>
+              <span
+                class="pf-v5-screen-reader"
+              />
+            </div>
           </td>
           <td
             class="pf-v5-c-table__td pf-m-width-10"
@@ -494,17 +491,14 @@ exports[`ActivityTable should render correctly 1`] = `
             data-label="Task"
             tabindex="-1"
           >
-            <a
-              href="/insights/tasks/executed/undefined"
+            <div
+              class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__md"
+              style="--pf-v5-c-skeleton--Width: 100%;"
             >
-              <div
-                class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__md"
-              >
-                <span
-                  class="pf-v5-screen-reader"
-                />
-              </div>
-            </a>
+              <span
+                class="pf-v5-screen-reader"
+              />
+            </div>
           </td>
           <td
             class="pf-v5-c-table__td pf-m-width-10"
@@ -593,17 +587,14 @@ exports[`ActivityTable should render correctly 1`] = `
             data-label="Task"
             tabindex="-1"
           >
-            <a
-              href="/insights/tasks/executed/undefined"
+            <div
+              class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__md"
+              style="--pf-v5-c-skeleton--Width: 100%;"
             >
-              <div
-                class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__md"
-              >
-                <span
-                  class="pf-v5-screen-reader"
-                />
-              </div>
-            </a>
+              <span
+                class="pf-v5-screen-reader"
+              />
+            </div>
           </td>
           <td
             class="pf-v5-c-table__td pf-m-width-10"
@@ -692,17 +683,14 @@ exports[`ActivityTable should render correctly 1`] = `
             data-label="Task"
             tabindex="-1"
           >
-            <a
-              href="/insights/tasks/executed/undefined"
+            <div
+              class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__md"
+              style="--pf-v5-c-skeleton--Width: 100%;"
             >
-              <div
-                class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__md"
-              >
-                <span
-                  class="pf-v5-screen-reader"
-                />
-              </div>
-            </a>
+              <span
+                class="pf-v5-screen-reader"
+              />
+            </div>
           </td>
           <td
             class="pf-v5-c-table__td pf-m-width-10"
@@ -791,17 +779,14 @@ exports[`ActivityTable should render correctly 1`] = `
             data-label="Task"
             tabindex="-1"
           >
-            <a
-              href="/insights/tasks/executed/undefined"
+            <div
+              class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__md"
+              style="--pf-v5-c-skeleton--Width: 100%;"
             >
-              <div
-                class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__md"
-              >
-                <span
-                  class="pf-v5-screen-reader"
-                />
-              </div>
-            </a>
+              <span
+                class="pf-v5-screen-reader"
+              />
+            </div>
           </td>
           <td
             class="pf-v5-c-table__td pf-m-width-10"


### PR DESCRIPTION
Tasks activities table first column contains links which are clickable when loading yielding 404 error.  This PR removes the link whilst the table is loading:

Before fix if you click on any of the Task entries whilst the table is loading you'll get a 404 error:
![Screenshot from 2025-05-06 22-04-30](https://github.com/user-attachments/assets/3d9bcabc-9008-4451-88f7-76fee5ece0b5)
![Screenshot from 2025-05-06 22-04-41](https://github.com/user-attachments/assets/33308124-7a85-40ff-958a-46953a85044e)


After fix you can't click on any of the Tasks entries whilst the table is loading:
![Screenshot from 2025-05-06 22-08-00](https://github.com/user-attachments/assets/e0f013a1-02ee-4e0a-8117-f55bf35161c0)

