### PR TITLE
fix: Consistent use of Sentence case in System Table

### DIFF
--- a/src/SmartComponents/SystemTable/SystemTable.js
+++ b/src/SmartComponents/SystemTable/SystemTable.js
@@ -100,7 +100,7 @@ const SystemTable = ({
   };
 
   const eligibilityFilter = {
-    label: 'Task Eligibility',
+    label: 'Task eligibility',
     type: 'singleSelect',
     filterValues: {
       value: eligibility.value,

--- a/src/SmartComponents/SystemTable/__tests__/constants.test.js
+++ b/src/SmartComponents/SystemTable/__tests__/constants.test.js
@@ -6,17 +6,17 @@ describe('systemColumns', () => {
     expect(result).not.toContainEqual({
       key: 'system_profile',
       props: { width: 10, isStatic: true },
-      title: 'RHEL AI Version',
+      title: 'RHEL AI version',
       renderFunc: expect.any(Function),
     });
   });
 
-  it('should return additional "RHEL AI Version" column when slug is "rhel-ai-update"', () => {
+  it('should return additional "RHEL AI version" column when slug is "rhel-ai-update"', () => {
     const result = systemColumns('rhel-ai-update');
     expect(result).toContainEqual({
       key: 'system_profile',
       props: { width: 10, isStatic: true },
-      title: 'RHEL AI Version',
+      title: 'RHEL AI version',
       renderFunc: expect.any(Function),
     });
   });

--- a/src/SmartComponents/SystemTable/__tests__/helpers.test.js
+++ b/src/SmartComponents/SystemTable/__tests__/helpers.test.js
@@ -30,7 +30,7 @@ describe('buildFilterSortString', () => {
         {
           id: 'Task eligibility',
           category: 'Task eligibility',
-          chips: [{ name: 'Eligible Systems', value: 'eligible-systems' }],
+          chips: [{ name: 'Eligible systems', value: 'eligible-systems' }],
         },
       ],
     };

--- a/src/SmartComponents/SystemTable/constants.js
+++ b/src/SmartComponents/SystemTable/constants.js
@@ -24,7 +24,7 @@ export const systemColumns = (slug) => {
       {
         key: 'system_profile',
         props: { width: 10, isStatic: true },
-        title: 'RHEL AI Version',
+        title: 'RHEL AI version',
         renderFunc: (system_profile) => {
           return populateRHELAIColumn(system_profile);
         },
@@ -44,7 +44,7 @@ export const systemColumns = (slug) => {
     {
       key: 'connected',
       props: { width: 15, isStatic: true }, // column isn't sortable
-      title: 'Connection Status',
+      title: 'Connection status',
       renderFunc: (connected) => {
         return populateConnectedColumn(connected);
       },
@@ -76,9 +76,9 @@ export const defaultOnLoad = (columns, getRegistry) => {
     });
 };
 
-const ELIGIBLE_SYSTEMS = 'Eligible Systems';
+const ELIGIBLE_SYSTEMS = 'Eligible systems';
 export const ELIGIBLE_SYSTEMS_VALUE = 'eligible-systems';
-const ALL_SYSTEMS = 'All Systems';
+const ALL_SYSTEMS = 'All systems';
 export const ALL_SYSTEMS_VALUE = 'all-systems';
 export const eligibilityFilterItems = [
   { label: ELIGIBLE_SYSTEMS, value: ELIGIBLE_SYSTEMS_VALUE },

--- a/src/SmartComponents/SystemTable/hooks.js
+++ b/src/SmartComponents/SystemTable/hooks.js
@@ -50,7 +50,7 @@ export const useGetEntities = (
       disableSelection: entity.requirements.length || !entity.connected,
       // for populating the eligibility column and the tooltip for ineligible systems
       eligibility: {
-        title: entity.requirements.length ? 'Not Eligible' : 'Eligible',
+        title: entity.requirements.length ? 'Not eligible' : 'Eligible',
         tooltip: entity.requirements.join('. '), // '' if no requirements
       },
       updated: entity.last_check_in,


### PR DESCRIPTION
Making sure System Table uses Sentence case more consistently, as per screenshot.

![Screenshot from 2025-05-26 10-41-25](https://github.com/user-attachments/assets/223f2c99-ff8c-4285-bc17-9d4857a6d09b)

## Summary by Sourcery

Standardize sentence case for UI text in the System Table component and update related tests

Enhancements:
- Convert System Table column titles, filter labels, and eligibility statuses from title case to sentence case for consistency

Tests:
- Update tests to expect the new sentence case labels in system table constants and helpers