### PR TITLE
fix(RHINENG-19596): Remove brand name from connected column

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,7 +7,6 @@ import {
   DisconnectedIcon,
   ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
-import useFeatureFlag from './Utilities/useFeatureFlag';
 
 const boldText = 'pf-v5-u-font-weight-bold';
 
@@ -70,10 +69,6 @@ export const populateEligibilityColumn = (eligibility) => {
 };
 
 export const populateConnectedColumn = (connected) => {
-  const productName = useFeatureFlag('platform.lightspeed-rebrand')
-    ? 'Lightspeed'
-    : 'Insights';
-
   return connected ? (
     <div>
       <Icon size="sm">
@@ -101,9 +96,9 @@ export const populateConnectedColumn = (connected) => {
           spaceItems={{ default: 'spaceItemsNone' }}
         >
           <p>
-            Run <span className={boldText}>rhc status</span> to check if this
-            system has an RHC connection to Red Hat {productName}. After
-            verifying the connection is active, click the{' '}
+            Run <span className={boldText}>rhc status</span> to check the status
+            of the system&#39;s connection to Red Hat. After verifying the
+            connection is active, click the{' '}
             <span className={boldText}>Select systems</span> button again.
           </p>
           <a


### PR DESCRIPTION
No need to put Lightspeed/Insights in the connection tooltip.  Just 'Red Hat' is enough because rhc status checks more than just the connection to Red Hat Lightspeed/Insights.  Plus the useFeatureFlag command was failing anyway :open_mouth: 