### PR TITLE
fix(RHINENG-23840): Gracefully handle bad requests in SystemTable

### DIFF
--- a/src/PresentationalComponents/NoResultsTable/NoResultsTable.js
+++ b/src/PresentationalComponents/NoResultsTable/NoResultsTable.js
@@ -6,30 +6,44 @@ import {
   EmptyStateBody,
   EmptyStateVariant,
 } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 import EmptyTable from '@redhat-cloud-services/frontend-components/EmptyTable';
+import { NO_RESULTS_MAP, NO_RESULTS_REASONS } from '../../constants';
 
-const NoResultsTable = ({ type }) => (
-  <EmptyTable>
+const NoResultsTable = ({
+  type,
+  titleText,
+  reason = NO_RESULTS_REASONS.NO_MATCH,
+}) => (
+  <EmptyTable style={{ margin: 0 }}>
     <Bullseye>
       <EmptyState
+        variant={EmptyStateVariant.sm}
+        icon={NO_RESULTS_MAP[reason]?.icon || SearchIcon}
+        titleText={
+          titleText ||
+          NO_RESULTS_MAP[reason]?.titleText ||
+          `No matching ${type} found`
+        }
         headingLevel="h5"
-        titleText={`No matching ${type} found`}
-        variant={EmptyStateVariant.full}
       >
         <EmptyStateBody>
-          To continue, edit your filter settings and search again.
+          {NO_RESULTS_MAP[reason]?.bodyText ||
+            'To continue, edit your filter settings and search again.'}
         </EmptyStateBody>
       </EmptyState>
     </Bullseye>
   </EmptyTable>
 );
 
-export const emptyRows = (type) => {
+export const emptyRows = (type, titleText, reason) => {
   return [
     {
       cells: [
         {
-          title: () => <NoResultsTable type={type} />, // eslint-disable-line
+          title: () => (
+            <NoResultsTable type={type} titleText={titleText} reason={reason} />
+          ), // eslint-disable-line
           props: {
             colSpan: 100,
           },
@@ -41,6 +55,8 @@ export const emptyRows = (type) => {
 
 NoResultsTable.propTypes = {
   type: propTypes.string,
+  titleText: propTypes.string,
+  reason: propTypes.oneOf(Object.values(NO_RESULTS_REASONS)),
 };
 
 export default NoResultsTable;

--- a/src/PresentationalComponents/NoResultsTable/__tests__/NoResultsTable.tests.js
+++ b/src/PresentationalComponents/NoResultsTable/__tests__/NoResultsTable.tests.js
@@ -1,7 +1,8 @@
-//import React from 'react';
-import { render } from '@testing-library/react';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
 
-import emptyRows from '../NoResultsTable';
+import NoResultsTable, { emptyRows } from '../NoResultsTable';
+import { NO_RESULTS_REASONS } from '../../../constants';
 
 jest.mock('../../../../api');
 
@@ -9,8 +10,104 @@ describe('NoResultsTable', () => {
   let type = 'items';
 
   it('should render correctly', async () => {
-    const { asFragment } = render(emptyRows(type));
+    const rows = emptyRows(type);
+    const { asFragment } = render(rows[0].cells[0].title());
 
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  describe('with different reason props', () => {
+    it('should display no_match reason content by default', () => {
+      render(<NoResultsTable type="systems" />);
+
+      expect(screen.getByText('No matching systems found')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'To continue, edit your filter settings and search again.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('should display no_match reason content explicitly', () => {
+      render(
+        <NoResultsTable type="systems" reason={NO_RESULTS_REASONS.NO_MATCH} />
+      );
+
+      expect(screen.getByText('No matching systems found')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'To continue, edit your filter settings and search again.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('should display error reason content', () => {
+      render(
+        <NoResultsTable type="systems" reason={NO_RESULTS_REASONS.ERROR} />
+      );
+
+      expect(
+        screen.getByText('Error encountered when fetching systems.')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'To continue, try resetting the filters and search again.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('should use custom titleText when provided', () => {
+      render(
+        <NoResultsTable type="systems" titleText="Custom error message" />
+      );
+
+      expect(screen.getByText('Custom error message')).toBeInTheDocument();
+    });
+
+    it('should use custom titleText with error reason', () => {
+      render(
+        <NoResultsTable
+          type="systems"
+          titleText="Custom error message"
+          reason={NO_RESULTS_REASONS.ERROR}
+        />
+      );
+
+      expect(screen.getByText('Custom error message')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'To continue, try resetting the filters and search again.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('should fallback to default content for unknown reason', () => {
+      render(<NoResultsTable type="systems" reason="unknown_reason" />);
+
+      expect(screen.getByText('No matching systems found')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'To continue, edit your filter settings and search again.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('emptyRows helper', () => {
+    it('should pass reason prop to NoResultsTable component', () => {
+      const rows = emptyRows('systems', null, NO_RESULTS_REASONS.ERROR);
+      const { container } = render(rows[0].cells[0].title());
+
+      expect(
+        container.querySelector('.pf-v6-c-empty-state')
+      ).toBeInTheDocument();
+    });
+
+    it('should pass titleText prop to NoResultsTable component', () => {
+      const rows = emptyRows('systems', 'Custom title');
+      render(rows[0].cells[0].title());
+
+      expect(screen.getByText('Custom title')).toBeInTheDocument();
+    });
   });
 });

--- a/src/PresentationalComponents/NoResultsTable/__tests__/__snapshots__/NoResultsTable.tests.js.snap
+++ b/src/PresentationalComponents/NoResultsTable/__tests__/__snapshots__/NoResultsTable.tests.js.snap
@@ -4,13 +4,14 @@ exports[`NoResultsTable should render correctly 1`] = `
 <DocumentFragment>
   <div
     class="ins-c-table__empty"
+    style="margin: 0px;"
   >
      
     <div
       class="pf-v6-l-bullseye"
     >
       <div
-        class="pf-v6-c-empty-state"
+        class="pf-v6-c-empty-state pf-m-sm"
       >
         <div
           class="pf-v6-c-empty-state__content"
@@ -19,12 +20,29 @@ exports[`NoResultsTable should render correctly 1`] = `
             class="pf-v6-c-empty-state__header"
           >
             <div
+              class="pf-v6-c-empty-state__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                />
+              </svg>
+            </div>
+            <div
               class="pf-v6-c-empty-state__title"
             >
               <h5
                 class="pf-v6-c-empty-state__title-text"
               >
-                No matching undefined found
+                No matching systems found
               </h5>
             </div>
           </div>

--- a/src/SmartComponents/SystemTable/__tests__/SystemTable.tests.js
+++ b/src/SmartComponents/SystemTable/__tests__/SystemTable.tests.js
@@ -102,4 +102,25 @@ describe('SystemTable', () => {
       expect.anything() // ref
     );
   });
+
+  it('should pass onError and setFetchError callbacks to useGetEntities', () => {
+    const mockUseGetEntities = require('../hooks').useGetEntities;
+
+    render(
+      <Provider store={mockStore()}>
+        <SystemTable selectedIds={[]} slug="test-task" />
+      </Provider>
+    );
+
+    // Verify that useGetEntities was called with callbacks
+    expect(mockUseGetEntities).toHaveBeenCalled();
+    const callArgs =
+      mockUseGetEntities.mock.calls[mockUseGetEntities.mock.calls.length - 1];
+    const callbacks = callArgs[1];
+
+    expect(callbacks).toHaveProperty('onError');
+    expect(callbacks).toHaveProperty('setFetchError');
+    expect(typeof callbacks.onError).toBe('function');
+    expect(typeof callbacks.setFetchError).toBe('function');
+  });
 });

--- a/src/SmartComponents/SystemTable/__tests__/hooks.test.js
+++ b/src/SmartComponents/SystemTable/__tests__/hooks.test.js
@@ -1,0 +1,327 @@
+import { useGetEntities } from '../hooks';
+import { fetchSystems } from '../../../../api';
+
+jest.mock('../../../../api');
+
+describe('useGetEntities', () => {
+  let onComplete;
+  let setFilterSortString;
+  let onError;
+  let setFetchError;
+  let addNotification;
+  let selectedIds;
+  let slug;
+
+  beforeEach(() => {
+    onComplete = jest.fn();
+    setFilterSortString = jest.fn();
+    onError = jest.fn();
+    setFetchError = jest.fn();
+    addNotification = jest.fn();
+    selectedIds = [];
+    slug = 'test-task';
+    jest.clearAllMocks();
+  });
+
+  const config = {
+    page: 1,
+    per_page: 20,
+    orderBy: 'display_name',
+    orderDirection: 'asc',
+    filters: {},
+    tags: [],
+    workloadFilters: {},
+    activeFiltersConfig: {
+      filters: [],
+    },
+  };
+
+  describe('successful fetch', () => {
+    it('should reset error state on successful fetch', async () => {
+      const mockData = [
+        {
+          id: '1',
+          display_name: 'system1',
+          requirements: [],
+          connected: true,
+          last_check_in: '2024-01-01',
+        },
+      ];
+
+      fetchSystems.mockResolvedValue({
+        data: mockData,
+        meta: { count: 1 },
+      });
+
+      const getEntities = useGetEntities(onComplete, {
+        selectedIds,
+        setFilterSortString,
+        slug,
+        onError,
+        setFetchError,
+        addNotification,
+      });
+
+      await getEntities([], config);
+
+      expect(onError).toHaveBeenCalledWith(null);
+      expect(setFetchError).toHaveBeenCalledWith(false);
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  describe('400 error handling', () => {
+    it('should set fetchError to true on 400 error', async () => {
+      const error400 = {
+        response: {
+          status: 400,
+          data: { message: 'Bad request' },
+        },
+        message: 'Bad request from API',
+        data: [],
+        meta: { count: 0 },
+      };
+
+      fetchSystems.mockResolvedValue(error400);
+
+      const getEntities = useGetEntities(onComplete, {
+        selectedIds,
+        setFilterSortString,
+        slug,
+        onError,
+        setFetchError,
+        addNotification,
+      });
+
+      await getEntities([], config);
+
+      expect(addNotification).toHaveBeenCalledWith({
+        variant: 'danger',
+        title: 'There was an error fetching systems',
+        description: 'Bad request from API',
+        dismissable: true,
+      });
+      expect(onError).toHaveBeenCalledWith(
+        'Error fetching systems with given filters'
+      );
+      expect(setFetchError).toHaveBeenCalledWith(true);
+    });
+
+    it('should return empty results on 400 error', async () => {
+      const error400 = {
+        response: {
+          status: 400,
+          data: { message: 'Invalid filter' },
+        },
+        message: 'Invalid filter parameter',
+        data: [],
+        meta: { count: 0 },
+      };
+
+      fetchSystems.mockResolvedValue(error400);
+
+      const getEntities = useGetEntities(onComplete, {
+        selectedIds,
+        setFilterSortString,
+        slug,
+        onError,
+        setFetchError,
+        addNotification,
+      });
+
+      const result = await getEntities([], config);
+
+      expect(result.results).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe('callbacks are optional', () => {
+    it('should not throw if onError is not provided', async () => {
+      const mockData = [
+        {
+          id: '1',
+          display_name: 'system1',
+          requirements: [],
+          connected: true,
+          last_check_in: '2024-01-01',
+        },
+      ];
+
+      fetchSystems.mockResolvedValue({
+        data: mockData,
+        meta: { count: 1 },
+      });
+
+      const getEntities = useGetEntities(onComplete, {
+        selectedIds,
+        setFilterSortString,
+        slug,
+        // onError not provided
+        setFetchError,
+      });
+
+      await expect(getEntities([], config)).resolves.toBeDefined();
+    });
+
+    it('should not throw if setFetchError is not provided', async () => {
+      const mockData = [
+        {
+          id: '1',
+          display_name: 'system1',
+          requirements: [],
+          connected: true,
+          last_check_in: '2024-01-01',
+        },
+      ];
+
+      fetchSystems.mockResolvedValue({
+        data: mockData,
+        meta: { count: 1 },
+      });
+
+      const getEntities = useGetEntities(onComplete, {
+        selectedIds,
+        setFilterSortString,
+        slug,
+        onError,
+        // setFetchError not provided
+      });
+
+      await expect(getEntities([], config)).resolves.toBeDefined();
+    });
+
+    it('should handle 400 error when callbacks are not provided', async () => {
+      const error400 = {
+        response: {
+          status: 400,
+          data: { message: 'Bad request' },
+        },
+        message: 'Bad request from API',
+        data: [],
+        meta: { count: 0 },
+      };
+
+      fetchSystems.mockResolvedValue(error400);
+
+      const getEntities = useGetEntities(onComplete, {
+        selectedIds,
+        setFilterSortString,
+        slug,
+        // onError and setFetchError not provided
+      });
+
+      const result = await getEntities([], config);
+
+      expect(result.results).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe('data transformation', () => {
+    it('should correctly map entity data with requirements', async () => {
+      const mockData = [
+        {
+          id: '1',
+          display_name: 'system1',
+          requirements: ['Requirement 1', 'Requirement 2'],
+          connected: true,
+          last_check_in: '2024-01-01',
+        },
+      ];
+
+      fetchSystems.mockResolvedValue({
+        data: mockData,
+        meta: { count: 1 },
+      });
+
+      const getEntities = useGetEntities(onComplete, {
+        selectedIds,
+        setFilterSortString,
+        slug,
+        onError,
+        setFetchError,
+        addNotification,
+      });
+
+      const result = await getEntities([], config);
+
+      expect(result.results[0].eligibility).toEqual({
+        title: 'Not eligible',
+        tooltip: 'Requirement 1. Requirement 2',
+      });
+      expect(result.results[0].disableSelection).toBe(2); // requirements.length (2) is truthy
+    });
+
+    it('should correctly map entity data without requirements', async () => {
+      const mockData = [
+        {
+          id: '1',
+          display_name: 'system1',
+          requirements: [],
+          connected: true,
+          last_check_in: '2024-01-01',
+        },
+      ];
+
+      fetchSystems.mockResolvedValue({
+        data: mockData,
+        meta: { count: 1 },
+      });
+
+      const getEntities = useGetEntities(onComplete, {
+        selectedIds,
+        setFilterSortString,
+        slug,
+        onError,
+        setFetchError,
+        addNotification,
+      });
+
+      const result = await getEntities([], config);
+
+      expect(result.results[0].eligibility).toEqual({
+        title: 'Eligible',
+        tooltip: '',
+      });
+      expect(result.results[0].disableSelection).toBe(false);
+    });
+
+    it('should mark selected systems as selected', async () => {
+      const mockData = [
+        {
+          id: '1',
+          display_name: 'system1',
+          requirements: [],
+          connected: true,
+          last_check_in: '2024-01-01',
+        },
+        {
+          id: '2',
+          display_name: 'system2',
+          requirements: [],
+          connected: true,
+          last_check_in: '2024-01-02',
+        },
+      ];
+
+      fetchSystems.mockResolvedValue({
+        data: mockData,
+        meta: { count: 2 },
+      });
+
+      const getEntities = useGetEntities(onComplete, {
+        selectedIds: ['1'],
+        setFilterSortString,
+        slug,
+        onError,
+        setFetchError,
+      });
+
+      const result = await getEntities([], config);
+
+      expect(result.results[0].selected).toBe(true);
+      expect(result.results[1].selected).toBe(false);
+    });
+  });
+});

--- a/src/SmartComponents/SystemTable/hooks.js
+++ b/src/SmartComponents/SystemTable/hooks.js
@@ -3,7 +3,14 @@ import { buildFilterSortString } from './helpers';
 
 export const useGetEntities = (
   onComplete,
-  { selectedIds, setFilterSortString, slug }
+  {
+    selectedIds,
+    setFilterSortString,
+    slug,
+    onError,
+    setFetchError,
+    addNotification,
+  }
 ) => {
   return async (_items, config) => {
     const {
@@ -30,6 +37,23 @@ export const useGetEntities = (
     );
     const fetchedEntities = await fetchSystems(filterSortString, slug);
 
+    // Handle 400 error response
+    if (fetchedEntities?.response?.status === 400) {
+      addNotification &&
+        addNotification({
+          variant: 'danger',
+          title: 'There was an error fetching systems',
+          description: fetchedEntities.message || 'Failed to fetch systems',
+          dismissable: true,
+        });
+      fetchedEntities.data = [];
+      fetchedEntities.meta = { count: 0 };
+      onError && onError('Error fetching systems with given filters');
+      setFetchError && setFetchError(true);
+    } else {
+      onError && onError(null);
+      setFetchError && setFetchError(false);
+    }
     const {
       data,
       meta: { count },

--- a/src/Utilities/hooks/useTableTools/Components/__tests__/__snapshots__/TasksTables.tests.js.snap
+++ b/src/Utilities/hooks/useTableTools/Components/__tests__/__snapshots__/TasksTables.tests.js.snap
@@ -1250,13 +1250,14 @@ exports[`TasksTables should render empty 1`] = `
         >
           <div
             class="ins-c-table__empty"
+            style="margin: 0px;"
           >
              
             <div
               class="pf-v6-l-bullseye"
             >
               <div
-                class="pf-v6-c-empty-state"
+                class="pf-v6-c-empty-state pf-m-sm"
               >
                 <div
                   class="pf-v6-c-empty-state__content"
@@ -1265,12 +1266,29 @@ exports[`TasksTables should render empty 1`] = `
                     class="pf-v6-c-empty-state__header"
                   >
                     <div
+                      class="pf-v6-c-empty-state__icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v6-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 512 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                        />
+                      </svg>
+                    </div>
+                    <div
                       class="pf-v6-c-empty-state__title"
                     >
                       <h5
                         class="pf-v6-c-empty-state__title-text"
                       >
-                        No matching items found
+                        No matching systems found
                       </h5>
                     </div>
                   </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,6 +17,7 @@ import {
 } from '@redhat-cloud-services/frontend-components/Skeleton';
 import RunTaskButton from './PresentationalComponents/RunTaskButton/RunTaskButton';
 import { createLink } from './helpers';
+import { SearchIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 
 /**
  * String constants
@@ -85,6 +86,24 @@ export const TASK_STATUS = {
   COMPLETED_WITH_ERRORS: 'Completed With Errors',
   FAILURE: 'Failure',
   CANCELLED: 'Cancelled',
+};
+
+export const NO_RESULTS_REASONS = {
+  NO_MATCH: 'no_match',
+  ERROR: 'error',
+};
+
+export const NO_RESULTS_MAP = {
+  [NO_RESULTS_REASONS.NO_MATCH]: {
+    icon: SearchIcon,
+    titleText: 'No matching systems found',
+    bodyText: 'To continue, edit your filter settings and search again.',
+  },
+  [NO_RESULTS_REASONS.ERROR]: {
+    icon: ExclamationCircleIcon,
+    titleText: 'Error encountered when fetching systems.',
+    bodyText: 'To continue, try resetting the filters and search again.',
+  },
 };
 
 /**


### PR DESCRIPTION
Similar to https://github.com/RedHatInsights/insights-advisor-frontend/pull/1731 for Advisor FE.

Reproducer:
- use prod
- login as insights-qa account
- click 'Select systems' for the ping task
- filter systems on RHEL10.7 OS (which doesn't exist in the backend and will return a 400 error)
- before fix will encounter 'Something went wrong' error
- after fix will see 'Error fetching systems' message which is nicer

Before fix:
<img width="1920" height="1009" alt="Screenshot from 2026-02-17 12-47-44" src="https://github.com/user-attachments/assets/14c0ba9e-3a7e-43c9-aa6e-0270d71f9259" />

After fix:
<img width="1920" height="1009" alt="Screenshot from 2026-02-17 12-48-32" src="https://github.com/user-attachments/assets/e3607538-de6b-4f60-8716-e992a26a965d" />

