### PR TITLE
feat(rhineng-25210): add batched requests to activity tab

### DIFF
--- a/src/SmartComponents/ActivityTable/ActivityTable.js
+++ b/src/SmartComponents/ActivityTable/ActivityTable.js
@@ -30,7 +30,6 @@ import {
 } from '../completedTaskDetailsHelpers';
 import RunTaskModal from '../RunTaskModal/RunTaskModal';
 import RefreshFooterContent from '../RefreshFooterContent';
-import usePromiseQueue from '../../Utilities/hooks/usePromiseQueue';
 
 const ActivityTable = () => {
   const addNotification = useAddNotification();
@@ -49,8 +48,9 @@ const ActivityTable = () => {
   const [selectedSystems, setSelectedSystems] = useState([]);
   const [lastUpdated, setLastUpdated] = useState(null);
   const [isRunning, setIsRunning] = useState(false);
-
-  const { resolve } = usePromiseQueue();
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(20);
+  const [total, setTotal] = useState(0);
 
   const fetchTaskDetails = async (id) => {
     setTaskError();
@@ -76,33 +76,35 @@ const ActivityTable = () => {
     }
   };
 
-  const fetchData = async (count) => {
-    let results;
-    const batchSize = 200;
-    const pages = Math.ceil(count / batchSize) || 1;
-    const result = await resolve(
-      [...new Array(pages)].map(
-        (_, pageIdx) => () =>
-          fetchExecutedTasks(
-            `?limit=${batchSize}&offset=${batchSize * pageIdx}`,
-          ),
-      ),
+  /**
+   * Fetches a single page of tasks from the server using server-side pagination
+   *  @param   {number}        pageNum  - Current page number (1-indexed)
+   *  @param   {number}        pageSize - Number of items per page
+   *  @returns {Promise<void>}
+   */
+  const fetchData = async (pageNum, pageSize) => {
+    const offset = (pageNum - 1) * pageSize;
+    const result = await fetchExecutedTasks(
+      `?limit=${pageSize}&offset=${offset}`,
     );
 
-    if (isError(result[0])) {
-      createNotification(result[0], addNotification);
-      setError(result[0]);
+    if (isError(result)) {
+      createNotification(result, addNotification);
+      setError(result);
+      setActivities([]);
+      setTableLoading(false);
     } else {
-      results = result.map(({ data }) => data).flat();
-    }
+      const tasks = result.data || [];
 
-    if (results.some((result) => result.status === 'Running')) {
-      setIsRunning(true);
-    } else {
-      setIsRunning(false);
-    }
+      if (tasks.some((task) => task.status === 'Running')) {
+        setIsRunning(true);
+      } else {
+        setIsRunning(false);
+      }
 
-    setTasks(results);
+      setTotal(result.meta?.count || 0);
+      setTasks(tasks);
+    }
   };
 
   const handleCancelOrDeleteTask = async (task) => {
@@ -115,6 +117,11 @@ const ActivityTable = () => {
     fetchTaskDetails,
   );
 
+  /**
+   * Sets tasks data and updates run_date_time for display
+   *  @param   {Array}         result - Array of task objects
+   *  @returns {Promise<void>}
+   */
   const setTasks = async (result) => {
     result?.map(
       (task) => (task.run_date_time = renderRunDateTime(task.start_time)),
@@ -124,34 +131,34 @@ const ActivityTable = () => {
     setTableLoading(false);
   };
 
+  /**
+   * Refetches the current page of data and resets table loading state
+   *  @returns {Promise<void>}
+   */
   const refetchData = async () => {
     setTableLoading(true);
     await setActivities(LOADING_ACTIVITIES_TABLE);
-    fetchSingleTask();
+    fetchCurrentPage();
   };
 
-  const fetchSingleTask = async () => {
+  /**
+   * Fetches the current page based on state values (page, perPage)
+   * Updates lastUpdated timestamp
+   *  @returns {Promise<void>}
+   */
+  const fetchCurrentPage = async () => {
     setLastUpdated(new Date());
-    const task = await fetchExecutedTasks(`?limit=1&offset=0`);
-    if (isError(task)) {
-      createNotification(task, addNotification);
-      setError(task);
-      setActivities([]);
-    } else if (task.data.length === 0) {
-      setActivities([]);
-    } else {
-      fetchData(task.meta.count);
-    }
+    await fetchData(page, perPage);
   };
 
   useEffect(() => {
-    fetchSingleTask();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- run only on mount
-  }, []);
+    fetchCurrentPage();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch on page/perPage change
+  }, [page, perPage]);
 
   useInterval(() => {
     if (isRunning) {
-      fetchSingleTask();
+      fetchCurrentPage();
     }
   }, 60000);
 
@@ -226,6 +233,17 @@ const ActivityTable = () => {
               exportable: {
                 ...TASKS_TABLE_DEFAULTS(addNotification).exportable,
                 columns: exportableColumns,
+              },
+              perPage,
+              pagination: {
+                page,
+                perPage,
+                itemCount: total,
+                onSetPage: (_, newPage) => setPage(newPage),
+                onPerPageSelect: (_, newPerPage) => {
+                  setPerPage(newPerPage);
+                  setPage(1);
+                },
               },
             }}
             emptyRows={emptyRows('tasks')}

--- a/src/SmartComponents/ActivityTable/ActivityTable.js
+++ b/src/SmartComponents/ActivityTable/ActivityTable.js
@@ -52,6 +52,20 @@ const ActivityTable = () => {
   const [perPage, setPerPage] = useState(20);
   const [total, setTotal] = useState(0);
   const [sortBy, setSortBy] = useState({ index: 3, direction: 'desc' });
+  const [activeFilters, setActiveFilters] = useState({});
+
+  /**
+   * Checks if any filters are currently active
+   *  @returns {boolean} True if any filter has a non-empty value
+   */
+  const hasActiveFilters = () => {
+    return Object.values(activeFilters).some((value) => {
+      if (Array.isArray(value)) {
+        return value.length > 0;
+      }
+      return value !== '' && value !== undefined && value !== null;
+    });
+  };
 
   const fetchTaskDetails = async (id) => {
     setTaskError();
@@ -88,7 +102,30 @@ const ActivityTable = () => {
   };
 
   /**
-   * Fetches a single page of tasks from the server using server-side pagination
+   * Builds filter query parameters from active filters
+   *  @param   {object}   filters          - Active filter state object with filter keys and values
+   *  @param   {string}   [filters.task]   - Text filter for task name
+   *  @param   {string[]} [filters.status] - Array of status values to filter by
+   *  @returns {string}                    URL query string for filters (e.g., "&text=value&status=Running")
+   */
+  const buildFilterParams = (filters) => {
+    let params = '';
+
+    if (filters['task']) {
+      params += `&text=${encodeURIComponent(filters['task'])}`;
+    }
+
+    if (filters['status'] && filters['status'].length > 0) {
+      filters['status'].forEach((statusValue) => {
+        params += `&status=${encodeURIComponent(statusValue)}`;
+      });
+    }
+
+    return params;
+  };
+
+  /**
+   * Fetches a single page of tasks from the server using server-side pagination and filtering
    *  @param   {number}        pageNum  - Current page number (1-indexed)
    *  @param   {number}        pageSize - Number of items per page
    *  @returns {Promise<void>}
@@ -97,8 +134,9 @@ const ActivityTable = () => {
     const offset = (pageNum - 1) * pageSize;
     const sortField = getApiSortField(sortBy.index);
     const sortParam = sortBy.direction === 'desc' ? `-${sortField}` : sortField;
+    const filterParams = buildFilterParams(activeFilters);
     const result = await fetchExecutedTasks(
-      `?limit=${pageSize}&offset=${offset}&sort=${sortParam}`,
+      `?limit=${pageSize}&offset=${offset}&sort=${sortParam}${filterParams}`,
     );
 
     if (isError(result)) {
@@ -177,9 +215,11 @@ const ActivityTable = () => {
   };
 
   useEffect(() => {
+    setTableLoading(true);
+    setActivities(LOADING_ACTIVITIES_TABLE);
     fetchCurrentPage();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, perPage, sortBy]);
+  }, [page, perPage, sortBy, activeFilters]);
 
   useInterval(() => {
     if (isRunning) {
@@ -235,7 +275,7 @@ const ActivityTable = () => {
             text={COMPLETED_TASKS_ERROR}
             error={`Error ${error?.response?.status}: ${error?.message}`}
           />
-        ) : activities?.length === 0 ? (
+        ) : activities?.length === 0 && !tableLoading && !hasActiveFilters() ? (
           <EmptyStateDisplay
             icon={WrenchIcon}
             color="#6a6e73"
@@ -250,6 +290,13 @@ const ActivityTable = () => {
             items={activities}
             filters={{
               filterConfig: [...nameFilter, ...statusFilter],
+              onFilterUpdate: (filterName, filterValue) => {
+                setActiveFilters((prev) => ({
+                  ...prev,
+                  [filterName]: filterValue,
+                }));
+                setPage(1);
+              },
             }}
             options={{
               ...TASKS_TABLE_DEFAULTS(addNotification),

--- a/src/SmartComponents/ActivityTable/ActivityTable.js
+++ b/src/SmartComponents/ActivityTable/ActivityTable.js
@@ -51,6 +51,7 @@ const ActivityTable = () => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(20);
   const [total, setTotal] = useState(0);
+  const [sortBy, setSortBy] = useState({ index: 3, direction: 'desc' });
 
   const fetchTaskDetails = async (id) => {
     setTaskError();
@@ -77,6 +78,16 @@ const ActivityTable = () => {
   };
 
   /**
+   * Maps column index to API sort field name
+   *  @param   {number} columnIndex - Column index (0-based)
+   *  @returns {string}             API field name for sorting
+   */
+  const getApiSortField = (columnIndex) => {
+    const sortFields = ['name', 'systems_count', 'status', 'start_time'];
+    return sortFields[columnIndex] || 'start_time';
+  };
+
+  /**
    * Fetches a single page of tasks from the server using server-side pagination
    *  @param   {number}        pageNum  - Current page number (1-indexed)
    *  @param   {number}        pageSize - Number of items per page
@@ -84,8 +95,10 @@ const ActivityTable = () => {
    */
   const fetchData = async (pageNum, pageSize) => {
     const offset = (pageNum - 1) * pageSize;
+    const sortField = getApiSortField(sortBy.index);
+    const sortParam = sortBy.direction === 'desc' ? `-${sortField}` : sortField;
     const result = await fetchExecutedTasks(
-      `?limit=${pageSize}&offset=${offset}`,
+      `?limit=${pageSize}&offset=${offset}&sort=${sortParam}`,
     );
 
     if (isError(result)) {
@@ -116,6 +129,18 @@ const ActivityTable = () => {
     handleCancelOrDeleteTask,
     fetchTaskDetails,
   );
+
+  /**
+   * Handles sort changes - updates sort state and resets to page 1
+   *  @param   {*}      _         - Unused event parameter
+   *  @param   {number} index     - Column index being sorted
+   *  @param   {string} direction - Sort direction ('asc' or 'desc')
+   *  @returns {void}
+   */
+  const handleSort = (_, index, direction) => {
+    setSortBy({ index, direction });
+    setPage(1);
+  };
 
   /**
    * Sets tasks data and updates run_date_time for display
@@ -153,8 +178,8 @@ const ActivityTable = () => {
 
   useEffect(() => {
     fetchCurrentPage();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch on page/perPage change
-  }, [page, perPage]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, perPage, sortBy]);
 
   useInterval(() => {
     if (isRunning) {
@@ -245,6 +270,8 @@ const ActivityTable = () => {
                   setPage(1);
                 },
               },
+              sortBy,
+              onSort: handleSort,
             }}
             emptyRows={emptyRows('tasks')}
             isStickyHeader

--- a/src/SmartComponents/ActivityTable/Filters.js
+++ b/src/SmartComponents/ActivityTable/Filters.js
@@ -4,12 +4,7 @@ export const nameFilter = [
   {
     type: conditionalFilterType.text,
     label: 'Task',
-    filter: (tasks, value) =>
-      tasks.filter((task) =>
-        typeof task.name === 'string'
-          ? task.name.toLowerCase().includes(value.toLowerCase())
-          : null,
-      ),
+    filter: (tasks) => tasks,
   },
 ];
 
@@ -17,13 +12,12 @@ export const statusFilter = [
   {
     type: conditionalFilterType.checkbox,
     label: 'Status',
-    filter: (tasks, value) =>
-      tasks.filter((task) => value.includes(task.status.toLowerCase())),
+    filter: (tasks) => tasks,
     items: [
-      { label: 'Running', value: 'running' },
-      { label: 'Completed', value: 'completed' },
-      { label: 'Completed with errors', value: 'completed with errors' },
-      { label: 'Failure', value: 'failure' },
+      { label: 'Running', value: 'Running' },
+      { label: 'Completed', value: 'Completed' },
+      { label: 'Completed With Errors', value: 'Completed With Errors' },
+      { label: 'Failure', value: 'Failure' },
     ],
   },
 ];

--- a/src/SmartComponents/ActivityTable/__tests__/ActivityTable.tests.js
+++ b/src/SmartComponents/ActivityTable/__tests__/ActivityTable.tests.js
@@ -413,9 +413,291 @@ describe('ActivityTable', () => {
       </MemoryRouter>,
     );
 
-    // Verify initial fetch uses default page=1, perPage=20, resulting in offset=0, limit=20
     await waitFor(() => {
-      expect(fetchExecutedTasks).toHaveBeenCalledWith('?limit=20&offset=0');
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+  });
+
+  it('should use server-side sorting when clicking column headers', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const taskHeader = screen.getAllByRole('columnheader')[0];
+    const taskHeaderButton = within(taskHeader).getByRole('button');
+    await userEvent.click(taskHeaderButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=name',
+      );
+    });
+  });
+
+  it('should toggle sort direction when clicking same column twice', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalled();
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const systemsHeader = screen.getAllByRole('columnheader')[1];
+    const systemsHeaderButton = within(systemsHeader).getByRole('button');
+
+    await userEvent.click(systemsHeaderButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=systems_count',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    await userEvent.click(systemsHeaderButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-systems_count',
+      );
+    });
+  });
+
+  it('should sort by status column', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalled();
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const statusHeader = screen.getAllByRole('columnheader')[2];
+    const statusHeaderButton = within(statusHeader).getByRole('button');
+    await userEvent.click(statusHeaderButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=status',
+      );
+    });
+  });
+
+  it('should reset to page 1 when sorting from a different page', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return { data: activityTableItems.data, meta: { count: 100 } };
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const pagination = screen.getAllByLabelText('Go to next page')[0];
+    await userEvent.click(pagination);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=20&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const taskHeader = screen.getAllByRole('columnheader')[0];
+    const taskHeaderButton = within(taskHeader).getByRole('button');
+    await userEvent.click(taskHeaderButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=name',
+      );
+    });
+  });
+
+  it('should sort by run date/time column in ascending order', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalled();
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const runDateHeader = screen.getAllByRole('columnheader')[3];
+    const runDateHeaderButton = within(runDateHeader).getByRole('button');
+    await userEvent.click(runDateHeaderButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=start_time',
+      );
+    });
+  });
+
+  it('should refetch with current sort after delete', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    deleteExecutedTask.mockImplementation(async () => {
+      return { data: {} };
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const taskHeader = screen.getAllByRole('columnheader')[0];
+    const taskHeaderButton = within(taskHeader).getByRole('button');
+    await userEvent.click(taskHeaderButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=name',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const row = screen.getByRole('row', {
+      name: /task a 10 completed/i,
+    });
+
+    await userEvent.click(
+      within(row).getByRole('button', {
+        name: /kebab toggle/i,
+      }),
+    );
+
+    await userEvent.click(
+      screen.getByRole('menuitem', {
+        name: /delete/i,
+      }),
+    );
+
+    await userEvent.click(await screen.findByLabelText('Delete task button'));
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=name',
+      );
+    });
+  });
+
+  it('should handle pagination with sorted data', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return { data: activityTableItems.data, meta: { count: 100 } };
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const statusHeader = screen.getAllByRole('columnheader')[2];
+    const statusHeaderButton = within(statusHeader).getByRole('button');
+    await userEvent.click(statusHeaderButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=status',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const nextPageButton = screen.getAllByLabelText('Go to next page')[0];
+    await userEvent.click(nextPageButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=20&sort=status',
+      );
     });
   });
 });

--- a/src/SmartComponents/ActivityTable/__tests__/ActivityTable.tests.js
+++ b/src/SmartComponents/ActivityTable/__tests__/ActivityTable.tests.js
@@ -117,7 +117,7 @@ describe('ActivityTable', () => {
     expect(input.value).toBe('A');
   });
 
-  it('should remove name filter', async () => {
+  it('should remove name filter and refetch data', async () => {
     fetchExecutedTasks.mockImplementation(async () => {
       return activityTableItems;
     });
@@ -130,12 +130,34 @@ describe('ActivityTable', () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => expect(fetchExecutedTasks).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
     const input = screen.getByLabelText('text input');
     fireEvent.change(input, { target: { value: 'A' } });
     expect(input.value).toBe('A');
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&text=A',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
     fireEvent.change(input, { target: { value: '' } });
     expect(input.value).toBe('');
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
   });
 
   it('should filter by status completed', async () => {
@@ -152,8 +174,12 @@ describe('ActivityTable', () => {
     );
 
     await waitFor(() => {
-      expect(fetchExecutedTasks).toHaveBeenCalled();
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
     });
+
+    fetchExecutedTasks.mockClear();
 
     // Click the conditional filter toggle
     await userEvent.click(
@@ -178,9 +204,11 @@ describe('ActivityTable', () => {
     // Now click the Completed checkbox
     await userEvent.click(screen.getAllByText('Completed')[0]);
 
+    // Verify server-side filtering: API called with status filter parameter
     await waitFor(() => {
-      expect(screen.getByText('Task A')).toBeInTheDocument();
-      expect(screen.queryByText('Task B')).not.toBeInTheDocument();
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&status=Completed',
+      );
     });
   });
 
@@ -198,8 +226,12 @@ describe('ActivityTable', () => {
     );
 
     await waitFor(() => {
-      expect(fetchExecutedTasks).toHaveBeenCalled();
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
     });
+
+    fetchExecutedTasks.mockClear();
 
     // Click the conditional filter toggle
     await userEvent.click(
@@ -224,9 +256,11 @@ describe('ActivityTable', () => {
     // Now click the Running checkbox
     await userEvent.click(screen.getAllByText('Running')[0]);
 
+    // Verify server-side filtering: API called with status filter parameter
     await waitFor(() => {
-      expect(screen.getByText('Task B')).toBeInTheDocument();
-      expect(screen.queryByText('Task A')).not.toBeInTheDocument();
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&status=Running',
+      );
     });
   });
 
@@ -697,6 +731,362 @@ describe('ActivityTable', () => {
     await waitFor(() => {
       expect(fetchExecutedTasks).toHaveBeenCalledWith(
         '?limit=20&offset=20&sort=status',
+      );
+    });
+  });
+
+  it('should apply multiple status filters with server-side filtering', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /conditional filter toggle/i,
+      }),
+    );
+
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Status' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Options menu' }),
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    await userEvent.click(screen.getAllByText('Running')[0]);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&status=Running',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    await userEvent.click(screen.getAllByText('Completed')[0]);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&status=Running&status=Completed',
+      );
+    });
+  });
+
+  it('should combine text and status filters', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const input = screen.getByLabelText('text input');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&text=test',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /conditional filter toggle/i,
+      }),
+    );
+
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Status' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Options menu' }),
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    await userEvent.click(screen.getAllByText('Running')[0]);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&text=test&status=Running',
+      );
+    });
+  });
+
+  it('should reset to page 1 when applying filters', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return { data: activityTableItems.data, meta: { count: 100 } };
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const nextPageButton = screen.getAllByLabelText('Go to next page')[0];
+    await userEvent.click(nextPageButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=20&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const input = screen.getByLabelText('text input');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&text=test',
+      );
+    });
+  });
+
+  it('should maintain filters when sorting', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const input = screen.getByLabelText('text input');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&text=test',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const taskHeader = screen.getAllByRole('columnheader')[0];
+    const taskHeaderButton = within(taskHeader).getByRole('button');
+    await userEvent.click(taskHeaderButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=name&text=test',
+      );
+    });
+  });
+
+  it('should maintain filters when changing page', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return { data: activityTableItems.data, meta: { count: 100 } };
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const input = screen.getByLabelText('text input');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&text=test',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const nextPageButton = screen.getAllByLabelText('Go to next page')[0];
+    await userEvent.click(nextPageButton);
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=20&sort=-start_time&text=test',
+      );
+    });
+  });
+
+  it('should show table with empty rows when filters return no results', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalled();
+    });
+
+    fetchExecutedTasks.mockImplementation(async () => {
+      return { data: [], meta: { count: 0 } };
+    });
+
+    const input = screen.getByLabelText('text input');
+    fireEvent.change(input, { target: { value: 'nonexistent' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('No matching tasks found')).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText('text input')).toBeInTheDocument();
+  });
+
+  it('should encode special characters in text filter', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    const input = screen.getByLabelText('text input');
+    fireEvent.change(input, { target: { value: 'test&value=hack' } });
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&text=test%26value%3Dhack',
+      );
+    });
+  });
+
+  it('should handle all status filter options', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalled();
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /conditional filter toggle/i,
+      }),
+    );
+
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Status' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Options menu' }),
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    await userEvent.click(screen.getByText('Completed With Errors'));
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&status=Completed%20With%20Errors',
+      );
+    });
+
+    fetchExecutedTasks.mockClear();
+
+    await userEvent.click(screen.getByText('Failure'));
+
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith(
+        '?limit=20&offset=0&sort=-start_time&status=Completed%20With%20Errors&status=Failure',
       );
     });
   });

--- a/src/SmartComponents/ActivityTable/__tests__/ActivityTable.tests.js
+++ b/src/SmartComponents/ActivityTable/__tests__/ActivityTable.tests.js
@@ -331,7 +331,8 @@ describe('ActivityTable', () => {
     expect(executeTask).toHaveBeenCalled();
 
     await waitFor(() => {
-      expect(fetchExecutedTasks).toHaveBeenCalledTimes(4);
+      // 1 call on mount + 1 call after delete/cancel = 2 calls with server-side pagination
+      expect(fetchExecutedTasks).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -394,7 +395,27 @@ describe('ActivityTable', () => {
     expect(deleteExecutedTask).toHaveBeenCalledWith(1);
 
     await waitFor(() => {
-      expect(fetchExecutedTasks).toHaveBeenCalledTimes(4);
+      // 1 call on mount + 1 call after delete/cancel = 2 calls with server-side pagination
+      expect(fetchExecutedTasks).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('should use server-side pagination with correct offset and limit on initial load', async () => {
+    fetchExecutedTasks.mockImplementation(async () => {
+      return activityTableItems;
+    });
+
+    render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <ActivityTable />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    // Verify initial fetch uses default page=1, perPage=20, resulting in offset=0, limit=20
+    await waitFor(() => {
+      expect(fetchExecutedTasks).toHaveBeenCalledWith('?limit=20&offset=0');
     });
   });
 });

--- a/src/Utilities/hooks/useTableTools/__tests__/useTableSort.test.js
+++ b/src/Utilities/hooks/useTableTools/__tests__/useTableSort.test.js
@@ -43,6 +43,25 @@ describe('useTableSort', () => {
 
     expect(result.current.tableProps.sortBy).toEqual(newSortBy);
   });
+
+  it('uses external onSort for server-side sorting', () => {
+    const sortBy = {
+      index: 3,
+      direction: 'desc',
+    };
+    const externalOnSort = jest.fn();
+
+    const { result } = renderHook(() =>
+      useTableSort(columns, {
+        sortBy,
+        onSort: externalOnSort,
+      }),
+    );
+
+    expect(result.current.sorter).toBeNull();
+    expect(result.current.tableProps.onSort).toBe(externalOnSort);
+    expect(result.current.tableProps.sortBy).toEqual(sortBy);
+  });
 });
 
 describe('useTableSortWithItems', () => {

--- a/src/Utilities/hooks/useTableTools/useFilterConfig.js
+++ b/src/Utilities/hooks/useTableTools/useFilterConfig.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import FilterConfigBuilder from './FilterConfigBuilder/FilterConfigBuilder';
 import useSelectedFilter from './useSelectedFilter';
+import { stringToId } from './FilterConfigBuilder/Helpers';
 
 const filterValues = (activeFilters) =>
   Object.values(activeFilters).filter((value) => {
@@ -31,8 +32,11 @@ const perpareInitialActiveFilters = (
 const useFilterConfig = (options = {}) => {
   const { filters, setPage, selectedFilter, onDeleteFilter } = options;
   const enableFilters = !!filters;
-  const { filterConfig = [], activeFilters: initialActiveFiltersRaw } =
-    filters || {};
+  const {
+    filterConfig = [],
+    activeFilters: initialActiveFiltersRaw,
+    onFilterUpdate: onFilterUpdateCallback,
+  } = filters || {};
 
   const [activeFilters, setActiveFilters] = useState({});
   const initialActiveFilters = perpareInitialActiveFilters(
@@ -46,6 +50,7 @@ const useFilterConfig = (options = {}) => {
     }));
 
     setPage && setPage(1);
+    onFilterUpdateCallback && onFilterUpdateCallback(filter, value);
   };
 
   const addConfigItem = (item) => {
@@ -53,13 +58,31 @@ const useFilterConfig = (options = {}) => {
     setActiveFilters(filterConfigBuilder.initialDefaultState(activeFilters));
   };
 
-  const clearAllFilter = () =>
-    setActiveFilters(filterConfigBuilder.initialDefaultState());
+  const clearAllFilter = () => {
+    const newFilters = filterConfigBuilder.initialDefaultState();
+    setActiveFilters(newFilters);
+    if (onFilterUpdateCallback) {
+      Object.keys(activeFilters).forEach((key) => {
+        const newValue = newFilters[key] !== undefined ? newFilters[key] : '';
+        onFilterUpdateCallback(key, newValue);
+      });
+    }
+  };
 
-  const deleteFilter = (chips) =>
-    setActiveFilters(
-      filterConfigBuilder.removeFilterWithChip(chips, activeFilters),
+  const deleteFilter = (chips) => {
+    const newFilters = filterConfigBuilder.removeFilterWithChip(
+      chips,
+      activeFilters,
     );
+    setActiveFilters(newFilters);
+    if (onFilterUpdateCallback && chips.category) {
+      const filterId = stringToId(chips.category);
+      const newValue =
+        newFilters[filterId] !== undefined ? newFilters[filterId] : '';
+      onFilterUpdateCallback(filterId, newValue);
+    }
+  };
+
   const onFilterDelete = async (_event, chips, clearAll = false) => {
     (await clearAll) ? clearAllFilter() : deleteFilter(chips[0]);
     onDeleteFilter && onDeleteFilter(chips, clearAll);

--- a/src/Utilities/hooks/useTableTools/usePaginate.js
+++ b/src/Utilities/hooks/useTableTools/usePaginate.js
@@ -4,10 +4,19 @@ import {
   SkeletonSize,
 } from '@redhat-cloud-services/frontend-components/Skeleton';
 
+/**
+ * Hook for handling table pagination - supports both client-side and server-side pagination
+ *  @param   {object}           options              - Configuration options
+ *  @param   {number}           [options.perPage]    - Items per page
+ *  @param   {object | boolean} [options.pagination] - Custom pagination config (for server-side) or false to disable
+ *  @param   {boolean}          isTableLoading       - Whether table is currently loading
+ *  @returns {object}                                Pagination utilities
+ */
 const usePaginate = (options = {}, isTableLoading) => {
-  const { perPage = 10 } = options;
+  const { perPage = 10, pagination: customPagination } = options;
   const enablePagination = options?.pagination !== false;
 
+  // Client-side pagination state (always called to satisfy React hooks rules)
   const [paginationState, setPaginationState] = useState({
     perPage,
     page: 1,
@@ -36,6 +45,21 @@ const usePaginate = (options = {}, isTableLoading) => {
       page: nextPage > 0 ? nextPage : 1,
     });
   };
+
+  // If custom pagination is provided (server-side), use it directly
+  if (customPagination && typeof customPagination === 'object') {
+    return {
+      paginator: (items) => items, // No client-side pagination
+      setPage: () => {}, // Handled by parent
+      toolbarProps: {
+        pagination: !isTableLoading ? (
+          customPagination
+        ) : (
+          <Skeleton size={SkeletonSize.lg} />
+        ),
+      },
+    };
+  }
 
   return enablePagination
     ? {

--- a/src/Utilities/hooks/useTableTools/useRowsBuilder.js
+++ b/src/Utilities/hooks/useTableTools/useRowsBuilder.js
@@ -58,10 +58,16 @@ const useRowsBuilder = (items, columns, options = {}) => {
         })
       : EmptyRowsComponent;
 
+  // Build pagination props, preserving custom itemCount for server-side pagination
   const pagination = options?.pagination
     ? {
         ...options.pagination,
-        itemCount: filteredItems.length,
+        // Server-side pagination provides itemCount (total from API)
+        // Client-side pagination uses filtered items length
+        itemCount:
+          options.pagination.itemCount !== undefined
+            ? options.pagination.itemCount
+            : filteredItems.length,
       }
     : undefined;
 

--- a/src/Utilities/hooks/useTableTools/useTableSort.js
+++ b/src/Utilities/hooks/useTableTools/useTableSort.js
@@ -19,8 +19,12 @@ const columnOffset = (options = {}) =>
   (typeof options.detailsComponent !== 'undefined');
 
 const useTableSort = (columns, options = {}) => {
+  // If onSort is provided externally (server-side sorting), use it
+  const externalOnSort = options.onSort;
+  const externalSortBy = options.sortBy;
+
   const [sortBy, setSortBy] = useState(
-    options.sortBy || {
+    externalSortBy || {
       index: 3,
       direction: 'asc',
     },
@@ -39,6 +43,18 @@ const useTableSort = (columns, options = {}) => {
       items,
       sortBy.direction,
     );
+
+  if (externalOnSort) {
+    return {
+      sorter: null, // Disable client-side sorting
+      tableProps: {
+        onSort: externalOnSort,
+        sortBy: externalSortBy,
+        cells: addSortableTransform(columns),
+      },
+    };
+  }
+
   return {
     sorter,
     tableProps: {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-25210

Before update:
In activity tab all pages at the same time and wait for all of the requests to resolve before displaying data in the table
After update:
Add batched requests to the Activity tab in tasks, now we request one page at a time. It's faster and easier to request one page with offset and limit and get the exact data we need from the API

## Summary by Sourcery

Implement server-side paginated fetching for the Activity table to load one page of tasks at a time instead of batching all pages on the client.

New Features:
- Add server-side pagination to the Activity table with page, per-page, and total item tracking.

Enhancements:
- Extend the generic table pagination hook to support custom server-side pagination configs while retaining client-side pagination behavior.
- Preserve server-reported total item counts in row-building utilities for accurate pagination display.

Tests:
- Update ActivityTable tests to reflect reduced API calls under server-side pagination and verify correct offset/limit usage on initial load.