### PR TITLE
fix(kessel): prevent RBAC v1 calls during feature flag loading

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import './App.scss';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { RBACProvider } from '@redhat-cloud-services/frontend-components/RBACProvider';
 import { AccessCheck } from '@project-kessel/react-kessel-access-check';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 import { KESSEL_API_BASE_URL } from './constants';
 import useFeatureFlag from './Utilities/useFeatureFlag';
 import { useFlagsStatus } from '@unleash/proxy-client-react';
@@ -36,7 +37,11 @@ const App = () => {
   }, [chrome]);
 
   if (!flagsReady) {
-    return null;
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
   }
 
   return isKesselEnabled ? (

--- a/src/App.js
+++ b/src/App.js
@@ -9,11 +9,13 @@ import { RBACProvider } from '@redhat-cloud-services/frontend-components/RBACPro
 import { AccessCheck } from '@project-kessel/react-kessel-access-check';
 import { KESSEL_API_BASE_URL } from './constants';
 import useFeatureFlag from './Utilities/useFeatureFlag';
+import { useFlagsStatus } from '@unleash/proxy-client-react';
 import pckg from '../package.json';
 
 const App = () => {
   const chrome = useChrome();
   const dispatch = useDispatch();
+  const { flagsReady } = useFlagsStatus();
   const isKesselEnabled = useFeatureFlag('tasks.kessel_enabled');
 
   useEffect(() => {
@@ -33,14 +35,16 @@ const App = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- dispatch is stable
   }, [chrome]);
 
+  if (!flagsReady) {
+    return null;
+  }
+
   return isKesselEnabled ? (
     <AccessCheck.Provider
       baseUrl={window.location.origin}
       apiPath={KESSEL_API_BASE_URL}
     >
-      <RBACProvider appName="tasks">
-        <Routes />
-      </RBACProvider>
+      <Routes />
     </AccessCheck.Provider>
   ) : (
     <RBACProvider appName="tasks">

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -40,6 +40,13 @@ const mockStore = configureStore([]);
 describe('App', () => {
   let store;
 
+  const renderApp = () =>
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>,
+    );
+
   beforeEach(() => {
     store = mockStore({});
     useFlagsStatus.mockReturnValue({ flagsReady: true });
@@ -51,17 +58,14 @@ describe('App', () => {
   });
 
   describe('Feature flag loading states', () => {
-    it('waits for feature flags to load before rendering', () => {
+    it('shows loading spinner while waiting for feature flags', () => {
       useFlagsStatus.mockReturnValue({ flagsReady: false });
-      useFeatureFlag.mockReturnValue(false);
 
-      render(
-        <Provider store={store}>
-          <App />
-        </Provider>,
-      );
+      renderApp();
 
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
       expect(screen.queryByTestId('rbac-provider')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('kessel-provider')).not.toBeInTheDocument();
       expect(screen.queryByTestId('routes')).not.toBeInTheDocument();
     });
 
@@ -69,56 +73,30 @@ describe('App', () => {
       useFlagsStatus.mockReturnValue({ flagsReady: true });
       useFeatureFlag.mockReturnValue(false);
 
-      render(
-        <Provider store={store}>
-          <App />
-        </Provider>,
-      );
+      renderApp();
 
       expect(screen.getByTestId('rbac-provider')).toBeInTheDocument();
       expect(screen.getByTestId('routes')).toBeInTheDocument();
+      expect(screen.queryByTestId('kessel-provider')).not.toBeInTheDocument();
     });
 
     it('renders Kessel provider after flags load with Kessel enabled', () => {
       useFlagsStatus.mockReturnValue({ flagsReady: true });
       useFeatureFlag.mockReturnValue(true);
 
-      render(
-        <Provider store={store}>
-          <App />
-        </Provider>,
-      );
+      renderApp();
 
       expect(screen.getByTestId('kessel-provider')).toBeInTheDocument();
-      expect(screen.queryByTestId('rbac-provider')).not.toBeInTheDocument();
       expect(screen.getByTestId('routes')).toBeInTheDocument();
-    });
-
-    it('avoids rendering RBACProvider during flag loading phase', () => {
-      useFlagsStatus.mockReturnValue({ flagsReady: false });
-      useFeatureFlag.mockReturnValue(false);
-
-      render(
-        <Provider store={store}>
-          <App />
-        </Provider>,
-      );
-
       expect(screen.queryByTestId('rbac-provider')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('routes')).not.toBeInTheDocument();
     });
   });
 
   describe('RBAC v1 mode', () => {
     it('renders only RBACProvider when Kessel is disabled', () => {
-      useFlagsStatus.mockReturnValue({ flagsReady: true });
       useFeatureFlag.mockReturnValue(false);
 
-      render(
-        <Provider store={store}>
-          <App />
-        </Provider>,
-      );
+      renderApp();
 
       expect(screen.getByTestId('rbac-provider')).toBeInTheDocument();
       expect(screen.queryByTestId('kessel-provider')).not.toBeInTheDocument();
@@ -127,14 +105,9 @@ describe('App', () => {
 
   describe('Kessel mode', () => {
     it('renders only Kessel provider when enabled', () => {
-      useFlagsStatus.mockReturnValue({ flagsReady: true });
       useFeatureFlag.mockReturnValue(true);
 
-      render(
-        <Provider store={store}>
-          <App />
-        </Provider>,
-      );
+      renderApp();
 
       expect(screen.getByTestId('kessel-provider')).toBeInTheDocument();
       expect(screen.queryByTestId('rbac-provider')).not.toBeInTheDocument();

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -1,0 +1,143 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import App from '../App';
+import useFeatureFlag from '../Utilities/useFeatureFlag';
+import { useFlagsStatus } from '@unleash/proxy-client-react';
+
+jest.mock('../Routes', () => {
+  const MockRoutes = () => <div data-testid="routes">Routes</div>;
+  MockRoutes.displayName = 'MockRoutes';
+  return MockRoutes;
+});
+jest.mock('../Utilities/useFeatureFlag');
+jest.mock('@unleash/proxy-client-react');
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    identifyApp: jest.fn(),
+    on: jest.fn(),
+    mapGlobalFilter: jest.fn(),
+  }),
+}));
+jest.mock('@redhat-cloud-services/frontend-components/RBACProvider', () => ({
+  // eslint-disable-next-line react/prop-types
+  RBACProvider: function MockRBACProvider({ children }) {
+    return <div data-testid="rbac-provider">{children}</div>;
+  },
+}));
+jest.mock('@project-kessel/react-kessel-access-check', () => ({
+  AccessCheck: {
+    // eslint-disable-next-line react/prop-types
+    Provider: function MockKesselProvider({ children }) {
+      return <div data-testid="kessel-provider">{children}</div>;
+    },
+  },
+}));
+
+const mockStore = configureStore([]);
+
+describe('App', () => {
+  let store;
+
+  beforeEach(() => {
+    store = mockStore({});
+    useFlagsStatus.mockReturnValue({ flagsReady: true });
+    useFeatureFlag.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Feature flag loading states', () => {
+    it('waits for feature flags to load before rendering', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: false });
+      useFeatureFlag.mockReturnValue(false);
+
+      render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+      );
+
+      expect(screen.queryByTestId('rbac-provider')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('routes')).not.toBeInTheDocument();
+    });
+
+    it('renders RBAC provider after flags load with Kessel disabled', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: true });
+      useFeatureFlag.mockReturnValue(false);
+
+      render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+      );
+
+      expect(screen.getByTestId('rbac-provider')).toBeInTheDocument();
+      expect(screen.getByTestId('routes')).toBeInTheDocument();
+    });
+
+    it('renders Kessel provider after flags load with Kessel enabled', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: true });
+      useFeatureFlag.mockReturnValue(true);
+
+      render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+      );
+
+      expect(screen.getByTestId('kessel-provider')).toBeInTheDocument();
+      expect(screen.queryByTestId('rbac-provider')).not.toBeInTheDocument();
+      expect(screen.getByTestId('routes')).toBeInTheDocument();
+    });
+
+    it('avoids rendering RBACProvider during flag loading phase', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: false });
+      useFeatureFlag.mockReturnValue(false);
+
+      render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+      );
+
+      expect(screen.queryByTestId('rbac-provider')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('routes')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('RBAC v1 mode', () => {
+    it('renders only RBACProvider when Kessel is disabled', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: true });
+      useFeatureFlag.mockReturnValue(false);
+
+      render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+      );
+
+      expect(screen.getByTestId('rbac-provider')).toBeInTheDocument();
+      expect(screen.queryByTestId('kessel-provider')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Kessel mode', () => {
+    it('renders only Kessel provider when enabled', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: true });
+      useFeatureFlag.mockReturnValue(true);
+
+      render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+      );
+
+      expect(screen.getByTestId('kessel-provider')).toBeInTheDocument();
+      expect(screen.queryByTestId('rbac-provider')).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Fixes race condition where RBAC v1 API calls were made even when Kessel feature flag (tasks.kessel_enabled) was enabled.

Problem:
- useFeatureFlag returns false while Unleash flags are loading
- App briefly renders RBACProvider before switching to Kessel
- RBACProvider makes /api/rbac/v1/access/?application=tasks call
- Results in unwanted RBAC v1 API call even with Kessel enabled

Solution:
1. Wait for flagsReady before rendering either provider
2. Remove RBACProvider from Kessel branch (was nested incorrectly)

Changes:
- src/App.js: Added flagsReady check, removed RBACProvider from Kessel branch
- src/__tests__/App.test.js: New test file with 6 tests covering:
  - Feature flag loading states
  - RBAC v1 mode rendering
  - Kessel mode rendering
  - Race condition prevention

Verification:
With Kessel enabled, ZERO calls to:
GET /api/rbac/v1/access/?application=tasks

## Summary by Sourcery

Gate App rendering on Unleash flag readiness and align provider selection with the Kessel feature flag to avoid unintended RBAC v1 usage.

Bug Fixes:
- Prevent RBAC v1 provider from rendering while feature flags are still loading to avoid unwanted RBAC v1 API calls when Kessel should be active.
- Ensure Kessel mode no longer nests RBACProvider so only the correct access provider is used based on the feature flag.

Tests:
- Add App tests covering flag loading behavior, RBAC v1 mode, Kessel mode, and guarding against the RBAC race condition during feature flag initialization.