### PR TITLE
fix(RHINENG-25712): replaced hardcoded color to fix dark theme bug

### DIFF
--- a/src/SmartComponents/TasksPage/tasks-page.scss
+++ b/src/SmartComponents/TasksPage/tasks-page.scss
@@ -2,6 +2,6 @@
 // Found in Routes.js as the rootClass
 
 .tabs-background {
-    background-color: white;
+    background-color: var(--pf-v6-global--BackgroundColor--100);
     padding-left: 24px;
 }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-25712


Before:
<img width="1280" height="454" alt="image" src="https://github.com/user-attachments/assets/49070770-645b-48aa-9a10-163534131b99" />

After:
<img width="1280" height="454" alt="image" src="https://github.com/user-attachments/assets/63466a07-4b52-4c1f-a25b-79d814174230" />

## Summary by Sourcery

Bug Fixes:
- Fix incorrect tabs background color in dark theme by using the global background color variable.