### PR TITLE
chore(Kessel): use kessel-sdk library to fetch defeault workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@patternfly/react-log-viewer": "^6.3.0",
         "@patternfly/react-table": "^6.4.1",
         "@patternfly/react-tokens": "^6.4.0",
-        "@project-kessel/react-kessel-access-check": "^0.5.0",
+        "@project-kessel/react-kessel-access-check": "^0.5.3",
         "@redhat-cloud-services/frontend-components": "^7.3.0",
         "@redhat-cloud-services/frontend-components-notifications": "^6.5.0",
         "@redhat-cloud-services/frontend-components-utilities": "^7.2.0",
@@ -4221,9 +4221,9 @@
       }
     },
     "node_modules/@project-kessel/react-kessel-access-check": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@project-kessel/react-kessel-access-check/-/react-kessel-access-check-0.5.0.tgz",
-      "integrity": "sha512-yOQEsX/Z53PSFuiemdGkKNKCRXRVb3Tzo/z8JpmC1uMGm7cT9ny49VqJokRHVuqCLGPH3IqbBd1USD1I2vi1Ew==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@project-kessel/react-kessel-access-check/-/react-kessel-access-check-0.5.3.tgz",
+      "integrity": "sha512-mA5yOO5l9laPYSkh6FDZ8RsIH1vCqvdx9EjZkpWZBbWGEbjZ0i1fQjYxEo6hpByfYy3dxpws54jT+smNr6aKNw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@patternfly/react-log-viewer": "^6.3.0",
     "@patternfly/react-table": "^6.4.1",
     "@patternfly/react-tokens": "^6.4.0",
-    "@project-kessel/react-kessel-access-check": "^0.5.0",
+    "@project-kessel/react-kessel-access-check": "^0.5.3",
     "@redhat-cloud-services/frontend-components": "^7.3.0",
     "@redhat-cloud-services/frontend-components-notifications": "^6.5.0",
     "@redhat-cloud-services/frontend-components-utilities": "^7.2.0",

--- a/src/Utilities/__tests__/useDefaultWorkspace.test.js
+++ b/src/Utilities/__tests__/useDefaultWorkspace.test.js
@@ -1,37 +1,30 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { useDefaultWorkspace } from '../useDefaultWorkspace';
+import { fetchDefaultWorkspace } from '@project-kessel/react-kessel-access-check';
+import {
+  useDefaultWorkspace,
+  resetDefaultWorkspaceCache,
+} from '../useDefaultWorkspace';
 
-const mockAxiosGet = jest.fn();
-
-jest.mock(
-  '@redhat-cloud-services/frontend-components-utilities/interceptors',
-  () => ({
-    useAxiosWithPlatformInterceptors: () => ({
-      get: mockAxiosGet,
-    }),
-  }),
-);
+jest.mock('@project-kessel/react-kessel-access-check', () => ({
+  fetchDefaultWorkspace: jest.fn(),
+}));
 
 describe('useDefaultWorkspace', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetDefaultWorkspaceCache();
     console.error = jest.fn();
   });
 
   it('should fetch default workspace successfully', async () => {
     const mockWorkspaceId = 'workspace-123';
-    const mockResponse = {
-      data: [
-        {
-          id: mockWorkspaceId,
-          type: 'default',
-          name: 'Default Workspace',
-          created: '2024-01-01',
-          modified: '2024-01-01',
-        },
-      ],
-    };
-    mockAxiosGet.mockResolvedValue(mockResponse);
+    fetchDefaultWorkspace.mockResolvedValue({
+      id: mockWorkspaceId,
+      type: 'default',
+      name: 'Default Workspace',
+      created: '2024-01-01',
+      modified: '2024-01-01',
+    });
 
     const { result } = renderHook(() => useDefaultWorkspace());
 
@@ -43,27 +36,16 @@ describe('useDefaultWorkspace', () => {
 
     expect(result.current.workspaceId).toBe(mockWorkspaceId);
     expect(result.current.error).toBe(null);
-    expect(mockAxiosGet).toHaveBeenCalledWith('/api/rbac/v2/workspaces/', {
-      params: { limit: 1, type: 'default' },
-    });
-  });
-
-  it('should handle null workspace response', async () => {
-    mockAxiosGet.mockResolvedValue({ data: { data: null } });
-
-    const { result } = renderHook(() => useDefaultWorkspace());
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.workspaceId).toBe(null);
-    expect(result.current.error).toBe(null);
+    expect(fetchDefaultWorkspace).toHaveBeenCalledWith(window.location.origin);
   });
 
   it('should handle workspace fetch error', async () => {
-    const mockError = new Error('Network error');
-    mockAxiosGet.mockRejectedValue(mockError);
+    const mockError = {
+      code: 404,
+      message: 'No default workspace found in response',
+      details: [],
+    };
+    fetchDefaultWorkspace.mockRejectedValue(mockError);
 
     const { result } = renderHook(() => useDefaultWorkspace());
 
@@ -75,34 +57,13 @@ describe('useDefaultWorkspace', () => {
     expect(result.current.error).toBe(mockError);
   });
 
-  it('should handle undefined workspace data', async () => {
-    mockAxiosGet.mockResolvedValue({ data: { data: undefined } });
-
-    const { result } = renderHook(() => useDefaultWorkspace());
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+  it('should handle workspace without id', async () => {
+    fetchDefaultWorkspace.mockResolvedValue({
+      type: 'default',
+      name: 'Default Workspace',
+      created: '2024-01-01',
+      modified: '2024-01-01',
     });
-
-    expect(result.current.workspaceId).toBe(null);
-    expect(result.current.error).toBe(null);
-  });
-
-  it('should handle malformed workspace response', async () => {
-    mockAxiosGet.mockResolvedValue({ data: { data: [{ name: 'test' }] } });
-
-    const { result } = renderHook(() => useDefaultWorkspace());
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.workspaceId).toBe(null);
-    expect(result.current.error).toBe(null);
-  });
-
-  it('should handle empty workspace array', async () => {
-    mockAxiosGet.mockResolvedValue({ data: { data: [] } });
 
     const { result } = renderHook(() => useDefaultWorkspace());
 

--- a/src/Utilities/__tests__/usePermissionCheck.test.js
+++ b/src/Utilities/__tests__/usePermissionCheck.test.js
@@ -167,7 +167,7 @@ describe('useKesselPermissions', () => {
     expect(result.current.isLoading).toBe(true);
   });
 
-  it('should return hasAccess true when workspace is not available but resources empty', () => {
+  it('should return hasAccess false when workspace ID is not available', () => {
     useDefaultWorkspace.mockReturnValue({
       workspaceId: null,
       isLoading: false,
@@ -186,7 +186,7 @@ describe('useKesselPermissions', () => {
 
     const { result } = renderHook(() => useKesselPermissions(['view']));
 
-    expect(result.current.hasAccess).toBe(true);
+    expect(result.current.hasAccess).toBe(false);
     expect(result.current.isLoading).toBe(false);
   });
 

--- a/src/Utilities/useDefaultWorkspace.js
+++ b/src/Utilities/useDefaultWorkspace.js
@@ -1,5 +1,11 @@
 import { useState, useEffect } from 'react';
-import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import { fetchDefaultWorkspace } from '@project-kessel/react-kessel-access-check';
+
+let defaultWorkspacePromise = null;
+
+export const resetDefaultWorkspaceCache = () => {
+  defaultWorkspacePromise = null;
+};
 
 /**
  * Hook to fetch the default workspace ID from RBAC API.
@@ -8,49 +14,29 @@ import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/fronten
  *  @returns {{workspaceId: string|null, isLoading: boolean, error: Error|null}} Workspace fetch result
  */
 export const useDefaultWorkspace = () => {
-  const axios = useAxiosWithPlatformInterceptors();
   const [workspaceId, setWorkspaceId] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
+  const baseUrl = window.location.origin;
 
   useEffect(() => {
-    let isCancelled = false;
+    if (!defaultWorkspacePromise) {
+      defaultWorkspacePromise = fetchDefaultWorkspace(baseUrl);
+    }
 
-    const fetchDefaultWorkspaceId = async () => {
-      try {
-        setIsLoading(true);
-        const { data } = await axios.get('/api/rbac/v2/workspaces/', {
-          params: {
-            limit: 1,
-            type: 'default',
-          },
-        });
-
-        if (!isCancelled) {
-          const defaultWorkspaceId = data?.[0]?.id || null;
-          setWorkspaceId(defaultWorkspaceId);
-          setError(null);
-        }
-      } catch (err) {
-        if (!isCancelled) {
-          console.error('Failed to fetch default workspace:', err);
-          setError(err);
-          setWorkspaceId(null);
-        }
-      } finally {
-        if (!isCancelled) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    fetchDefaultWorkspaceId();
-
-    return () => {
-      isCancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- axios is stable
-  }, []);
+    defaultWorkspacePromise
+      .then((workspace) => {
+        setWorkspaceId(workspace?.id ?? null);
+        setError(null);
+      })
+      .catch((err) => {
+        defaultWorkspacePromise = null;
+        console.error('Failed to fetch default workspace:', err);
+        setError(err);
+        setWorkspaceId(null);
+      })
+      .finally(() => setIsLoading(false));
+  }, [baseUrl]);
 
   return { workspaceId, isLoading, error };
 };

--- a/src/Utilities/usePermissionCheck.js
+++ b/src/Utilities/usePermissionCheck.js
@@ -55,16 +55,12 @@ export const useKesselPermissions = (kesselRelations) => {
     return { hasAccess: false, isLoading: true };
   }
 
+  if (!workspaceId || workspaceError || error) {
+    return { hasAccess: false, isLoading: false };
+  }
+
   if (params?.resources?.length === 0) {
     return { hasAccess: true, isLoading: false };
-  }
-
-  if (!workspaceId || workspaceError) {
-    return { hasAccess: false, isLoading: false };
-  }
-
-  if (error) {
-    return { hasAccess: false, isLoading: false };
   }
 
   const hasAccess = Array.isArray(data)


### PR DESCRIPTION
### Description
Nothing changes here, it's refactoring PR so we don't have our own implementation but we can reuse helper from sdk library. It will help us avoid inconsistency.

### How to test
1. Navigate to any advisor page
2. Check if api/rbac/v2/workspaces call is made with `type=default & with_ancestors=true` parameters

## Summary by Sourcery

Refactor default workspace handling to use the shared Kessel SDK helper and tighten permission checks around missing workspaces.

Bug Fixes:
- Ensure permission checks fail when no workspace ID or related errors are present instead of treating empty resources as granted access.

Enhancements:
- Replace custom RBAC default workspace fetching logic with the Kessel SDK fetchDefaultWorkspace helper and add shared caching with reset support.
- Update hooks and tests to align with the new default workspace fetching behavior and workspace-dependent permission logic.

Tests:
- Adjust useDefaultWorkspace and useKesselPermissions tests to cover the new SDK-based fetching flow, caching reset, and stricter workspace requirements for access.