### PR TITLE
fix(navigation): avoid having duplicated left-nav items

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -38,18 +38,14 @@ objects:
               - pathname: /ansible/tasks
 
       bundleSegments:
-        - segmentId: tasks-insights-automation
+        - segmentId: tasks-insights
           bundleId: insights
-          position: 1500
+          position: 1600
           navItems:
-            - title: Automation Toolkit
-              id: automation
-              expandable: true
-              routes:
-                - title: Tasks
-                  id: tasks
-                  href: /insights/tasks
-                  product: Red Hat Insights
+            - title: Tasks
+              id: tasks
+              href: /insights/tasks
+              product: Red Hat Insights
         - segmentId: tasks-ansible
           bundleId: ansible
           position: 1000


### PR DESCRIPTION
## Summary by Sourcery

Update frontend navigation configuration to avoid duplicated left-nav items between Insights and Ansible bundles.

Bug Fixes:
- Remove duplicate Automation Toolkit navigation entry and ensure Tasks appears once under the Insights bundle.

Build:
- Adjust frontend deployment bundle segment IDs and nav items for the Insights tasks segment.