### PR TITLE
fix(navigation): avoid having duplicated left-nav items

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -37,15 +37,29 @@ objects:
               - pathname: /insights/tasks
               - pathname: /ansible/tasks
 
-      bundleSegments:
-        - segmentId: tasks-insights
-          bundleId: insights
-          position: 1600
+      navigationSegments:
+        - segmentId: tasks-nav
           navItems:
             - title: Tasks
               id: tasks
               href: /insights/tasks
               product: Red Hat Insights
+
+      bundleSegments:
+        - segmentId: tasks-insights
+          bundleId: insights
+          position: 1500
+          navItems:
+            - title: Automation Toolkit
+              id: automation
+              expandable: true
+              routes:
+                - segmentRef:
+                    segmentId: remediations-nav
+                    frontendName: remediations
+                - segmentRef:
+                    segmentId: tasks-nav
+                    frontendName: tasks
         - segmentId: tasks-ansible
           bundleId: ansible
           position: 1000


### PR DESCRIPTION
I tried to avoid using refs but seems there is no way to do that. Based on doc we need to have main app that will define bundle `Automation Toolkit` and app that will consume it https://github.com/RedHatInsights/frontend-starter-app/blob/master/docs/frontend-operator/navigation.md

## Summary by Sourcery

Rework frontend navigation configuration to avoid duplicated left-nav items by introducing a reusable navigation segment for Tasks and wiring it into the Automation Toolkit bundle.

Enhancements:
- Add a shared navigation segment for Tasks used across bundles to prevent duplicate left navigation entries.
- Update bundle segments to define an Automation Toolkit expandable nav item that references existing navigation segments for Tasks and Remediations.